### PR TITLE
feat: open-world 探测式本机增强 — 命名管道直发 + API 邀请静默回退

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,10 +281,12 @@ mcp_servers:
 │   ├── ws-manager.js       # WebSocket 管理
 │   ├── event-pipeline.js   # 事件处理管道
 │   ├── friend-state.js     # 好友状态管理
-│   └── rate-limiter.js     # API 限流
+│   ├── rate-limiter.js     # API 限流
+│   └── vrchat-launch.js    # 打开实例统一入口（管道探测 + API 回退）
 ├── vrchat-api.js           # VRChat API 客户端
 ├── fetch-otp.py            # 邮箱 IMAP OTP 自动抓取
 ├── migrate-vrcx0.mjs       # VRCX-0 数据迁移脚本
+├── open-world.mjs          # 本机辅助：创建房间并在 VRChat 内打开（管道/API 双通道）
 ├── hermes-plugin/          # Hermes 托管插件
 │   ├── plugin.yaml
 │   ├── __init__.py
@@ -317,6 +319,23 @@ node migrate-vrcx0.mjs <VRCX数据库路径> <userId>
 ```
 
 > **注意**：userId 可在 VRChat 官网个人资料页查看，格式如 `usr_xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`。脚本会自动去掉横线匹配 VRCX 数据库表名格式。
+
+## 🧰 辅助工具（本机可选）
+
+### `open-world.mjs` — 创建房间并在 VRChat 客户端内打开（探测式本机增强）
+
+创建一个新房间，并在**运行中的 VRChat 客户端**内打开指定世界（游戏内弹确认菜单，不会新开进程）：
+
+```bash
+node open-world.mjs wrld_xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx   # 按世界 ID 开图
+node open-world.mjs "地图名字"                                   # 按名字搜索开图
+node open-world.mjs --instance <完整location>                    # 直接加入指定实例
+```
+
+- **原理**：核心逻辑在 `core/vrchat-launch.js`（统一入口 `openInstance`）：
+  1. **本机增强（仅 Windows）**：探测 VRChat 命名管道 `\\.\pipe\VRChatURLLaunchPipe`，存在则直发 `vrchat://launch` URL——已运行的客户端在游戏内**一步弹出加入菜单**（VRCX VRCIPC 同款协议，不新开进程）；
+  2. **跨平台回退**：管道探测失败（VRChat 未运行 / 非 Windows）**静默回退**为 API 邀请自己传送（`POST /invite/myself/to/{worldId}:{instanceId}`）——客户端收到邀请通知，接受后传送，功能不缺失。
+- **依赖**：仓库根目录 `credentials.json`（VRChat 登录凭据）；纯本机工具，不参与服务主流程，非 Windows 平台自动走 API 邀请。
 
 ## 🛠 故障排查
 

--- a/core/vrchat-launch.js
+++ b/core/vrchat-launch.js
@@ -1,0 +1,148 @@
+/**
+ * VRChat 打开/加入实例统一入口（core 模块，平台增强版）
+ *
+ * 功能：打开指定实例（worldId:instanceId 完整 location）的**统一入口**：
+ *   1. 本机增强（仅 Windows）：探测 VRChat 命名管道 `\\.\pipe\VRChatURLLaunchPipe`，
+ *      存在则通过管道直发 `vrchat://launch` URL——已运行的 VRChat 客户端在游戏内
+ *      直接弹出「加入房间」确认菜单，**一步直达、不新开进程**（VRCX VRCIPC 同款协议）。
+ *   2. 跨平台回退（所有平台）：探测失败 / 非 Windows / 超时时，**静默回退**为 API 邀请
+ *      （`POST /invite/myself/to/{worldId}:{instanceId}`）——客户端收到 invite 通知，
+ *      接受后传送。功能不缺失，仅体验降级（邀请需手动接受）。
+ *
+ * 设计约束（对齐 DEVELOPMENT.md §2-12 / §3.1）：
+ *   - 平台门控：非 win32 不加载管道路径，直接走 API；
+ *   - 静默回退：管道失败快速回退 API，调用方无感知、不增加失败率；
+ *   - 依赖注入：API 客户端由调用方传入（CLI 与服务 MCP handler 共用本模块）；
+ *   - 无个人环境硬编码；不读 VRChat 安装目录；不依赖 GUI/桌面环境；
+ *   - 探测与发送带超时保护（默认 1.5s），失败不影响服务本身。
+ *
+ * 适用平台：管道增强仅 Windows（VRChat 客户端 + 命名管道）；API 回退全平台。
+ *
+ * 用法：
+ *   import { openInstance } from './vrchat-launch.js';
+ *   const res = await openInstance({ location, shortName, api });
+ *   // res = { method: 'pipe' | 'api', success: true, ... }
+ */
+
+import net from 'node:net';
+
+/** VRChat 运行时监听的命名管道（VRCX VRCIPC.cs 同款常量） */
+export const LAUNCH_PIPE = '\\\\.\\pipe\\VRChatURLLaunchPipe';
+
+/** 平台门控：管道增强仅 Windows 可用 */
+export function isPipeSupported() {
+  return process.platform === 'win32';
+}
+
+/**
+ * 构建 vrchat://launch URL。
+ * 注意：id 必须是**完整 location**（wrld_xxx:01277~region(jp)，含实例号），
+ * 只传 worldId 时 IPC 成功但游戏内无反应（2026-08-09 实测）。
+ * id 参数**不编码**（`:` `~` `(` `)` 原样），与 VRCX src/stores/launch.js 一致；
+ * 编码后 VRChat 客户端解析失败（实测坑）。
+ */
+export function buildLaunchUrl(location, shortName) {
+  if (!location || typeof location !== 'string') {
+    throw new Error('location 必填（完整实例 location，如 wrld_xxx:01277~region(jp)）');
+  }
+  const base = `vrchat://launch?ref=vrcx.app&id=${location}`;
+  return shortName ? `${base}&shortName=${encodeURIComponent(shortName)}` : base;
+}
+
+/**
+ * 通过命名管道直发 launch URL 到运行中的 VRChat。
+ * 协议：连接管道 → 写 UTF-8 URL → 读 1 字节响应（1=成功）。
+ * @returns {Promise<{success: true, method: 'pipe'}>}
+ * @throws {Error} 管道不存在 / 连接超时 / 写入失败（调用方应静默回退）
+ */
+export function launchViaPipe(location, shortName, { timeoutMs = 1500 } = {}) {
+  if (!isPipeSupported()) {
+    return Promise.reject(new Error('非 Windows 平台，命名管道不可用'));
+  }
+  const url = buildLaunchUrl(location, shortName);
+  return new Promise((resolve, reject) => {
+    const client = net.createConnection(LAUNCH_PIPE);
+    const timer = setTimeout(() => {
+      client.destroy();
+      reject(new Error('IPC 连接超时（VRChat 未运行或未监听管道）'));
+    }, timeoutMs);
+    client.on('connect', () => {
+      client.write(Buffer.from(url, 'utf-8'));
+    });
+    client.on('data', (buf) => {
+      clearTimeout(timer);
+      client.end();
+      if (buf[0] === 1) resolve({ success: true, method: 'pipe' });
+      else reject(new Error(`IPC 响应异常（buf[0]=${buf[0]}，预期 1）`));
+    });
+    client.on('error', (err) => {
+      clearTimeout(timer);
+      reject(new Error(`IPC 连接失败: ${err.message}`));
+    });
+  });
+}
+
+/**
+ * API 邀请回退：POST /invite/myself/to/{worldId}:{instanceId}。
+ * 客户端收到 invite 通知，接受后传送（跨平台路径，功能不缺失）。
+ * @param {object} api VrchatApiClient 实例（由调用方注入）
+ * @returns {Promise<{success: true, method: 'api', notificationId?: string}>}
+ * @throws {Error} 参数不合法 / API 失败
+ */
+export async function inviteSelfViaApi(api, location) {
+  if (!api || typeof api._request !== 'function') {
+    throw new Error('缺少 api 客户端（inviteSelfViaApi 需要注入 VrchatApiClient）');
+  }
+  if (!location || typeof location !== 'string') {
+    throw new Error('location 必填（如 wrld_x:12345~hidden(usr_x)~region(jp)）');
+  }
+  const idx = location.indexOf(':');
+  if (idx <= 0) throw new Error('location 格式应为 worldId:instanceId');
+  const wId = location.slice(0, idx);
+  const iId = location.slice(idx + 1);
+  if (!String(wId).startsWith('wrld_')) throw new Error('worldId 必须是 wrld_ 开头');
+  if (!iId) throw new Error('instanceId 不能为空');
+  const r = await api._request('POST', `/invite/myself/to/${wId}:${iId}`);
+  if (r.status >= 400) {
+    throw new Error(`邀请自己失败 API ${r.status}: ${JSON.stringify(r.data).slice(0, 200)}（404=实例无效或不是合法参与者）`);
+  }
+  const d = r.data || {};
+  return { success: true, method: 'api', notificationId: d.id || null };
+}
+
+/**
+ * 统一入口：打开/加入指定实例。
+ * 管道可用（Windows + VRChat 运行中）→ 管道直发一步直达；否则静默回退 API 邀请。
+ * 不抛「管道不可用」类错误——任何管道失败都转为 API 回退；仅当 API 也失败才抛错。
+ *
+ * @param {object} opts
+ * @param {string} opts.location 完整实例 location（wrld_xxx:01277~region(jp)）
+ * @param {string} [opts.shortName] 房间短名（可选，管道 URL 携带，菜单显示更友好）
+ * @param {object} opts.api VrchatApiClient 实例（API 回退必需；注入方负责认证）
+ * @param {boolean} [opts.forceApi=false] 强制走 API（跳过管道探测，测试/远程场景用）
+ * @param {number} [opts.timeoutMs=1500] 管道探测/发送超时
+ * @returns {Promise<{success: boolean, method: 'pipe'|'api', notificationId?: string, error?: string}>}
+ */
+export async function openInstance({ location, shortName, api, forceApi = false, timeoutMs = 1500 }) {
+  // 1) 本机增强：Windows 且未强制 API 时，尝试管道直发
+  if (!forceApi && isPipeSupported()) {
+    try {
+      const res = await launchViaPipe(location, shortName, { timeoutMs });
+      return { ...res, detail: '管道直发：游戏内已弹出加入菜单' };
+    } catch (e) {
+      // 静默回退：不抛管道错误，转入 API 路径
+    }
+  }
+  // 2) 跨平台回退：API 邀请自己传送
+  if (!api) {
+    return { success: false, method: 'api', error: '管道不可用且未注入 api 客户端，无法回退' };
+  }
+  try {
+    const res = await inviteSelfViaApi(api, location);
+    return { ...res, detail: 'API 邀请：客户端收到邀请通知，接受后传送' };
+  } catch (e) {
+    return { success: false, method: 'api', error: e.message };
+  }
+}
+
+export default { openInstance, launchViaPipe, inviteSelfViaApi, buildLaunchUrl, isPipeSupported, LAUNCH_PIPE };

--- a/open-world.mjs
+++ b/open-world.mjs
@@ -24,24 +24,23 @@ import { openInstance } from './core/vrchat-launch.js';
 import { readFileSync, existsSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { execSync } from 'node:child_process';
+import { execSync, execFileSync } from 'node:child_process';
+import { RateLimiter } from './core/rate-limiter.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const CRED_FILE = path.join(__dirname, 'credentials.json');
 const COOKIE_FILE = path.join(__dirname, 'auth_cookie.txt');
 
-// 平台检测：本工具仅支持 Windows（命名管道机制）
-if (process.platform !== 'win32') {
-  console.error('❌ 本工具仅支持 Windows（依赖 \\\\.\\pipe\\VRChatURLLaunchPipe 命名管道）');
-  process.exit(1);
-}
+// 平台说明：命名管道增强仅 Windows（core/vrchat-launch.js 内平台门控）；
+// 非 Windows / VRChat 未运行时自动回退 API 邀请（不在此处退出）
 
 async function fetchOtp() {
   const creds = JSON.parse(readFileSync(CRED_FILE, 'utf-8'));
   const authCode = creds.imap_auth_code || creds.qqmail_auth_code || '';
-  let cmd = `python "${path.join(__dirname, 'fetch-otp.py')}" "${creds.email}" "${authCode}"`;
-  if (creds.imap_host) cmd += ` "${creds.imap_host}"`;
-  return execSync(cmd, { timeout: 15000, encoding: 'utf-8' }).trim();
+  // execFile 数组传参，避免授权码含引号/特殊字符破坏命令
+  const args = [path.join(__dirname, 'fetch-otp.py'), creds.email, authCode];
+  if (creds.imap_host) args.push(creds.imap_host);
+  return execFileSync('python', args, { timeout: 15000, encoding: 'utf-8' }).trim();
 }
 
 // ── 解析参数：worldId / 地图名 / 主题词（开个XX的图）/ --instance ──
@@ -69,24 +68,29 @@ const THEME_HINTS = ['夏天', '夏', '海', '雪', '恐怖', '太空', '宇宙'
   'horror', 'space', 'forest', 'game', 'music', 'chill', 'relax', 'night', 'moon'];
 const isThemeHint = THEME_HINTS.some(h => target.includes(h));
 if (isThemeHint && !/^wrld_/.test(target)) {
-  const { execSync } = await import('node:child_process');
-  try {
-    const out = execSync(`node world-themes.mjs "${target}" --random`, {
-      cwd: __dirname, timeout: 15000, encoding: 'utf-8',
-    });
-    const pick = JSON.parse(out.slice(out.indexOf('{')));
-    if (pick.world?.id) {
-      target = pick.world.id;
-      console.error(`[theme] ${pick.emoji} 主题「${pick.theme}」随机抽中: ${pick.world.name} (${pick.world.id})`);
+  // 主题词解析依赖 world-themes.mjs（可选增强：本仓库存在才启用，否则按地图名处理）
+  if (!existsSync(path.join(__dirname, 'world-themes.mjs'))) {
+    console.error('[theme] world-themes.mjs 不存在，跳过主题解析（按地图名处理）');
+  } else {
+    try {
+      const out = execSync(`node world-themes.mjs "${target}" --random`, {
+        cwd: __dirname, timeout: 15000, encoding: 'utf-8',
+      });
+      const pick = JSON.parse(out.slice(out.indexOf('{')));
+      if (pick.world?.id) {
+        target = pick.world.id;
+        console.error(`[theme] ${pick.emoji} 主题「${pick.theme}」随机抽中: ${pick.world.name} (${pick.world.id})`);
+      }
+    } catch (e) {
+      console.error(`[theme] 主题解析失败（按地图名处理）: ${e.message}`);
     }
-  } catch (e) {
-    console.error(`[theme] 主题解析失败（按地图名处理）: ${e.message}`);
   }
 }
 
 // ── 认证 ──
 const creds = JSON.parse(readFileSync(CRED_FILE, 'utf-8'));
 const api = new VrchatApiClient(creds.email, creds.password);
+const rateLimiter = new RateLimiter({ minInterval: 2600 });
 if (existsSync(COOKIE_FILE)) api.loadCookieFromFile(COOKIE_FILE);
 try {
   const user = await api.ensureAuthWithAutoOtp(fetchOtp);
@@ -125,7 +129,7 @@ if (!/^wrld_/.test(target)) {
   let found = null;
   // 优先 API 搜索（精确 > 开头 > 包含 > 第一个）
   try {
-    const r = await api._request('GET', `/worlds?search=${encodeURIComponent(target)}&n=15`);
+    const r = await rateLimiter.execute(() => api._request('GET', `/worlds?search=${encodeURIComponent(target)}&n=15`));
     if (r.status === 200 && Array.isArray(r.data) && r.data.length) {
       const low = target.toLowerCase();
       const exact = r.data.find(w => (w.name || '').toLowerCase() === low);
@@ -163,7 +167,7 @@ if (!/^wrld_/.test(target)) {
 // 获取世界名（展示用）
 let worldName = worldId;
 try {
-  const r = await api._request('GET', `/worlds/${worldId}`);
+    const r = await rateLimiter.execute(() => api._request('GET', `/worlds/${worldId}`));
   if (r.status === 200 && r.data?.name) worldName = r.data.name;
 } catch { /* 用 id 兜底 */ }
 
@@ -173,7 +177,7 @@ console.error(`[world] ${worldName} (${worldId})`);
 let shortName = null;
 let instanceLocation = null;
 try {
-  const r = await api._request('POST', `/instances`, { worldId, region: 'jp', type: 'public', platform: 'standalonewindows' });
+    const r = await rateLimiter.execute(() => api._request('POST', `/instances`, { worldId, region: 'jp', type: 'public', platform: 'standalonewindows' }));
   if (r.status === 200 && r.data?.location) {
     instanceLocation = r.data.location;
     shortName = r.data.shortName || r.data.secureName || null;

--- a/open-world.mjs
+++ b/open-world.mjs
@@ -1,0 +1,204 @@
+#!/usr/bin/env node
+/**
+ * VRChat 开地图脚本 (open-world.mjs) — 本机辅助工具
+ *
+ * 功能：创建一个新房间，并在运行中的 VRChat 客户端内打开指定世界
+ *      （游戏内弹出确认菜单，不会新开 VRChat 进程）
+ * 用法：
+ *   node open-world.mjs wrld_xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+ *   node open-world.mjs "地图名字"          # 支持按名字搜（API 搜索，优先精确匹配）
+ *   node open-world.mjs --instance <完整location>   # 直接加入指定实例（弹世界房间菜单）
+ *
+ * 原理（探测式本机增强，core/vrchat-launch.js 统一入口）：
+ *   1. 调 VRChat API 为指定世界创建新实例 -> 拿到 location + shortName
+ *   2. 探测本机 VRChat 命名管道 \\.\pipe\VRChatURLLaunchPipe：存在则管道直发
+ *      vrchat://launch?ref=vrcx.app&id=<完整location>&shortName=<sn>
+ *      （游戏内弹确认菜单，一步直达，不新开进程）
+ *   3. 管道探测失败（VRChat 未运行）→ 静默回退 API 邀请自己传送
+ *      （POST /invite/myself/to/{worldId}:{instanceId}，客户端收到邀请通知）
+ *
+ * 注意：管道增强仅 Windows；API 邀请回退全平台可用。
+ */
+import { VrchatApiClient } from './vrchat-api.js';
+import { openInstance } from './core/vrchat-launch.js';
+import { readFileSync, existsSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execSync } from 'node:child_process';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CRED_FILE = path.join(__dirname, 'credentials.json');
+const COOKIE_FILE = path.join(__dirname, 'auth_cookie.txt');
+
+// 平台检测：本工具仅支持 Windows（命名管道机制）
+if (process.platform !== 'win32') {
+  console.error('❌ 本工具仅支持 Windows（依赖 \\\\.\\pipe\\VRChatURLLaunchPipe 命名管道）');
+  process.exit(1);
+}
+
+async function fetchOtp() {
+  const creds = JSON.parse(readFileSync(CRED_FILE, 'utf-8'));
+  const authCode = creds.imap_auth_code || creds.qqmail_auth_code || '';
+  let cmd = `python "${path.join(__dirname, 'fetch-otp.py')}" "${creds.email}" "${authCode}"`;
+  if (creds.imap_host) cmd += ` "${creds.imap_host}"`;
+  return execSync(cmd, { timeout: 15000, encoding: 'utf-8' }).trim();
+}
+
+// ── 解析参数：worldId / 地图名 / 主题词（开个XX的图）/ --instance ──
+const INSTANCE_MODE = process.argv.includes('--instance');
+let target = process.argv[2];
+if (!target) {
+  console.error('用法: node open-world.mjs <worldId 或 地图名 或 主题词>');
+  console.error('      node open-world.mjs --instance <完整location>  # 加入指定实例');
+  console.error('主题词: 夏天 海 雪 恐怖 太空 森林自然 游戏 音乐 社交 放松 夜晚星空');
+  process.exit(1);
+}
+// 模式定位：--instance 后面跟的值
+if (INSTANCE_MODE) {
+  const idx = process.argv.indexOf('--instance');
+  target = process.argv[idx + 1];
+  if (!target) {
+    console.error('❌ --instance 缺少参数');
+    process.exit(1);
+  }
+}
+
+// 主题词识别：如果参数是主题（或其关键词），用 world-themes.mjs 随机抽一个未逛的
+const THEME_HINTS = ['夏天', '夏', '海', '雪', '恐怖', '太空', '宇宙', '森林', '自然',
+  '游戏', '音乐', '社交', '放松', '夜晚', '星空', '月', 'summer', 'beach', 'snow',
+  'horror', 'space', 'forest', 'game', 'music', 'chill', 'relax', 'night', 'moon'];
+const isThemeHint = THEME_HINTS.some(h => target.includes(h));
+if (isThemeHint && !/^wrld_/.test(target)) {
+  const { execSync } = await import('node:child_process');
+  try {
+    const out = execSync(`node world-themes.mjs "${target}" --random`, {
+      cwd: __dirname, timeout: 15000, encoding: 'utf-8',
+    });
+    const pick = JSON.parse(out.slice(out.indexOf('{')));
+    if (pick.world?.id) {
+      target = pick.world.id;
+      console.error(`[theme] ${pick.emoji} 主题「${pick.theme}」随机抽中: ${pick.world.name} (${pick.world.id})`);
+    }
+  } catch (e) {
+    console.error(`[theme] 主题解析失败（按地图名处理）: ${e.message}`);
+  }
+}
+
+// ── 认证 ──
+const creds = JSON.parse(readFileSync(CRED_FILE, 'utf-8'));
+const api = new VrchatApiClient(creds.email, creds.password);
+if (existsSync(COOKIE_FILE)) api.loadCookieFromFile(COOKIE_FILE);
+try {
+  const user = await api.ensureAuthWithAutoOtp(fetchOtp);
+  api.saveCookieToFile(COOKIE_FILE);
+  console.error(`[auth] ${user.displayName}`);
+} catch (e) {
+  console.error('[auth] 失败:', e.message);
+  process.exit(1);
+}
+
+// ── 模式分发：--instance 直接发 URL（跳过世界解析与建房间）──
+// 注：--user 模式已废弃（VRChat 官方无 vrchat://user 协议，无法弹用户主页）
+if (INSTANCE_MODE) {
+  // 直接加入指定实例（弹世界房间菜单，不新建房间）
+  // 统一入口：本机管道直发 → 探测失败静默回退 API 邀请
+  console.error(`[instance] 直接加入实例: ${target}`);
+  try {
+    const res = await openInstance({ location: target, api });
+    if (res.success) {
+      console.error(`[launch] ✅ ${res.detail}`);
+      console.log(JSON.stringify({ ok: true, via: res.method, mode: 'instance', target, display: target, notificationId: res.notificationId || null }));
+    } else {
+      throw new Error(res.error || '打开失败');
+    }
+  } catch (e) {
+    console.error(`❌ 打开失败: ${e.message}`);
+    console.log(JSON.stringify({ ok: false, error: e.message, url: target }));
+    process.exit(1);
+  }
+  process.exit(0);
+}
+
+// ── 解析世界 ID（支持名字）──
+let worldId = target;
+if (!/^wrld_/.test(target)) {
+  let found = null;
+  // 优先 API 搜索（精确 > 开头 > 包含 > 第一个）
+  try {
+    const r = await api._request('GET', `/worlds?search=${encodeURIComponent(target)}&n=15`);
+    if (r.status === 200 && Array.isArray(r.data) && r.data.length) {
+      const low = target.toLowerCase();
+      const exact = r.data.find(w => (w.name || '').toLowerCase() === low);
+      const starts = r.data.find(w => (w.name || '').toLowerCase().startsWith(low));
+      const includes = r.data.find(w => (w.name || '').toLowerCase().includes(low));
+      found = exact || starts || includes
+        ? { id: (exact || starts || includes).id, name: (exact || starts || includes).name }
+        : { id: r.data[0].id, name: r.data[0].name };
+    }
+  } catch (e) { console.error(`[search] API 搜索失败: ${e.message}`); }
+
+  if (!found) {
+    // 兜底：vrc-monitor 自己的 events 表（world_name 记录，无第三方依赖）
+    try {
+      const Database = (await import('better-sqlite3')).default;
+      const db = new Database(path.join(__dirname, 'vrc-monitor.sqlite3'), { readonly: true, timeout: 10000 });
+      const rows = db.prepare(
+        `SELECT world_id, world_name FROM events
+         WHERE world_name IS NOT NULL AND world_name != '' AND world_name = ?
+         LIMIT 1`
+      ).all(target);
+      if (rows.length) found = { id: rows[0].world_id, name: rows[0].world_name };
+      db.close();
+    } catch (e) { /* ignore */ }
+  }
+
+  if (!found) {
+    console.error(`❌ 找不到地图: ${target}`);
+    process.exit(1);
+  }
+  worldId = found.id;
+  console.error(`[resolve] ${target} -> ${found.name} (${worldId})`);
+}
+
+// 获取世界名（展示用）
+let worldName = worldId;
+try {
+  const r = await api._request('GET', `/worlds/${worldId}`);
+  if (r.status === 200 && r.data?.name) worldName = r.data.name;
+} catch { /* 用 id 兜底 */ }
+
+console.error(`[world] ${worldName} (${worldId})`);
+
+// ── 1. 创建新实例 ──
+let shortName = null;
+let instanceLocation = null;
+try {
+  const r = await api._request('POST', `/instances`, { worldId, region: 'jp', type: 'public', platform: 'standalonewindows' });
+  if (r.status === 200 && r.data?.location) {
+    instanceLocation = r.data.location;
+    shortName = r.data.shortName || r.data.secureName || null;
+    console.error(`[instance] 已创建: ${instanceLocation}${shortName ? ` (shortName=${shortName})` : ''}`);
+  } else {
+    console.error(`[instance] 创建失败 (${r.status})，回退直接 launch`);
+  }
+} catch (e) {
+  console.error(`[instance] 创建失败: ${e.message}，回退直接 launch`);
+}
+
+// ── 2. 打开 VRChat ──
+// 统一入口（core/vrchat-launch.js）：本机管道直发（一步直达）→ 探测失败静默回退 API 邀请
+// 注意：id 必须是完整 location（含实例号），裸 worldId 游戏内无反应（实测）
+if (!instanceLocation) {
+  console.error('❌ 创建实例失败且无可用 location，无法打开（裸 worldId 实测无效）');
+  console.log(JSON.stringify({ ok: false, error: 'instance creation failed', worldId }));
+  process.exit(1);
+}
+const res = await openInstance({ location: instanceLocation, shortName, api });
+if (res.success) {
+  console.error(`[launch] ✅ ${res.detail}`);
+  console.log(JSON.stringify({ ok: true, via: res.method, worldId, worldName, instance: instanceLocation, notificationId: res.notificationId || null }));
+} else {
+  console.error(`❌ 打开失败: ${res.error}`);
+  console.log(JSON.stringify({ ok: false, error: res.error, worldId }));
+  process.exit(1);
+}


### PR DESCRIPTION
## 需求来源

issue #4 讨论的落地（[讨论：是否允许通过命名管道操作本机 VRChat 客户端](https://github.com/ggg123124/vrc-monitor/issues/4)）。

背景：本机场景下「创建房间并在游戏内打开」的两种路径体验差距明显——**命名管道直发**（游戏内弹确认菜单 → 点一下加入，1 步）vs **API 邀请**（游戏内收邀请通知 → ESC → 打开邀请 → 接受，至少 3 步）。按 issue #4 确认的方向（探测式本机增强 + 静默回退），实现为 core 模块统一入口，对齐 `e8d29d0` 更新后的开发约束（§3.1 允许探测式本机增强、§2-12 平台专属代码要求）。

## 实现方式

### `core/vrchat-launch.js`（新增，统一入口 `openInstance`）

```js
const res = await openInstance({ location, shortName, api });
// res = { method: 'pipe' | 'api', success: true, detail }
```

1. **本机增强（仅 Windows）**：探测 VRChat 命名管道 `\\.\pipe\VRChatURLLaunchPipe`（连接超时 1.5s 快速失败），存在则直发 `vrchat://launch?ref=vrcx.app&id=<完整location>&shortName=<sn>`——已运行的客户端在游戏内**一步弹出加入菜单**（VRCX VRCIPC.cs 同款协议，不新开进程）。id 必须是完整 location（含实例号），裸 worldId 游戏内无反应（实测）。
2. **跨平台回退（所有平台）**：管道探测失败 / 非 Windows / 超时 → **静默回退** API 邀请自己传送（`POST /invite/myself/to/{worldId}:{instanceId}`，复用现有 `invite_myself` 链路）——客户端收到邀请通知，接受后传送，功能不缺失。
3. **约束对齐**：
   - 平台门控：`process.platform !== 'win32'` 不加载管道路径；
   - 依赖注入：api 客户端由调用方传入（CLI 与服务 MCP handler 共用同一模块）；
   - 无个人环境硬编码、不读 VRChat 安装目录、不依赖 GUI/桌面环境；
   - 探测/发送带超时保护，失败快速回退，不影响服务本身。

### `open-world.mjs`（重构为薄封装）

保留 CLI 职责（参数解析 / 主题词→world-themes 抽图 / 认证 / 创建实例），打开动作统一走 `core/vrchat-launch.js`；创建实例失败不再回退裸 worldId（实测游戏内无反应），明确报错。

### `README.md`

目录结构登记 `core/vrchat-launch.js` + `open-world.mjs`；新增「辅助工具」章节说明用法、管道/API 双通道与回退行为。

## 验证过程与结果

**隔离测试 12/12 全过**（临时脚本，验证后已清理）：

| 类别 | 用例 |
|---|---|
| URL 构建 | id 不编码（`~region(jp)` 原样）/ shortName 编码 / 缺 location 抛错 |
| 平台门控 | 非 win32 禁用管道 |
| API 邀请 | 路径正确（`/invite/myself/to/{worldId}:{instanceId}`）/ API 失败抛错 / 参数校验 / 缺 api 抛错 |
| 统一入口 | forceApi 走 API / 无 api 返回错误不抛异常 / 真实管道路径结构正确 |

**真实环境实测**：
- VRChat 运行时：`openInstance` 返回 `{method: 'pipe', success: true}`——管道直发成功，游戏内弹加入菜单；
- VRChat 未运行：管道 1.5s 超时 → 静默回退 API 邀请（`method: 'api'`），不抛管道错误。

**语法**：`node --check` 全过（core/vrchat-launch.js + open-world.mjs）。

**复现**：`node open-world.mjs --instance wrld_xxx:01277~region(jp)`（需仓库根目录 `credentials.json`；Windows + VRChat 运行中走管道，否则走 API 邀请）。
