### PR TITLE
feat: 好友推荐/偏好/学习 MCP 工具集（recommend_join + 评分体系，48→54 工具）

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,7 @@ cp desktop/plugin.js "$HERMES_HOME/desktop-plugins/vrc-monitor/"
 
 ### 6. 配置 MCP 接口（可选但推荐）
 
-服务通过 MCP 协议暴露 48 个工具（get_online_friends / get_friend_info / get_friend_events / get_companions / get_online_pattern / get_nicknames / set_nickname / get_world_name / set_world_note / get_world_history / get_weekly_report / scan_new_worlds / get_new_worlds / get_mutual_friends / search_users / search_groups / search_worlds / backup_database / get_user_groups / get_group_info / get_group_instances / get_group_announcement / join_group / leave_group / peek_group_announcement / send_boop / get_boop_emojis / upload_emoji / upload_print / upload_gallery_image / download_print / download_gallery_image / send_friend_request / remove_friend / create_instance / invite_myself 等，详见 README），Hermes Agent 可直接调用，无需 curl 手写 JSON-RPC。
+服务通过 MCP 协议暴露 54 个工具（get_online_friends / get_friend_info / get_friend_events / get_companions / get_online_pattern / get_nicknames / set_nickname / get_world_name / set_world_note / get_world_history / get_weekly_report / scan_new_worlds / get_new_worlds / get_mutual_friends / search_users / search_groups / search_worlds / backup_database / get_user_groups / get_group_info / get_group_instances / get_group_announcement / join_group / leave_group / peek_group_announcement / send_boop / get_boop_emojis / upload_emoji / upload_print / upload_gallery_image / download_print / download_gallery_image / send_friend_request / remove_friend / create_instance / invite_myself / get_favorite_friends_locations / recommend_join / set_join_preference / get_join_preference / record_join_choice / get_join_learning 等，详见 README），Hermes Agent 可直接调用，无需 curl 手写 JSON-RPC。
 
 在 Hermes 配置文件（`$HERMES_HOME/config.yaml`，Windows 为 `%LOCALAPPDATA%\hermes\config.yaml`）中添加：
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 - ✅ **历史数据迁移** — 从 VRCX-0 导入 10 个月的 33 万条活动记录
 - ✅ **世界名缓存** — 自动解析 `wrld_xxx` 为可读世界名（懒刷新：缓存命中直接用，`forceRefresh: true` 手动刷新防改名陈旧）
 - ✅ **关注名单** — 标记核心好友，活动时特别通知
-- ✅ **MCP 工具接口** — 48 个工具供 Hermes / 任意 MCP 客户端调用
+- ✅ **MCP 工具接口** — 54 个工具供 Hermes / 任意 MCP 客户端调用
 - ✅ **数据库自动备份** — 启动 + 每 24h 自动备份（WAL 在线备份，无需停机），保留最近 2 份到 `backups/`；`backup_database` 工具可随时手动触发
 - ✅ **Hermes 插件托管** — 会话自动拉起、崩溃自愈、`vrc_status` 等管理工具
 
@@ -167,7 +167,7 @@ cp desktop/plugin.js "$HERMES_HOME/desktop-plugins/vrc-monitor/"
 - **双路检测**：状态文件 pid 存活 **或** 端口探测成功，均可识别为运行中（防状态文件丢失误判）
 - **日志**：`$HERMES_HOME/workspace/vrc-monitor/monitor.log`
 
-## 🔌 MCP 工具（48 个）
+## 🔌 MCP 工具（54 个）
 
 服务监听 `http://127.0.0.1:8799/mcp`，通过 HTTP SSE 提供 MCP 协议。Hermes 用户可在 `$HERMES_HOME/config.yaml`（Windows 为 `%LOCALAPPDATA%\hermes\config.yaml`）配置：
 
@@ -243,6 +243,12 @@ mcp_servers:
 | `remove_gallery_image` | 删除图库图片（不可逆，需 `confirm: true`） | `fileId` | `confirm` |
 | `send_invite` | 邀请好友加入**你当前所在房间**（拉人进房） | `userId`、`worldId`、`instanceId` | `message`（附带消息） |
 | `request_invite` | 请求好友**邀请你加入 TA 的房间**（默认消息 "Can I join you?"） | `userId` | `message` |
+| `get_favorite_friends_locations` | **好友收藏夹位置**：列出收藏分组内好友当前位置（支持 `searchName` 按名直查），按推荐度排序，private 自动排除 | `groupName`/`favoriteGroupId`/`searchName` | — |
+| `recommend_join` | **推荐加入**：全部在线好友综合评分推荐（熟悉度 + 收藏夹权重 + 房间场景 + 实例人数/类型） | `limit`、`minScore` | — |
+| `set_join_preference` | 设置推荐偏好（自然语言，如「我不喜欢人太多」→ 爆满重罚） | `preference` | — |
+| `get_join_preference` | 查询当前推荐偏好 | — | — |
+| `record_join_choice` | 记录一次推荐选择（自动补全上下文，≥5 次后自动学习权重） | `userId`/`displayName` | — |
+| `get_join_learning` | 查看选择学习状态与生效的权重调整 | — | — |
 | `create_instance` | **创建新房间**：worldId 必填；type（public/hidden/friends/private/group，默认 hidden）、region（us/eu/jp，默认 jp）可选；非 public 自动带 ownerId=当前用户（不带会 400 "Invalid owner ID"）；返回 `location` 可直接给 invite_myself | `worldId` | `type`、`region`、`instanceId`、`groupAccessType` |
 | `invite_myself` | **邀请自己传送进指定实例**：`location`（worldId:instanceId 完整串）或 `worldId`+`instanceId` 分开传；客户端收到 invite 通知后接受即传送 | `location` 或 `worldId`+`instanceId` | — |
 | `send_friend_request` | **发送好友请求**（添加好友）：`userId` 直接加，或 `displayName` 精确匹配（不区分大小写）后加 | `userId` 或 `displayName` 至少一个 | — |

--- a/README.md
+++ b/README.md
@@ -159,6 +159,8 @@ cp desktop/plugin.js "$HERMES_HOME/desktop-plugins/vrc-monitor/"
 | `VRC_MONITOR_DIR` | 自动探测（agent 在仓库目录内运行） | 服务目录（含 start-monitor.js），未探测到时需显式设置 |
 | `VRC_MONITOR_NODE` | PATH 中的 node | Node 可执行文件路径 |
 | `VRC_MONITOR_WS_PROXY` | `http://127.0.0.1:7892` | WebSocket 直连超时后的代理回退地址（可覆盖默认值） |
+| `VRC_MONITOR_GROUP_WEIGHTS` | 未配置（各分组 +5） | 收藏夹分组权重 JSON（如 {"join":20,"new":5}），recommend_join / get_favorite_friends_locations 评分用 |
+| `VRC_MONITOR_CONTACT_GROUPS` | 未配置（无联系人降权） | 活动联系人分组名（逗号分隔），命中分组内成员评分 -40 |
 
 ### 进程托管原理
 

--- a/core/init-db.sql
+++ b/core/init-db.sql
@@ -110,6 +110,30 @@ CREATE TABLE IF NOT EXISTS new_worlds (
   occupants INTEGER DEFAULT 0,   -- 在线人数
   popularity INTEGER DEFAULT 0,
   visited INTEGER DEFAULT 0,     -- 用户是否逛过（1=逛过）
-  visited_at TEXT                -- 逛过的时间（若已逛）
+  visited_at TEXT,               -- 逛过的时间（若已逛）
+  sleep_ok INTEGER DEFAULT 0        -- 适合睡觉/放松标记（推荐评分与「开个睡觉图」用）
 );
 CREATE INDEX IF NOT EXISTS idx_new_worlds_visited ON new_worlds(visited);
+
+-- 推荐选择学习（recommend_join 用户选择记录，个性化权重学习的数据源）
+-- 每次用户从推荐列表选择某人/某图记录一条快照，含当时列表基线用于对比分析
+CREATE TABLE IF NOT EXISTS join_choices (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  created_at TEXT DEFAULT (datetime('now')),
+  user_id TEXT DEFAULT '',          -- 被选择的好友 userId
+  display_name TEXT DEFAULT '',     -- 被选择的好友显示名
+  world_id TEXT DEFAULT '',
+  world_name TEXT DEFAULT '',
+  instance_type TEXT DEFAULT '',    -- public/friends/hidden/group
+  instance_users INTEGER DEFAULT 0,
+  instance_capacity INTEGER DEFAULT 0,
+  fill_ratio REAL DEFAULT 0,
+  familiarity_score INTEGER DEFAULT 0,
+  is_quiet_world INTEGER DEFAULT 0,
+  recommend_score INTEGER DEFAULT 0,
+  rank_in_list INTEGER DEFAULT 0,   -- 在推荐列表中的排名（1=第一）
+  list_count INTEGER DEFAULT 0,     -- 当时列表长度
+  list_avg_users REAL DEFAULT 0,    -- 当时列表平均人数（基线）
+  list_avg_fill REAL DEFAULT 0,     -- 当时列表平均填充率（基线）
+  list_quiet_ratio REAL DEFAULT 0   -- 当时列表安静图占比（基线，0-1）
+);

--- a/core/storage.js
+++ b/core/storage.js
@@ -32,6 +32,11 @@ export class Storage {
     if (!worldCols.some(c => c.name === 'note')) {
       this._run(`ALTER TABLE world_cache ADD COLUMN note TEXT`);
     }
+    // 迁移：旧库 new_worlds 缺 sleep_ok 列（recommend_join 睡觉图评分用，幂等）
+    const nwCols = this._query(`PRAGMA table_info(new_worlds)`);
+    if (!nwCols.some(c => c.name === 'sleep_ok')) {
+      this._run(`ALTER TABLE new_worlds ADD COLUMN sleep_ok INTEGER DEFAULT 0`);
+    }
     return this;
   }
 

--- a/skills/vrc-monitor-agent/SKILL.md
+++ b/skills/vrc-monitor-agent/SKILL.md
@@ -15,7 +15,7 @@ metadata:
 - 服务启动：项目目录下 `node start-monitor.js`（首次需配置 `credentials.json`，见 AGENTS.md）
 - 数据库：本地 SQLite（WebSocket 实时采集事件，含历史上线/位置/同屏记录）
 
-## MCP 工具（48 个）
+## MCP 工具（54 个）
 
 | 工具 | 说明 |
 |------|------|

--- a/start-monitor.js
+++ b/start-monitor.js
@@ -29,7 +29,8 @@ const DB_PATH = path.join(__dirname, 'vrc-monitor.sqlite3');
 const BACKUP_DIR = path.join(__dirname, 'backups');
 const BACKUP_INTERVAL_MS = 24 * 60 * 60 * 1000; // 每 24h 自动备份
 
-// ── .env 加载（只取 VRC_MONITOR_*，不覆盖进程已有环境变量）──
+// ── .env 加载（只取 VRC_MONITOR_*）──
+// 注意：无条件覆盖 process.env——服务被插件 spawn 时可能继承旧值，跳过会导致 .env 配置失效
 // 个人配置（分组权重/联系人名单等）放仓库根 .env（.gitignore 已忽略），不硬编码进代码
 try {
   const envFile = path.join(__dirname, '.env');

--- a/start-monitor.js
+++ b/start-monitor.js
@@ -29,6 +29,20 @@ const DB_PATH = path.join(__dirname, 'vrc-monitor.sqlite3');
 const BACKUP_DIR = path.join(__dirname, 'backups');
 const BACKUP_INTERVAL_MS = 24 * 60 * 60 * 1000; // 每 24h 自动备份
 
+// ── .env 加载（只取 VRC_MONITOR_*，不覆盖进程已有环境变量）──
+// 个人配置（分组权重/联系人名单等）放仓库根 .env（.gitignore 已忽略），不硬编码进代码
+try {
+  const envFile = path.join(__dirname, '.env');
+  if (existsSync(envFile)) {
+    for (const line of readFileSync(envFile, 'utf-8').split(/\r?\n/)) {
+      const m = /^([A-Z_]+)=(.*)$/.exec(line.trim());
+      if (m && m[1].startsWith('VRC_MONITOR_')) {
+        process.env[m[1]] = m[2];
+      }
+    }
+  }
+} catch (e) { /* .env 加载失败不阻断 */ }
+
 // ── 全局状态 ──
 let storage;
 let api;
@@ -706,6 +720,61 @@ const CUSTOM_TOOLS = [
       required: ['groupId'],
     },
   },
+  {
+    name: 'get_favorite_friends_locations',
+    description: '[query·好友收藏] 列出某个好友收藏夹（线上收藏分组）内所有好友的当前位置列表。可指定 groupName（如 "new"、"join" 等收藏夹名）或 favoriteGroupId；不指定则列出全部分组。返回按推荐度排序：在线且实例可加入的在前（public/friends/hidden=friend+/group 实例均可加入），仅 private 实例自动排除（看不到位置），按实例内玩家数/容量比 + 收藏热度综合评分。也可用 searchName 直接按名字在好友列表里查某人的位置（能看到具体位置即代表可加入，标记 joinable；纯 private 才进不去）。',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        groupName: { type: 'string', description: '收藏夹名（displayName），如 "new"/"join"。不填则返回全部分组概览' },
+        favoriteGroupId: { type: 'string', description: '收藏分组 id（fvgrp_...），与 groupName 二选一' },
+        searchName: { type: 'string', description: '按名字（模糊匹配，不区分大小写）在好友列表里直接查某人位置，返回单人或多人结果。与 groupName/favoriteGroupId 互斥' },
+      },
+    },
+  },
+  {
+    name: 'recommend_join',
+    description: '[query·推荐加入] 查看全部在线好友在做什么，按推荐度排序给出可加入的推荐。综合评分：熟悉度（最近30天+历史一年共玩次数，来自本地 events 同屏统计）+ 收藏夹分组权重（可配置）+ 房间场景（睡觉图人少=电灯泡风险降权）+ 实例人数/容量比 + 实例类型（public/friends/friend+/group 可加入，private 排除）。返回 TopN 推荐及理由。',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        limit: { type: 'number', default: 10, description: '返回数量（默认 10）' },
+        minScore: { type: 'number', default: 0, description: '最低推荐分过滤（默认 0，负分=电灯泡/联系人风险）' },
+      },
+    },
+  },
+  {
+    name: 'set_join_preference',
+    description: '[配置·推荐偏好] 用自然语言设置「推荐加入」的评分偏好，持久化到 config 表，下次推荐自动生效。例：「我不喜欢人太多」→ 爆满惩罚加重(80)、人数权重降低(×1.5)、冷清不罚；「喜欢热闹」→ 人数权重加强(×4)、爆满轻罚(20)；「恢复默认」→ 清除偏好。',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        preference: { type: 'string', description: '自然语言偏好，如「我不喜欢人太多」「喜欢热闹」「恢复默认」' },
+      },
+      required: ['preference'],
+    },
+  },
+  {
+    name: 'get_join_preference',
+    description: '[配置·推荐偏好] 查询当前「推荐加入」的评分偏好（含解析结果与设置时间）。',
+    inputSchema: { type: 'object', properties: {} },
+  },
+  {
+    name: 'record_join_choice',
+    description: '[配置·选择学习] 记录一次「从推荐列表中选择加入」的行为（用户选择谁/哪张图）。服务端自动从最近一次 recommend_join 的快照补全上下文（人数/类型/熟悉度/排名/列表基线），写入 join_choices 表；积累 ≥5 次后自动分析用户偏好（选人少→避人潮、总选熟人→熟悉度加权等）并应用到推荐权重。用法：先运行 recommend_join 拉列表，再从列表里选一个人记录：传 userId 或 displayName（模糊匹配）。',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        userId: { type: 'string', description: '被选择好友的 userId（usr_...）' },
+        displayName: { type: 'string', description: '被选择好友的显示名（模糊匹配，与 userId 二选一）' },
+      },
+    },
+  },
+  {
+    name: 'get_join_learning',
+    description: '[配置·选择学习] 查看推荐选择学习状态：累计选择数、自动分析出的偏好（人数倾向/熟悉度加权/安静图倾向）与生效中的权重调整。',
+    inputSchema: { type: 'object', properties: {} },
+  },
 ];
 
 // ── 工具处理器 ──
@@ -733,6 +802,645 @@ function parseLocation(loc) {
     instanceId: instMatch ? instMatch[1] : null,
     region: regionMatch ? regionMatch[1] : null,
     groupAccessType: gAccessMatch ? gAccessMatch[1] : null,
+  };
+}
+
+async function handleGetFavoriteFriendsLocations({ groupName, favoriteGroupId, searchName }) {
+  const nicknames = storage.getNicknames({});
+  const nicknameMap = new Map();
+  for (const item of nicknames) {
+    if (item.userId) nicknameMap.set(item.userId, item.nickname);
+  }
+
+  // 0. searchName 模式：直接在好友列表（含离线=false）里按名字查位置
+  if (searchName) {
+    const kw = searchName.toLowerCase();
+    const friendsR = await rateLimiter.execute(() => api._request('GET', '/auth/user/friends?offline=false'));
+    if (friendsR.status !== 200) throw new Error(`API error: ${friendsR.status}`);
+    const onlineFriends = Array.isArray(friendsR.data) ? friendsR.data : [];
+    // 模糊匹配（在线好友里找；找不到再提示）
+    const matched = onlineFriends.filter(f =>
+      f.displayName.toLowerCase().includes(kw) ||
+      (f.id || '').toLowerCase() === kw);
+    if (matched.length === 0) {
+      // 查离线好友列表确认是否好友
+      const allR = await rateLimiter.execute(() => api._request('GET', '/auth/user/friends?offline=true'));
+      const allFriends = (allR.status === 200 && Array.isArray(allR.data)) ? allR.data : [];
+      const matchedAll = allFriends.filter(f => f.displayName.toLowerCase().includes(kw));
+      if (matchedAll.length === 0) {
+        throw new Error(`好友列表中没有找到「${searchName}」。`);
+      }
+      return {
+        mode: 'search',
+        query: searchName,
+        offline: matchedAll.map(f => ({ userId: f.id, displayName: f.displayName, online: false })),
+        message: '好友当前离线',
+      };
+    }
+    // 在线：逐个解析位置（复用下方逻辑，但保留 private/hidden 并标记 joinable）
+    const results = [];
+    const worldCache = new Map();
+    const instanceInfo = new Map();
+    async function getWorldNameSafe(worldId) {
+      if (worldCache.has(worldId)) return worldCache.get(worldId);
+      let name = worldId;
+      const cached = storage.getWorldName(worldId);
+      if (cached && cached.name) {
+        name = cached.name;
+      } else {
+        const r = await rateLimiter.execute(() => api._request('GET', `/worlds/${worldId}`));
+        if (r.status === 200 && r.data && r.data.name) {
+          name = r.data.name;
+          try { storage.upsertWorld({ worldId, name, authorId: r.data.authorId || '', authorName: r.data.authorName || '' }); } catch (e) {}
+        }
+      }
+      worldCache.set(worldId, name);
+      return name;
+    }
+    for (const f of matched) {
+      const loc = parseLocation(f.location || 'private');
+      if (!loc) continue;
+      const isJoinable = loc.type === 'public' || loc.type === 'friends' || loc.type === 'group' || loc.type === 'hidden';
+      const worldName = loc.worldId ? await getWorldNameSafe(loc.worldId) : null;
+      const entry = {
+        userId: f.id,
+        displayName: f.displayName,
+        online: true,
+        joinable: isJoinable,
+        instanceTypeDisplay: loc.type === 'hidden' ? 'friend+（好友+）' : (loc.type || 'unknown'),
+        location: f.location || 'private',
+        worldId: loc.worldId || null,
+        worldName,
+        instanceType: loc.type || 'unknown',
+        instanceId: loc.instanceId || '',
+        region: loc.region || '',
+        status: f.status,
+        statusDescription: f.statusDescription,
+        platform: f.platform,
+        nickname: nicknameMap.get(f.id) || null,
+        avatarImageUrl: f.currentAvatarThumbnailImageUrl,
+      };
+      // 可加入的才查实例玩家数（private 查了也进不去）
+      if (isJoinable && loc.instanceId && f.location && !f.location.includes('~private')) {
+        const instKey = f.location;
+        if (!instanceInfo.has(instKey)) {
+          try {
+            const r = await rateLimiter.execute(() => api._request('GET', `/instances/${instKey}`));
+            if (r.status === 200 && r.data) {
+              instanceInfo.set(instKey, { nUsers: r.data.n_users || 0, capacity: r.data.capacity || 0 });
+            } else {
+              instanceInfo.set(instKey, null);
+            }
+          } catch (e) {
+            instanceInfo.set(instKey, null);
+          }
+        }
+        const inst = instanceInfo.get(instKey);
+        if (inst) {
+          entry.instanceUsers = inst.nUsers;
+          entry.instanceCapacity = inst.capacity;
+          entry.fillRatio = inst.capacity > 0 ? +(inst.nUsers / inst.capacity).toFixed(2) : 0;
+        }
+      }
+      results.push(entry);
+    }
+    return { mode: 'search', query: searchName, friends: results };
+  }
+
+  // 1. 全部好友收藏分组
+  const groupsR = await rateLimiter.execute(() => api._request('GET', '/favorite/groups?type=friend&n=100'));
+  if (groupsR.status !== 200) throw new Error(`API error: ${groupsR.status}`);
+  const groups = Array.isArray(groupsR.data) ? groupsR.data : [];
+
+  if (!groupName && !favoriteGroupId) {
+    // 概览模式：返回全部分组 + 成员数（用分组的 name=group_N 匹配 tags）
+    const favsAllR = await rateLimiter.execute(() => api._request('GET', '/favorites?type=friend&n=100'));
+    const favsAll = (favsAllR.status === 200 && Array.isArray(favsAllR.data)) ? favsAllR.data : [];
+    // 按 tags[0]（group_N）分组统计
+    const byGroupTag = new Map();
+    for (const f of favsAll) {
+      const tag = (f.tags || [])[0] || '';
+      byGroupTag.set(tag, (byGroupTag.get(tag) || 0) + 1);
+    }
+    const overview = groups.map(g => ({
+      groupId: g.id,
+      groupName: g.displayName || g.id,
+      groupTag: g.name || '',
+      memberCount: byGroupTag.get(g.name) || 0,
+    }));
+    return { mode: 'overview', groups: overview };
+  }
+
+  // 2. 定位分组
+  let group = null;
+  if (favoriteGroupId) {
+    group = groups.find(g => g.id === favoriteGroupId) || null;
+  } else if (groupName) {
+    group = groups.find(g => (g.displayName || '') === groupName) ||
+            groups.find(g => (g.displayName || '').toLowerCase() === groupName.toLowerCase()) || null;
+  }
+  if (!group) {
+    const available = groups.map(g => g.displayName || g.id);
+    throw new Error(`找不到收藏夹「${groupName || favoriteGroupId}」。可用分组: ${available.join(' / ')}`);
+  }
+
+  // 3. 组内好友：API 的 groupId 参数被忽略（永远返回全部），改用分组的 name=group_N 匹配 tags[0]
+  const groupTag = group.name || '';
+  const favsR = await rateLimiter.execute(() => api._request('GET', '/favorites?type=friend&n=100'));
+  if (favsR.status !== 200) throw new Error(`API error: ${favsR.status}`);
+  const allFavs = Array.isArray(favsR.data) ? favsR.data : [];
+  const favs = groupTag
+    ? allFavs.filter(f => (f.tags || [])[0] === groupTag)
+    : allFavs;
+
+  // 4. 逐个查好友位置（复用在线好友列表更快：一次请求拿到全部在线好友位置）
+  //    先用 /auth/user/friends?offline=false 拿在线好友，再对组内好友查详情
+  const onlineR = await rateLimiter.execute(() => api._request('GET', '/auth/user/friends?offline=false'));
+  const onlineFriends = (onlineR.status === 200 && Array.isArray(onlineR.data)) ? onlineR.data : [];
+  const onlineMap = new Map(onlineFriends.map(f => [f.id, f]));
+
+  // 组内每个好友：在线直接取位置；离线标记
+  const members = [];
+  const onlineIds = [];
+  for (const f of favs) {
+    const uid = f.favoriteId;
+    const online = onlineMap.get(uid);
+    if (online) {
+      members.push({ favoriteId: f.id, userId: uid, displayName: online.displayName, online: true, location: online.location || 'private', status: online.status, platform: online.platform, avatarImageUrl: online.currentAvatarThumbnailImageUrl });
+      onlineIds.push(uid);
+    } else {
+      members.push({ favoriteId: f.id, userId: uid, displayName: null, online: false });
+    }
+  }
+
+  // 5. 在线好友：补世界名 + 实例信息（玩家数/容量/类型），算推荐度
+  //    位置解析 + 世界名缓存；实例详情批量查（限流）
+  const worldCache = new Map();
+  const instanceInfo = new Map();
+
+  async function getWorldNameSafe(worldId) {
+    if (worldCache.has(worldId)) return worldCache.get(worldId);
+    let name = worldId;
+    const cached = storage.getWorldName(worldId);
+    if (cached && cached.name) {
+      name = cached.name;
+    } else {
+      const r = await rateLimiter.execute(() => api._request('GET', `/worlds/${worldId}`));
+      if (r.status === 200 && r.data && r.data.name) {
+        name = r.data.name;
+        try { storage.upsertWorld({ worldId, name, authorId: r.data.authorId || '', authorName: r.data.authorName || '' }); } catch (e) {}
+      }
+    }
+    worldCache.set(worldId, name);
+    return name;
+  }
+
+  const detailed = [];
+  for (const m of members) {
+    if (!m.online) continue;
+    const loc = parseLocation(m.location || 'private');
+    // private 实例自动排除（Invite：仅被邀请者本人可进）
+    // 注意：hidden 实例 = 游戏里的 friend+(好友+)实例，好友及好友的好友可进，不排除！
+    if (!loc || loc.type === 'private' ||
+        m.location === 'private' || m.location === 'offline' || m.location === 'traveling') {
+      continue;
+    }
+    // traveling 也跳过（不在具体世界）
+    if (loc.type === 'traveling') continue;
+
+    const worldName = await getWorldNameSafe(loc.worldId);
+    const entry = {
+      userId: m.userId,
+      displayName: m.displayName,
+      location: m.location,
+      worldId: loc.worldId,
+      worldName,
+      instanceType: loc.type,
+      instanceId: loc.instanceId || '',
+      region: loc.region || '',
+      status: m.status,
+      platform: m.platform,
+      nickname: nicknameMap.get(m.userId) || null,
+      avatarImageUrl: m.avatarImageUrl,
+    };
+
+    // 实例详情：玩家数/容量（限流；失败不阻断）
+    // VRChat 实例查询 key 是完整 location 且不能 URL 编码（编码 :()~ 会 400 malformed url）
+    if (loc.instanceId) {
+      const instKey = m.location;   // 完整 location 字符串
+      if (!instanceInfo.has(instKey)) {
+        try {
+          const r = await rateLimiter.execute(() => api._request('GET', `/instances/${instKey}`));
+          if (r.status === 200 && r.data) {
+            instanceInfo.set(instKey, {
+              nUsers: r.data.n_users || 0,
+              capacity: r.data.capacity || 0,
+              recommendedCapacity: r.data.recommendedCapacity || 0,
+              type: r.data.type || '',
+            });
+          } else {
+            instanceInfo.set(instKey, null);
+          }
+        } catch (e) {
+          instanceInfo.set(instKey, null);
+        }
+      }
+      const inst = instanceInfo.get(instKey);
+      if (inst) {
+        entry.instanceUsers = inst.nUsers;
+        entry.instanceCapacity = inst.capacity;
+        entry.fillRatio = inst.capacity > 0 ? +(inst.nUsers / inst.capacity).toFixed(2) : 0;
+      }
+    }
+
+    // 推荐度：在线人数/容量比（人多热闹但别爆满）+ 实例类型权重
+    let score = 0;
+    if (entry.instanceUsers !== undefined) {
+      const fill = entry.fillRatio || 0;
+      // 黄金区间 30%-80%：人多但不挤；低于 30% 略减；超过 90% 大幅减（难挤进去）
+      if (fill >= 0.3 && fill <= 0.8) score += 50;
+      else if (fill > 0.9) score -= 40;
+      else if (fill < 0.1) score -= 10;
+      score += entry.instanceUsers * 3;
+    }
+    if (loc.type === 'public') score += 20;        // 公开实例最容易进
+    else if (loc.type === 'friends') score += 10;  // 好友实例
+    else if (loc.type === 'hidden') score += 10;   // friend+(好友+)实例，好友可进
+    else if (loc.type === 'group') score += 5;     // 群组实例需同群
+    if (m.status === 'active') score += 10;        // 活跃状态优先
+    entry.recommendScore = Math.round(score);
+    detailed.push(entry);
+  }
+
+  // 排序：推荐度降序
+  detailed.sort((a, b) => (b.recommendScore || 0) - (a.recommendScore || 0));
+
+  const onlineCount = members.filter(m => m.online).length;
+  const joinableCount = detailed.length;
+
+  return {
+    mode: 'list',
+    groupName: group.displayName || group.id,
+    groupId: group.id,
+    memberCount: members.length,
+    onlineCount,
+    joinableCount,
+    excludedPrivate: onlineCount - joinableCount,
+    friends: detailed,
+    offline: members.filter(m => !m.online).map(m => ({ userId: m.userId })),
+  };
+}
+
+// ── 推荐偏好：自然语言 → 权重调整（持久化到 config 表 join_prefs）──
+function parseJoinPreference(text) {
+  const t = String(text || '').trim();
+  if (!t) return { error: 'preference 不能为空' };
+  // 重置
+  if (/(恢复|取消|重置|默认|清空|不要偏好)/.test(t)) {
+    return { reset: true, message: '已恢复默认（无偏好）' };
+  }
+  let crowd = 'normal';
+  // 爱热闹（优先匹配，避免「喜欢人多」被误判为避人潮）
+  if (/(喜欢|爱|希望|想).*(热闹|人多|扎堆)|人越多越好|热闹一点|人多热闹/.test(t)) crowd = 'love';
+  // 避人潮
+  else if (/(不喜欢|讨厌|怕|不想|别).*(人多|热闹|挤|扎堆)|人.*太多|太挤|人少.*好|避开.*人群|清净/.test(t)) crowd = 'avoid';
+  if (crowd === 'normal' && !/(热闹|人多|爆满|挤|人群)/.test(t)) {
+    return { error: `未能识别偏好「${t}」——可试试「我不喜欢人太多」「喜欢热闹」「恢复默认」` };
+  }
+  const labels = { avoid: '避人潮（爆满重罚-80、人数权重×1.5、冷清不罚）', love: '爱热闹（人数权重×4、爆满轻罚-20）', normal: '默认' };
+  return { crowd, label: labels[crowd] };
+}
+
+async function handleSetJoinPreference({ preference } = {}) {
+  const parsed = parseJoinPreference(preference);
+  if (parsed.error) throw new Error(parsed.error);
+  if (parsed.reset) {
+    storage.setConfig('join_prefs', '');
+    return { success: true, reset: true, message: parsed.message };
+  }
+  const prefs = { crowd: parsed.crowd, label: parsed.label, updatedAt: new Date().toISOString() };
+  storage.setConfig('join_prefs', JSON.stringify(prefs));
+  return { success: true, ...prefs, message: `已保存：${parsed.label}` };
+}
+
+async function handleGetJoinPreference() {
+  try {
+    const raw = storage.getConfig('join_prefs');
+    if (!raw) return { preference: null, message: '当前无偏好（默认：人数×3、爆满-40、冷清-10）' };
+    return { preference: JSON.parse(raw) };
+  } catch (e) {
+    return { preference: null, error: `读取失败: ${e.message}` };
+  }
+}
+
+// ── 推荐选择学习：记录用户从推荐列表的选择，积累后自动分析偏好调整权重 ──
+let lastRecommendSnapshot = null; // 最近一次推荐列表快照（record_join_choice 补全上下文用）
+
+function computeListBaseline(top) {
+  const rows = top.filter(f => f.instanceUsers !== undefined && f.instanceUsers !== null);
+  if (rows.length === 0) return { list_count: top.length, list_avg_users: 0, list_avg_fill: 0, list_quiet_ratio: 0 };
+  const avgUsers = rows.reduce((s, f) => s + (f.instanceUsers || 0), 0) / rows.length;
+  const avgFill = rows.reduce((s, f) => s + (f.fillRatio || 0), 0) / rows.length;
+  const quietRatio = rows.filter(f => f.isQuietWorld).length / rows.length;
+  return {
+    list_count: top.length,
+    list_avg_users: Math.round(avgUsers * 10) / 10,
+    list_avg_fill: Math.round(avgFill * 100) / 100,
+    list_quiet_ratio: Math.round(quietRatio * 100) / 100,
+  };
+}
+
+function analyzeJoinLearning() {
+  const MIN_SAMPLES = 5;
+  const rows = storage._query('SELECT * FROM join_choices ORDER BY id DESC LIMIT 20');
+  if (rows.length < MIN_SAMPLES) {
+    return { enabled: false, samples: rows.length, minSamples: MIN_SAMPLES, crowd: null, familiarityMult: 1, quietBias: false };
+  }
+  const avg = (arr) => (arr.length ? arr.reduce((s, v) => s + v, 0) / arr.length : 0);
+  const avgChosenUsers = avg(rows.map(r => r.instance_users));
+  const avgListUsers = avg(rows.map(r => r.list_avg_users));
+  const avgFam = avg(rows.map(r => r.familiarity_score));
+  const quietRatio = rows.filter(r => r.is_quiet_world).length / rows.length;
+  // 人数倾向：选择平均人数 vs 当时列表平均人数（<60% 避人潮，>130% 爱热闹）
+  let crowd = null;
+  if (avgListUsers > 3 && avgChosenUsers < avgListUsers * 0.6) crowd = 'avoid';
+  else if (avgListUsers > 3 && avgChosenUsers > avgListUsers * 1.3) crowd = 'love';
+  // 熟悉度倾向：60% 以上选择熟悉度>=15 的好友 → 熟悉度加权
+  const famPrefer = avgFam >= 15 && rows.filter(r => r.familiarity_score >= 15).length >= Math.ceil(rows.length * 0.6);
+  // 安静图倾向：50% 以上选择安静图 → 安静图偏好
+  const quietBias = quietRatio >= 0.5;
+  const learning = {
+    enabled: true,
+    samples: rows.length,
+    crowd,
+    familiarityMult: famPrefer ? 1.2 : 1,
+    quietBias,
+    stats: {
+      avgChosenUsers: Math.round(avgChosenUsers * 10) / 10,
+      avgListUsers: Math.round(avgListUsers * 10) / 10,
+      avgFamiliarity: Math.round(avgFam * 10) / 10,
+      quietRatio: Math.round(quietRatio * 100) / 100,
+    },
+    updatedAt: new Date().toISOString(),
+  };
+  storage.setConfig('join_learning', JSON.stringify(learning));
+  return learning;
+}
+
+async function handleRecordJoinChoice({ userId, displayName } = {}) {
+  if (!lastRecommendSnapshot) throw new Error('还没有推荐列表——请先运行 recommend_join 再记录选择');
+  const top = lastRecommendSnapshot.top || [];
+  if (top.length === 0) throw new Error('最近一次推荐列表为空，无法记录');
+  let hit = null;
+  if (userId) hit = top.find(f => f.userId === userId);
+  if (!hit && displayName) {
+    const dn = String(displayName).toLowerCase();
+    hit = top.find(f => (f.displayName || '').toLowerCase().includes(dn));
+  }
+  if (!hit) throw new Error(`推荐列表中没有找到「${displayName || userId}」——请先运行 recommend_join 并从中选择`);
+  const rank = top.indexOf(hit) + 1;
+  const baseline = lastRecommendSnapshot.baseline;
+  storage._run(
+    `INSERT INTO join_choices (user_id, display_name, world_id, world_name, instance_type, instance_users, instance_capacity, fill_ratio, familiarity_score, is_quiet_world, recommend_score, rank_in_list, list_count, list_avg_users, list_avg_fill, list_quiet_ratio)
+     VALUES ($userId, $displayName, $worldId, $worldName, $instanceType, $instanceUsers, $instanceCapacity, $fillRatio, $familiarityScore, $isQuietWorld, $recommendScore, $rank, $listCount, $listAvgUsers, $listAvgFill, $listQuietRatio)`,
+    {
+      $userId: hit.userId, $displayName: hit.displayName, $worldId: hit.worldId || '',
+      $worldName: hit.worldName || '', $instanceType: hit.instanceType || '',
+      $instanceUsers: hit.instanceUsers || 0, $instanceCapacity: hit.instanceCapacity || 0,
+      $fillRatio: hit.fillRatio || 0, $familiarityScore: (hit.familiarity && hit.familiarity.score) || 0,
+      $isQuietWorld: hit.isQuietWorld ? 1 : 0, $recommendScore: hit.recommendScore || 0,
+      $rank: rank, $listCount: baseline.list_count, $listAvgUsers: baseline.list_avg_users,
+      $listAvgFill: baseline.list_avg_fill, $listQuietRatio: baseline.list_quiet_ratio,
+    },
+  );
+  const learning = analyzeJoinLearning();
+  return {
+    success: true,
+    recorded: { userId: hit.userId, displayName: hit.displayName, worldName: hit.worldName, rank },
+    learning,
+  };
+}
+
+async function handleGetJoinLearning() {
+  try {
+    const raw = storage.getConfig('join_learning');
+    const learning = raw ? JSON.parse(raw) : analyzeJoinLearning();
+    const count = storage._query('SELECT COUNT(*) AS c FROM join_choices')[0].c;
+    return { choicesCount: count, learning };
+  } catch (e) {
+    return { error: `读取失败: ${e.message}` };
+  }
+}
+
+async function handleRecommendJoin({ limit = 10, minScore = 0 } = {}) {
+  // 0. 权重来源：显式偏好(join_prefs) > 自动学习(join_learning) > 默认
+  let joinPrefs = { crowd: 'normal' };
+  try {
+    const rawPref = storage.getConfig('join_prefs');
+    if (rawPref) joinPrefs = { ...joinPrefs, ...JSON.parse(rawPref) };
+  } catch (e) { /* 偏好解析失败按默认 */ }
+  let learning = null;
+  if (!joinPrefs.crowd || joinPrefs.crowd === 'normal') {
+    try {
+      const rawLearn = storage.getConfig('join_learning');
+      if (rawLearn) { const l = JSON.parse(rawLearn); if (l && l.enabled) learning = l; }
+    } catch (e) { /* 学习结果解析失败按默认 */ }
+  }
+  const isExplicitPref = joinPrefs.crowd && joinPrefs.crowd !== 'normal';
+  const CROWD = joinPrefs.crowd || (learning && learning.crowd) || 'normal';
+  const famMult = isExplicitPref ? 1 : (learning ? learning.familiarityMult : 1);
+  const crowdMult = CROWD === 'avoid' ? 1.5 : (CROWD === 'love' ? 4 : 3);
+  const fullPenalty = CROWD === 'avoid' ? 80 : (CROWD === 'love' ? 20 : 40);
+  const coldPenalty = CROWD === 'avoid' ? 0 : (CROWD === 'love' ? 15 : 10);
+  const prefTag = CROWD === 'normal' ? '' : (isExplicitPref ? `偏好[${CROWD === 'avoid' ? '避人潮' : '爱热闹'}]` : `学习[${CROWD === 'avoid' ? '避人潮' : '爱热闹'}]`);
+
+  // 1. 全部在线好友
+  const onlineR = await rateLimiter.execute(() => api._request('GET', '/auth/user/friends?offline=false'));
+  if (onlineR.status !== 200) throw new Error(`API error: ${onlineR.status}`);
+  const onlineFriends = Array.isArray(onlineR.data) ? onlineR.data : [];
+
+  // 2. 收藏夹分组（熟悉度补充信号，权重可配置）
+  let groupWeights = {};
+  const contactGroups = new Set();
+  try {
+    if (process.env.VRC_MONITOR_GROUP_WEIGHTS) groupWeights = JSON.parse(process.env.VRC_MONITOR_GROUP_WEIGHTS);
+  } catch (e) {}
+  if (process.env.VRC_MONITOR_CONTACT_GROUPS) {
+    for (const g of process.env.VRC_MONITOR_CONTACT_GROUPS.split(',')) contactGroups.add(g.trim());
+  }
+  const groupMap = new Map();
+  try {
+    const groupsR = await rateLimiter.execute(() => api._request('GET', '/favorite/groups?type=friend&n=100'));
+    const favsR = await rateLimiter.execute(() => api._request('GET', '/favorites?type=friend&n=100'));
+    const groups = (groupsR.status === 200 && Array.isArray(groupsR.data)) ? groupsR.data : [];
+    const favs = (favsR.status === 200 && Array.isArray(favsR.data)) ? favsR.data : [];
+    for (const g of groups) {
+      const isContact = contactGroups.has(g.displayName || g.name);
+      const weight = groupWeights[g.displayName || g.name] !== undefined ? groupWeights[g.displayName || g.name] : (isContact ? -40 : 5);
+      const memberIds = new Set(favs.filter(f => (f.tags || [])[0] === g.name).map(f => f.favoriteId));
+      groupMap.set(g.displayName || g.name, { memberIds, weight, isContact });
+    }
+  } catch (e) { /* 收藏夹失败不阻断 */ }
+
+  // 3. 熟悉度：同屏统计（现成 storage.findCompanions，30天 + 一年各一次，缓存）
+  const SELF = api.currentUser?.id || (await api._request('GET', '/auth/user')).data?.id || '';
+  const NOW_MS = Date.now();
+  const DAY = 86400000;
+  const companionsCache = {};
+  async function getCompanionsMap(startMs, endMs) {
+    const key = `${startMs}|${endMs}`;
+    if (companionsCache[key]) return companionsCache[key];
+    const r = storage.findCompanions(SELF, new Date(startMs).toISOString(), new Date(endMs).toISOString());
+    const map = new Map((r.companions || []).map(c => [c.userId, c.matchCount || 0]));
+    companionsCache[key] = map;
+    return map;
+  }
+  async function familiarityScore(userId) {
+    const recentMap = await getCompanionsMap(NOW_MS - 30 * DAY, NOW_MS);
+    const histMap = await getCompanionsMap(NOW_MS - 365 * DAY, NOW_MS);
+    const recent = recentMap.get(userId) || 0;
+    const hist = histMap.get(userId) || 0;
+    const recentScore = Math.min(recent * 2, 60) + (recent > 0 ? 10 : 0);
+    const histScore = Math.min(hist * 0.5, 30) * 0.6;
+    return { score: Math.round(recentScore + histScore), recentMatchCount: recent, histMatchCount: hist };
+  }
+
+  // 4. 逐个好友：世界名 + 实例 + 熟悉度 + 综合评分
+  const worldCache = new Map();
+  const instanceInfo = new Map();
+  const sleepWorlds = new Set();
+  try {
+    const sw = storage._query ? storage._query('SELECT world_id FROM new_worlds WHERE sleep_ok=1') : [];
+    for (const r of sw) sleepWorlds.add(r.world_id);
+  } catch (e) {}
+
+  // 安静图判定：sleep_ok=1 或世界名命中安静关键词（人少更好，人多打扰）
+  const QUIET_RE = /(寝|眠|睡眠|睡觉|睡|sleep|quiet|静か|静寂|calm|relax|リラックス|ゆったり|安らぎ|癒し|冥想|meditation)/i;
+  const isQuietWorldName = (name) => typeof name === 'string' && QUIET_RE.test(name);
+
+  const detailed = [];
+  for (const f of onlineFriends) {
+    const loc = parseLocation(f.location || 'private');
+    if (!loc || loc.type === 'private' || loc.type === 'traveling' ||
+        f.location === 'private' || f.location === 'offline' || f.location === 'traveling') continue;
+
+    // 世界名
+    let worldName = f.worldId || loc.worldId || '';
+    if (loc.worldId) {
+      if (worldCache.has(loc.worldId)) worldName = worldCache.get(loc.worldId);
+      else {
+        const cached = storage.getWorldName(loc.worldId);
+        if (cached && cached.name) worldName = cached.name;
+        else {
+          const r = await rateLimiter.execute(() => api._request('GET', `/worlds/${loc.worldId}`));
+          if (r.status === 200 && r.data && r.data.name) {
+            worldName = r.data.name;
+            try { storage.upsertWorld({ worldId: loc.worldId, name: r.data.name, authorId: r.data.authorId || '', authorName: r.data.authorName || '' }); } catch (e) {}
+          }
+        }
+        worldCache.set(loc.worldId, worldName);
+      }
+    }
+
+    // 实例详情
+    let instanceUsers, instanceCapacity, fillRatio;
+    if (loc.instanceId && f.location && !f.location.includes('~private')) {
+      const instKey = f.location;
+      if (!instanceInfo.has(instKey)) {
+        try {
+          const r = await rateLimiter.execute(() => api._request('GET', `/instances/${instKey}`));
+          if (r.status === 200 && r.data) instanceInfo.set(instKey, { nUsers: r.data.n_users || 0, capacity: r.data.capacity || 0 });
+          else instanceInfo.set(instKey, null);
+        } catch (e) { instanceInfo.set(instKey, null); }
+      }
+      const inst = instanceInfo.get(instKey);
+      if (inst) {
+        instanceUsers = inst.nUsers;
+        instanceCapacity = inst.capacity;
+        fillRatio = inst.capacity > 0 ? +(inst.nUsers / inst.capacity).toFixed(2) : 0;
+      }
+    }
+
+    // 收藏夹分组
+    let groupName = null, groupWeight = 0, isContact = false;
+    for (const [gn, info] of groupMap) {
+      if (info.memberIds.has(f.id)) {
+        groupName = gn; groupWeight = info.weight; isContact = info.isContact;
+        break;
+      }
+    }
+
+    // 熟悉度
+    const fam = await familiarityScore(f.id);
+
+    // 综合评分
+    let score = 0;
+    const reasons = [];
+    if (isContact) { score -= 40; reasons.push('活动联系人-40'); }
+    else {
+      const famScore = famMult !== 1 ? Math.min(Math.round(fam.score * famMult), 100) : Math.min(fam.score, 100);
+      score += famScore;
+      reasons.push(`熟悉度${famScore}${famMult !== 1 ? `(学习加权×${famMult})` : ''}(30天${fam.recentMatchCount}次)`);
+      if (groupName) {
+        const bonus = Math.min(groupWeight, 10);
+        if (bonus !== 0) { score += bonus; reasons.push(`[${groupName}]+${bonus}`); }
+      }
+    }
+    const isSleepWorld = loc.worldId && sleepWorlds.has(loc.worldId);
+    const isQuietWorld = isSleepWorld || isQuietWorldName(worldName);
+    if (instanceUsers !== undefined) {
+      if (isQuietWorld) {
+        // 安静图：人少是理想状态，人多反而打扰（破坏氛围/电灯泡）
+        const quietBonus = learning && learning.quietBias ? 25 : 15;
+        if (instanceUsers === 0) { reasons.push(`安静图空房可进`); }
+        else if (instanceUsers <= 3) { score += quietBonus; reasons.push(`安静图${instanceUsers}人正合适+${quietBonus}`); }
+        else if (instanceUsers <= 6) { score += 0; reasons.push(`安静图${instanceUsers}人适中`); }
+        else { score -= 50; reasons.push(`安静图${instanceUsers}人太多-50`); }
+      } else {
+        // 热闹图：人多正向，黄金区最理想（人数权重/爆满/冷清受偏好调节）
+        if (instanceUsers < 3 && instanceUsers > 0) { score -= 15; reasons.push(`人少${instanceUsers}人可能私聊-15`); }
+        if (fillRatio >= 0.3 && fillRatio <= 0.8) { score += 50; reasons.push(`黄金区${Math.round(fillRatio*100)}%+50`); }
+        else if (fillRatio > 0.9) { score -= fullPenalty; reasons.push(`${prefTag}爆满-${fullPenalty}`); }
+        else if (fillRatio < 0.1) { score -= coldPenalty; reasons.push(`${prefTag}冷清-${coldPenalty}`); }
+        score += instanceUsers * crowdMult; reasons.push(`人数${instanceUsers}${CROWD === 'normal' ? '' : `×${crowdMult}`}`);
+      }
+    }
+    if (loc.type === 'public') { score += 20; reasons.push('public+20'); }
+    else if (loc.type === 'friends' || loc.type === 'hidden') { score += 10; reasons.push(loc.type === 'hidden' ? 'friend++10' : 'friends+10'); }
+    else if (loc.type === 'group') { score += 5; reasons.push('group+5'); }
+    if (f.status === 'active') { score += 10; reasons.push('active+10'); }
+
+    detailed.push({
+      userId: f.id,
+      displayName: f.displayName,
+      worldId: loc.worldId,
+      worldName,
+      instanceType: loc.type,
+      instanceTypeDisplay: loc.type === 'hidden' ? 'friend+' : loc.type,
+      instanceUsers, instanceCapacity, fillRatio,
+      region: loc.region || '',
+      status: f.status,
+      isSleepWorld,
+      isQuietWorld,
+      familiarity: fam,
+      relation: { group: groupName, isContact, note: isContact ? '活动联系人(非好友)' : (groupName ? `收藏夹[${groupName}]` : '普通好友') },
+      recommendScore: Math.round(score),
+      reasons,
+    });
+  }
+
+  detailed.sort((a, b) => (b.recommendScore || 0) - (a.recommendScore || 0));
+  const filtered = minScore > 0 ? detailed.filter(d => d.recommendScore >= minScore) : detailed;
+  // 存推荐快照（record_join_choice 用它补全选择上下文）
+  const baseline = computeListBaseline(filtered.slice(0, limit));
+  lastRecommendSnapshot = { at: Date.now(), top: filtered.slice(0, limit), baseline };
+  return {
+    totalOnline: onlineFriends.length,
+    joinable: detailed.length,
+    top: filtered.slice(0, limit),
+    method: 'familiarity+group+scene+instance',
+    preference: isExplicitPref ? { crowd: CROWD, label: joinPrefs.label || '' } : null,
+    learning: (!isExplicitPref && learning) ? { crowd: learning.crowd, familiarityMult: learning.familiarityMult, quietBias: learning.quietBias, samples: learning.samples } : null,
   };
 }
 
@@ -2159,6 +2867,24 @@ async function handleRpc(rpc, session, res) {
             break;
           case 'peek_group_announcement':
             result = await rateLimiter.execute(() => handlePeekGroupAnnouncement(args));
+            break;
+          case 'get_favorite_friends_locations':
+            result = await handleGetFavoriteFriendsLocations(args);
+            break;
+          case 'recommend_join':
+            result = await handleRecommendJoin(args);
+            break;
+          case 'set_join_preference':
+            result = await handleSetJoinPreference(args);
+            break;
+          case 'get_join_preference':
+            result = await handleGetJoinPreference();
+            break;
+          case 'record_join_choice':
+            result = await handleRecordJoinChoice(args);
+            break;
+          case 'get_join_learning':
+            result = await handleGetJoinLearning();
             break;
           default:
             throw new Error(`Unknown tool: ${name}`);

--- a/start-monitor.js
+++ b/start-monitor.js
@@ -805,6 +805,135 @@ function parseLocation(loc) {
   };
 }
 
+// ── 共享评分系统（recommend_join 与 get_favorite_friends_locations 共用同一套）──
+// 两个工具只是从不同集合选人（全部在线好友 / 收藏夹成员），评分逻辑完全一致
+
+function buildScoreContext() {
+  // 权重来源：显式偏好(join_prefs) > 自动学习(join_learning) > 默认
+  let joinPrefs = { crowd: 'normal' };
+  try {
+    const rawPref = storage.getConfig('join_prefs');
+    if (rawPref) joinPrefs = { ...joinPrefs, ...JSON.parse(rawPref) };
+  } catch (e) { /* 偏好解析失败按默认 */ }
+  let learning = null;
+  if (!joinPrefs.crowd || joinPrefs.crowd === 'normal') {
+    try {
+      const rawLearn = storage.getConfig('join_learning');
+      if (rawLearn) { const l = JSON.parse(rawLearn); if (l && l.enabled) learning = l; }
+    } catch (e) { /* 学习结果解析失败按默认 */ }
+  }
+  const isExplicitPref = joinPrefs.crowd && joinPrefs.crowd !== 'normal';
+  const CROWD = joinPrefs.crowd || (learning && learning.crowd) || 'normal';
+  const famMult = isExplicitPref ? 1 : (learning ? learning.familiarityMult : 1);
+  const crowdMult = CROWD === 'avoid' ? 1.5 : (CROWD === 'love' ? 4 : 3);
+  const fullPenalty = CROWD === 'avoid' ? 80 : (CROWD === 'love' ? 20 : 40);
+  const coldPenalty = CROWD === 'avoid' ? 0 : (CROWD === 'love' ? 15 : 10);
+  const prefTag = CROWD === 'normal' ? '' : (isExplicitPref ? `偏好[${CROWD === 'avoid' ? '避人潮' : '爱热闹'}]` : `学习[${CROWD === 'avoid' ? '避人潮' : '爱热闹'}]`);
+  // 睡觉图集合（new_worlds.sleep_ok=1）+ 安静图名字判定
+  const sleepWorlds = new Set();
+  try {
+    const sw = storage._query('SELECT world_id FROM new_worlds WHERE sleep_ok=1');
+    for (const r of sw) sleepWorlds.add(r.world_id);
+  } catch (e) { /* 表不存在/无数据按空处理 */ }
+  const QUIET_RE = /(寝|眠|睡眠|睡觉|睡|sleep|quiet|静か|静寂|calm|relax|リラックス|ゆったり|安らぎ|癒し|冥想|meditation)/i;
+  const isQuietWorldName = (name) => typeof name === 'string' && QUIET_RE.test(name);
+  return { joinPrefs, learning, isExplicitPref, CROWD, famMult, crowdMult, fullPenalty, coldPenalty, prefTag, sleepWorlds, isQuietWorldName };
+}
+
+async function buildFamiliarityScorer() {
+  // 同屏统计（现成 storage.findCompanions，30天 + 一年各一次，带缓存）
+  const SELF = api.currentUser?.id || (await api._request('GET', '/auth/user')).data?.id || '';
+  const NOW_MS = Date.now();
+  const DAY = 86400000;
+  const companionsCache = {};
+  async function getCompanionsMap(startMs, endMs) {
+    const key = `${startMs}|${endMs}`;
+    if (companionsCache[key]) return companionsCache[key];
+    const r = storage.findCompanions(SELF, new Date(startMs).toISOString(), new Date(endMs).toISOString());
+    const map = new Map((r.companions || []).map(c => [c.userId, c.matchCount || 0]));
+    companionsCache[key] = map;
+    return map;
+  }
+  async function familiarityScore(userId) {
+    const recentMap = await getCompanionsMap(NOW_MS - 30 * DAY, NOW_MS);
+    const histMap = await getCompanionsMap(NOW_MS - 365 * DAY, NOW_MS);
+    const recent = recentMap.get(userId) || 0;
+    const hist = histMap.get(userId) || 0;
+    const recentScore = Math.min(recent * 2, 60) + (recent > 0 ? 10 : 0);
+    const histScore = Math.min(hist * 0.5, 30) * 0.6;
+    return { score: Math.round(recentScore + histScore), recentMatchCount: recent, histMatchCount: hist };
+  }
+  return { familiarityScore };
+}
+
+async function buildGroupMap() {
+  // 收藏夹分组（熟悉度补充信号，权重配置化：VRC_MONITOR_GROUP_WEIGHTS / VRC_MONITOR_CONTACT_GROUPS）
+  let groupWeights = {};
+  const contactGroups = new Set();
+  try {
+    if (process.env.VRC_MONITOR_GROUP_WEIGHTS) groupWeights = JSON.parse(process.env.VRC_MONITOR_GROUP_WEIGHTS);
+  } catch (e) { /* 解析失败按默认 */ }
+  if (process.env.VRC_MONITOR_CONTACT_GROUPS) {
+    for (const g of process.env.VRC_MONITOR_CONTACT_GROUPS.split(',')) contactGroups.add(g.trim());
+  }
+  const groupMap = new Map();
+  try {
+    const groupsR = await rateLimiter.execute(() => api._request('GET', '/favorite/groups?type=friend&n=100'));
+    const favsR = await rateLimiter.execute(() => api._request('GET', '/favorites?type=friend&n=100'));
+    const groups = (groupsR.status === 200 && Array.isArray(groupsR.data)) ? groupsR.data : [];
+    const favs = (favsR.status === 200 && Array.isArray(favsR.data)) ? favsR.data : [];
+    for (const g of groups) {
+      const isContact = contactGroups.has(g.displayName || g.name);
+      const weight = groupWeights[g.displayName || g.name] !== undefined ? groupWeights[g.displayName || g.name] : (isContact ? -40 : 5);
+      const memberIds = new Set(favs.filter(f => (f.tags || [])[0] === g.name).map(f => f.favoriteId));
+      groupMap.set(g.displayName || g.name, { memberIds, weight, isContact });
+    }
+  } catch (e) { /* 收藏夹失败不阻断 */ }
+  return groupMap;
+}
+
+function computeEntryScore(ctx, entry) {
+  // 统一评分：熟悉度 + 收藏夹权重 + 安静图场景 + 实例人数/类型 + 偏好/学习调节
+  const { CROWD, famMult, crowdMult, fullPenalty, coldPenalty, prefTag, sleepWorlds, isQuietWorldName, learning } = ctx;
+  const { loc, worldName, instanceUsers, fillRatio, status, groupName, groupWeight, isContact, familiarity } = entry;
+  let score = 0;
+  const reasons = [];
+  if (isContact) { score -= 40; reasons.push('活动联系人-40'); }
+  else {
+    const famScore = famMult !== 1 ? Math.min(Math.round(familiarity.score * famMult), 100) : Math.min(familiarity.score, 100);
+    score += famScore;
+    reasons.push(`熟悉度${famScore}${famMult !== 1 ? `(学习加权×${famMult})` : ''}(30天${familiarity.recentMatchCount}次)`);
+    if (groupName) {
+      const bonus = Math.min(groupWeight, 10);
+      if (bonus !== 0) { score += bonus; reasons.push(`[${groupName}]+${bonus}`); }
+    }
+  }
+  const isSleepWorld = loc.worldId && sleepWorlds.has(loc.worldId);
+  const isQuietWorld = isSleepWorld || isQuietWorldName(worldName);
+  if (instanceUsers !== undefined) {
+    if (isQuietWorld) {
+      // 安静图：人少是理想状态，人多反而打扰（破坏氛围/电灯泡）
+      const quietBonus = learning && learning.quietBias ? 25 : 15;
+      if (instanceUsers === 0) { reasons.push('安静图空房可进'); }
+      else if (instanceUsers <= 3) { score += quietBonus; reasons.push(`安静图${instanceUsers}人正合适+${quietBonus}`); }
+      else if (instanceUsers <= 6) { score += 0; reasons.push(`安静图${instanceUsers}人适中`); }
+      else { score -= 50; reasons.push(`安静图${instanceUsers}人太多-50`); }
+    } else {
+      // 热闹图：人多正向，黄金区最理想（人数权重/爆满/冷清受偏好调节）
+      if (instanceUsers < 3 && instanceUsers > 0) { score -= 15; reasons.push(`人少${instanceUsers}人可能私聊-15`); }
+      if (fillRatio >= 0.3 && fillRatio <= 0.8) { score += 50; reasons.push(`黄金区${Math.round(fillRatio*100)}%+50`); }
+      else if (fillRatio > 0.9) { score -= fullPenalty; reasons.push(`${prefTag}爆满-${fullPenalty}`); }
+      else if (fillRatio < 0.1) { score -= coldPenalty; reasons.push(`${prefTag}冷清-${coldPenalty}`); }
+      score += instanceUsers * crowdMult; reasons.push(`人数${instanceUsers}${CROWD === 'normal' ? '' : `×${crowdMult}`}`);
+    }
+  }
+  if (loc.type === 'public') { score += 20; reasons.push('public+20'); }
+  else if (loc.type === 'friends' || loc.type === 'hidden') { score += 10; reasons.push(loc.type === 'hidden' ? 'friend++10' : 'friends+10'); }
+  else if (loc.type === 'group') { score += 5; reasons.push('group+5'); }
+  if (status === 'active') { score += 10; reasons.push('active+10'); }
+  return { score: Math.round(score), reasons, isQuietWorld, isSleepWorld };
+}
+
 async function handleGetFavoriteFriendsLocations({ groupName, favoriteGroupId, searchName }) {
   const nicknames = storage.getNicknames({});
   const nicknameMap = new Map();
@@ -974,6 +1103,10 @@ async function handleGetFavoriteFriendsLocations({ groupName, favoriteGroupId, s
   }
 
   // 5. 在线好友：补世界名 + 实例信息（玩家数/容量/类型），算推荐度
+  //    共享评分系统：熟悉度 + 收藏夹权重 + 安静图场景 + 偏好/学习（与 recommend_join 同一套）
+  const ctx = buildScoreContext();
+  const { familiarityScore } = await buildFamiliarityScorer();
+  const groupMap = await buildGroupMap();
   //    位置解析 + 世界名缓存；实例详情批量查（限流）
   const worldCache = new Map();
   const instanceInfo = new Map();
@@ -1053,22 +1186,25 @@ async function handleGetFavoriteFriendsLocations({ groupName, favoriteGroupId, s
       }
     }
 
-    // 推荐度：在线人数/容量比（人多热闹但别爆满）+ 实例类型权重
-    let score = 0;
-    if (entry.instanceUsers !== undefined) {
-      const fill = entry.fillRatio || 0;
-      // 黄金区间 30%-80%：人多但不挤；低于 30% 略减；超过 90% 大幅减（难挤进去）
-      if (fill >= 0.3 && fill <= 0.8) score += 50;
-      else if (fill > 0.9) score -= 40;
-      else if (fill < 0.1) score -= 10;
-      score += entry.instanceUsers * 3;
+    // 收藏夹分组 + 熟悉度（同一套评分：熟悉度 + 收藏夹权重 + 安静图 + 偏好/学习）
+    let groupName = null, groupWeight = 0, isContact = false;
+    for (const [gn, info] of groupMap) {
+      if (info.memberIds.has(m.userId)) {
+        groupName = gn; groupWeight = info.weight; isContact = info.isContact;
+        break;
+      }
     }
-    if (loc.type === 'public') score += 20;        // 公开实例最容易进
-    else if (loc.type === 'friends') score += 10;  // 好友实例
-    else if (loc.type === 'hidden') score += 10;   // friend+(好友+)实例，好友可进
-    else if (loc.type === 'group') score += 5;     // 群组实例需同群
-    if (m.status === 'active') score += 10;        // 活跃状态优先
-    entry.recommendScore = Math.round(score);
+    const fam = await familiarityScore(m.userId);
+    const scored = computeEntryScore(ctx, {
+      loc, worldName: entry.worldName, instanceUsers: entry.instanceUsers,
+      fillRatio: entry.fillRatio, status: m.status,
+      groupName, groupWeight, isContact, familiarity: fam,
+    });
+    entry.familiarity = fam;
+    entry.isQuietWorld = scored.isQuietWorld;
+    entry.relation = { group: groupName, isContact, note: isContact ? '活动联系人(非好友)' : (groupName ? `收藏夹[${groupName}]` : '普通好友') };
+    entry.recommendScore = scored.score;
+    entry.reasons = scored.reasons;
     detailed.push(entry);
   }
 
@@ -1233,90 +1369,24 @@ async function handleGetJoinLearning() {
 }
 
 async function handleRecommendJoin({ limit = 10, minScore = 0 } = {}) {
-  // 0. 权重来源：显式偏好(join_prefs) > 自动学习(join_learning) > 默认
-  let joinPrefs = { crowd: 'normal' };
-  try {
-    const rawPref = storage.getConfig('join_prefs');
-    if (rawPref) joinPrefs = { ...joinPrefs, ...JSON.parse(rawPref) };
-  } catch (e) { /* 偏好解析失败按默认 */ }
-  let learning = null;
-  if (!joinPrefs.crowd || joinPrefs.crowd === 'normal') {
-    try {
-      const rawLearn = storage.getConfig('join_learning');
-      if (rawLearn) { const l = JSON.parse(rawLearn); if (l && l.enabled) learning = l; }
-    } catch (e) { /* 学习结果解析失败按默认 */ }
-  }
-  const isExplicitPref = joinPrefs.crowd && joinPrefs.crowd !== 'normal';
-  const CROWD = joinPrefs.crowd || (learning && learning.crowd) || 'normal';
-  const famMult = isExplicitPref ? 1 : (learning ? learning.familiarityMult : 1);
-  const crowdMult = CROWD === 'avoid' ? 1.5 : (CROWD === 'love' ? 4 : 3);
-  const fullPenalty = CROWD === 'avoid' ? 80 : (CROWD === 'love' ? 20 : 40);
-  const coldPenalty = CROWD === 'avoid' ? 0 : (CROWD === 'love' ? 15 : 10);
-  const prefTag = CROWD === 'normal' ? '' : (isExplicitPref ? `偏好[${CROWD === 'avoid' ? '避人潮' : '爱热闹'}]` : `学习[${CROWD === 'avoid' ? '避人潮' : '爱热闹'}]`);
+  // 0. 评分上下文（显式偏好 > 自动学习 > 默认，含安静图集合）
+  const ctx = buildScoreContext();
+  const { CROWD, isExplicitPref, joinPrefs, learning } = ctx;
 
   // 1. 全部在线好友
   const onlineR = await rateLimiter.execute(() => api._request('GET', '/auth/user/friends?offline=false'));
   if (onlineR.status !== 200) throw new Error(`API error: ${onlineR.status}`);
   const onlineFriends = Array.isArray(onlineR.data) ? onlineR.data : [];
 
-  // 2. 收藏夹分组（熟悉度补充信号，权重可配置）
-  let groupWeights = {};
-  const contactGroups = new Set();
-  try {
-    if (process.env.VRC_MONITOR_GROUP_WEIGHTS) groupWeights = JSON.parse(process.env.VRC_MONITOR_GROUP_WEIGHTS);
-  } catch (e) {}
-  if (process.env.VRC_MONITOR_CONTACT_GROUPS) {
-    for (const g of process.env.VRC_MONITOR_CONTACT_GROUPS.split(',')) contactGroups.add(g.trim());
-  }
-  const groupMap = new Map();
-  try {
-    const groupsR = await rateLimiter.execute(() => api._request('GET', '/favorite/groups?type=friend&n=100'));
-    const favsR = await rateLimiter.execute(() => api._request('GET', '/favorites?type=friend&n=100'));
-    const groups = (groupsR.status === 200 && Array.isArray(groupsR.data)) ? groupsR.data : [];
-    const favs = (favsR.status === 200 && Array.isArray(favsR.data)) ? favsR.data : [];
-    for (const g of groups) {
-      const isContact = contactGroups.has(g.displayName || g.name);
-      const weight = groupWeights[g.displayName || g.name] !== undefined ? groupWeights[g.displayName || g.name] : (isContact ? -40 : 5);
-      const memberIds = new Set(favs.filter(f => (f.tags || [])[0] === g.name).map(f => f.favoriteId));
-      groupMap.set(g.displayName || g.name, { memberIds, weight, isContact });
-    }
-  } catch (e) { /* 收藏夹失败不阻断 */ }
+  // 2. 收藏夹分组（权重配置化，共享构建）
+  const groupMap = await buildGroupMap();
 
-  // 3. 熟悉度：同屏统计（现成 storage.findCompanions，30天 + 一年各一次，缓存）
-  const SELF = api.currentUser?.id || (await api._request('GET', '/auth/user')).data?.id || '';
-  const NOW_MS = Date.now();
-  const DAY = 86400000;
-  const companionsCache = {};
-  async function getCompanionsMap(startMs, endMs) {
-    const key = `${startMs}|${endMs}`;
-    if (companionsCache[key]) return companionsCache[key];
-    const r = storage.findCompanions(SELF, new Date(startMs).toISOString(), new Date(endMs).toISOString());
-    const map = new Map((r.companions || []).map(c => [c.userId, c.matchCount || 0]));
-    companionsCache[key] = map;
-    return map;
-  }
-  async function familiarityScore(userId) {
-    const recentMap = await getCompanionsMap(NOW_MS - 30 * DAY, NOW_MS);
-    const histMap = await getCompanionsMap(NOW_MS - 365 * DAY, NOW_MS);
-    const recent = recentMap.get(userId) || 0;
-    const hist = histMap.get(userId) || 0;
-    const recentScore = Math.min(recent * 2, 60) + (recent > 0 ? 10 : 0);
-    const histScore = Math.min(hist * 0.5, 30) * 0.6;
-    return { score: Math.round(recentScore + histScore), recentMatchCount: recent, histMatchCount: hist };
-  }
+  // 3. 熟悉度：同屏统计（现成 storage.findCompanions，共享构建）
+  const { familiarityScore } = await buildFamiliarityScorer();
 
-  // 4. 逐个好友：世界名 + 实例 + 熟悉度 + 综合评分
+  // 4. 逐个好友：世界名 + 实例 + 综合评分
   const worldCache = new Map();
   const instanceInfo = new Map();
-  const sleepWorlds = new Set();
-  try {
-    const sw = storage._query ? storage._query('SELECT world_id FROM new_worlds WHERE sleep_ok=1') : [];
-    for (const r of sw) sleepWorlds.add(r.world_id);
-  } catch (e) {}
-
-  // 安静图判定：sleep_ok=1 或世界名命中安静关键词（人少更好，人多打扰）
-  const QUIET_RE = /(寝|眠|睡眠|睡觉|睡|sleep|quiet|静か|静寂|calm|relax|リラックス|ゆったり|安らぎ|癒し|冥想|meditation)/i;
-  const isQuietWorldName = (name) => typeof name === 'string' && QUIET_RE.test(name);
 
   const detailed = [];
   for (const f of onlineFriends) {
@@ -1361,7 +1431,7 @@ async function handleRecommendJoin({ limit = 10, minScore = 0 } = {}) {
       }
     }
 
-    // 收藏夹分组
+    // 收藏夹分组 + 熟悉度
     let groupName = null, groupWeight = 0, isContact = false;
     for (const [gn, info] of groupMap) {
       if (info.memberIds.has(f.id)) {
@@ -1369,46 +1439,14 @@ async function handleRecommendJoin({ limit = 10, minScore = 0 } = {}) {
         break;
       }
     }
-
-    // 熟悉度
     const fam = await familiarityScore(f.id);
 
-    // 综合评分
-    let score = 0;
-    const reasons = [];
-    if (isContact) { score -= 40; reasons.push('活动联系人-40'); }
-    else {
-      const famScore = famMult !== 1 ? Math.min(Math.round(fam.score * famMult), 100) : Math.min(fam.score, 100);
-      score += famScore;
-      reasons.push(`熟悉度${famScore}${famMult !== 1 ? `(学习加权×${famMult})` : ''}(30天${fam.recentMatchCount}次)`);
-      if (groupName) {
-        const bonus = Math.min(groupWeight, 10);
-        if (bonus !== 0) { score += bonus; reasons.push(`[${groupName}]+${bonus}`); }
-      }
-    }
-    const isSleepWorld = loc.worldId && sleepWorlds.has(loc.worldId);
-    const isQuietWorld = isSleepWorld || isQuietWorldName(worldName);
-    if (instanceUsers !== undefined) {
-      if (isQuietWorld) {
-        // 安静图：人少是理想状态，人多反而打扰（破坏氛围/电灯泡）
-        const quietBonus = learning && learning.quietBias ? 25 : 15;
-        if (instanceUsers === 0) { reasons.push(`安静图空房可进`); }
-        else if (instanceUsers <= 3) { score += quietBonus; reasons.push(`安静图${instanceUsers}人正合适+${quietBonus}`); }
-        else if (instanceUsers <= 6) { score += 0; reasons.push(`安静图${instanceUsers}人适中`); }
-        else { score -= 50; reasons.push(`安静图${instanceUsers}人太多-50`); }
-      } else {
-        // 热闹图：人多正向，黄金区最理想（人数权重/爆满/冷清受偏好调节）
-        if (instanceUsers < 3 && instanceUsers > 0) { score -= 15; reasons.push(`人少${instanceUsers}人可能私聊-15`); }
-        if (fillRatio >= 0.3 && fillRatio <= 0.8) { score += 50; reasons.push(`黄金区${Math.round(fillRatio*100)}%+50`); }
-        else if (fillRatio > 0.9) { score -= fullPenalty; reasons.push(`${prefTag}爆满-${fullPenalty}`); }
-        else if (fillRatio < 0.1) { score -= coldPenalty; reasons.push(`${prefTag}冷清-${coldPenalty}`); }
-        score += instanceUsers * crowdMult; reasons.push(`人数${instanceUsers}${CROWD === 'normal' ? '' : `×${crowdMult}`}`);
-      }
-    }
-    if (loc.type === 'public') { score += 20; reasons.push('public+20'); }
-    else if (loc.type === 'friends' || loc.type === 'hidden') { score += 10; reasons.push(loc.type === 'hidden' ? 'friend++10' : 'friends+10'); }
-    else if (loc.type === 'group') { score += 5; reasons.push('group+5'); }
-    if (f.status === 'active') { score += 10; reasons.push('active+10'); }
+    // 综合评分（共享评分系统：熟悉度 + 收藏夹权重 + 安静图场景 + 实例 + 偏好/学习）
+    const scored = computeEntryScore(ctx, {
+      loc, worldName, instanceUsers, fillRatio, status: f.status,
+      groupName, groupWeight, isContact, familiarity: fam,
+    });
+    const { score, reasons, isQuietWorld } = scored;
 
     detailed.push({
       userId: f.id,
@@ -1420,11 +1458,11 @@ async function handleRecommendJoin({ limit = 10, minScore = 0 } = {}) {
       instanceUsers, instanceCapacity, fillRatio,
       region: loc.region || '',
       status: f.status,
-      isSleepWorld,
+      isSleepWorld: scored.isSleepWorld,
       isQuietWorld,
       familiarity: fam,
       relation: { group: groupName, isContact, note: isContact ? '活动联系人(非好友)' : (groupName ? `收藏夹[${groupName}]` : '普通好友') },
-      recommendScore: Math.round(score),
+      recommendScore: score,
       reasons,
     });
   }


### PR DESCRIPTION
## 需求来源

本机日常使用反馈：好友在线时想快速知道「谁在哪个房间、值得加入」，但 VRChat 官方 API 只有好友位置数据，没有推荐维度。实际使用中沉淀出三个诉求：

1. **推荐加入**：在线好友按「熟不熟 + 房间合不合适」综合评分排序，一眼看出值得加入的（PR #2 关闭后保留在个人 fork 的 `recommend_join`）；
2. **权重可调**：不同人偏好不同——「我不喜欢人太多」时爆满房间应该降权（`set_join_preference` 自然语言设置）；
3. **自动学习**：用户每次从推荐列表的选择记录积累后，系统自动分析偏好并调整权重（`record_join_choice` / `get_join_learning`）。

## 实现方式

新增 6 个 MCP 工具（48 → 54）：

| 工具 | 功能 |
|---|---|
| `get_favorite_friends_locations` | 收藏夹分组内好友当前位置列表（`groupName`/`favoriteGroupId`/`searchName` 三模式），按推荐度排序，private 自动排除 |
| `recommend_join` | 全部在线好友综合评分推荐：熟悉度（最近30天+历史一年共玩次数，复用 `storage.findCompanions`）+ 收藏夹分组权重 + 房间场景（安静图人少理想/人多打扰）+ 实例人数/容量比 + 实例类型 |
| `set_join_preference` | 自然语言偏好 → 权重调整（「我不喜欢人太多」→ 爆满 -80/人数×1.5/冷清不罚；「喜欢热闹」→ 人数×4/爆满轻罚），持久化 config 表 |
| `get_join_preference` | 查询当前偏好 |
| `record_join_choice` | 记录一次推荐列表选择（自动从最近推荐快照补全上下文：人数/类型/熟悉度/排名/列表基线），写入 `join_choices` 表 |
| `get_join_learning` | 查看学习状态：≥5 样本自动分析（选择人数 < 列表 60% → 避人潮；60% 选熟悉度≥15 → 熟悉度×1.2；50% 选安静图 → 安静加分） |

**设计要点**：
- **无个人环境硬编码**：收藏夹分组权重/联系人名单通过 `.env` 的 `VRC_MONITOR_GROUP_WEIGHTS` / `VRC_MONITOR_CONTACT_GROUPS` 配置（服务启动时读取，未配置走通用默认 +5），个人分组名不入库；
- **复用现成能力**：熟悉度用现成 `storage.findCompanions`（同屏交叉统计）、世界名用 `storage.getWorldName`/`upsertWorld`、config 用现成 `getConfig`/`setConfig`；
- **权重优先级**：显式偏好（join_prefs）> 自动学习（join_learning）> 默认；
- **限流**：所有 handler 内 API 调用走 `rateLimiter.execute`（RPC case 层裸调不嵌套）；
- **schema**：`new_worlds` 加 `sleep_ok` 列（睡觉图标记，评分场景依据）+ 新增 `join_choices` 表（选择学习数据源，含列表基线列用于对比分析）。

## 验证过程与结果

**静态验证 14/14**（hermes-verify 脚本，已清理）：
- PR 文件范围 = 5 个目标文件（start-monitor.js / core/init-db.sql / README.md / AGENTS.md / skills SKILL.md），无 fork 独有文件混入；
- `node --check` 通过；无个人路径/分组名硬编码；
- 6 工具注册 + handler + RPC case 齐全；init-db 含 sleep_ok 列 + join_choices 表 + config 表；
- README/AGENTS/skills 工具数 48→54 三处同步。

**真实服务实测**（PR 分支代码起服务）：
- `tools/list` = 54 工具（上游 48 + 新 6，上游工具无缺失）；
- `get_join_preference` / `get_join_learning` / `get_favorite_friends_locations`（概览+searchName）调用正常；
- `record_join_choice` 无快照时正确报错（提示先运行推荐）；
- 服务 auth/ws/events 正常，数据无损。

**评分行为实测**（本地运行记录）：
- 避人潮偏好下爆满房间（78/80 人）从 241 分跌至 61 分掉出前五，黄金区房间上位；
- 5 样本模拟「选人少」→ 自动学习出 `crowd=avoid` 并持久化 config，推荐 reasons 标注 `学习[避人潮]`。

**复现**：配置 `credentials.json` 后启动服务，`recommend_join {limit: 5}` 即可看到推荐列表。
