### PR TITLE
feat: 学习系统 5 维度扩展 - 重复选人/人数舒适区/类型偏好 + 评分权重均衡

### DIFF
--- a/core/init-db.sql
+++ b/core/init-db.sql
@@ -111,9 +111,12 @@ CREATE TABLE IF NOT EXISTS new_worlds (
   popularity INTEGER DEFAULT 0,
   visited INTEGER DEFAULT 0,     -- 用户是否逛过（1=逛过）
   visited_at TEXT,               -- 逛过的时间（若已逛）
-  sleep_ok INTEGER DEFAULT 0        -- 适合睡觉/放松标记（推荐评分与「开个睡觉图」用）
+  tags TEXT DEFAULT '',          -- 作者标签 JSON 数组（author_tag_*，主题分类用）
+  description TEXT DEFAULT '',   -- 世界描述（主题关键词匹配用）
+  source TEXT DEFAULT 'new'      -- 来源: new=新发布-推荐 / hot=热门图追加
 );
 CREATE INDEX IF NOT EXISTS idx_new_worlds_visited ON new_worlds(visited);
+
 
 -- 推荐选择学习（recommend_join 用户选择记录，个性化权重学习的数据源）
 -- 每次用户从推荐列表选择某人/某图记录一条快照，含当时列表基线用于对比分析
@@ -135,5 +138,7 @@ CREATE TABLE IF NOT EXISTS join_choices (
   list_count INTEGER DEFAULT 0,     -- 当时列表长度
   list_avg_users REAL DEFAULT 0,    -- 当时列表平均人数（基线）
   list_avg_fill REAL DEFAULT 0,     -- 当时列表平均填充率（基线）
-  list_quiet_ratio REAL DEFAULT 0   -- 当时列表安静图占比（基线，0-1）
+  list_quiet_ratio REAL DEFAULT 0,  -- 当时列表安静图占比（基线，0-1）
+  world_tags TEXT DEFAULT ''        -- 被选世界的 author_tag_* 标签 JSON 数组（类型偏好学习用）
 );
+CREATE INDEX IF NOT EXISTS idx_join_choices_created ON join_choices(created_at);

--- a/core/storage.js
+++ b/core/storage.js
@@ -42,6 +42,17 @@ export class Storage {
     if (!jcCols.some(c => c.name === 'world_tags')) {
       this._run(`ALTER TABLE join_choices ADD COLUMN world_tags TEXT DEFAULT ''`);
     }
+    // 迁移：旧库 new_worlds 缺 tags/description/source 列（scan_new_worlds upsert 依赖，幂等）
+    const nwCols2 = this._query(`PRAGMA table_info(new_worlds)`);
+    if (!nwCols2.some(c => c.name === 'tags')) {
+      this._run(`ALTER TABLE new_worlds ADD COLUMN tags TEXT DEFAULT ''`);
+    }
+    if (!nwCols2.some(c => c.name === 'description')) {
+      this._run(`ALTER TABLE new_worlds ADD COLUMN description TEXT DEFAULT ''`);
+    }
+    if (!nwCols2.some(c => c.name === 'source')) {
+      this._run(`ALTER TABLE new_worlds ADD COLUMN source TEXT DEFAULT 'new'`);
+    }
     return this;
   }
 

--- a/core/storage.js
+++ b/core/storage.js
@@ -37,6 +37,11 @@ export class Storage {
     if (!nwCols.some(c => c.name === 'sleep_ok')) {
       this._run(`ALTER TABLE new_worlds ADD COLUMN sleep_ok INTEGER DEFAULT 0`);
     }
+    // 迁移：旧库 join_choices 缺 world_tags 列（类型偏好学习用，幂等）
+    const jcCols = this._query(`PRAGMA table_info(join_choices)`);
+    if (!jcCols.some(c => c.name === 'world_tags')) {
+      this._run(`ALTER TABLE join_choices ADD COLUMN world_tags TEXT DEFAULT ''`);
+    }
     return this;
   }
 

--- a/start-monitor.js
+++ b/start-monitor.js
@@ -15,6 +15,7 @@ import { randomUUID } from 'node:crypto';
 import { Storage } from './core/storage.js';
 import { RateLimiter } from './core/rate-limiter.js';
 import { VrchatApiClient } from './vrchat-api.js';
+import { openInstance } from './core/vrchat-launch.js';
 import { WsManager } from './core/ws-manager.js';
 import { EventPipeline } from './core/event-pipeline.js';
 import { backupDatabase } from './core/backup.js';
@@ -315,6 +316,50 @@ const CUSTOM_TOOLS = [
       required: ['userId'],
     },
   },
+  {
+    name: 'create_instance',
+    description: '[write·vrchat] Create a new instance (room) for a world. Returns instance location ready for invite_myself. Region defaults to jp.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        worldId: { type: 'string', description: 'World id (wrld_...)' },
+        type: { type: 'string', description: 'Instance type: public/hidden/friends/private/group (default hidden)' },
+        region: { type: 'string', description: 'Region: us/eu/jp (default jp)' },
+        instanceId: { type: 'string', description: 'Optional: existing instance id (shortName or full) to join instead of creating fresh' },
+        groupAccessType: { type: 'string', description: 'Required when type=group: members/plus/public' },
+      },
+      required: ['worldId'],
+    },
+  },
+  {
+    name: 'invite_myself',
+    description: '[write·vrchat] Open an instance in the running VRChat client (same engine as open_world): named-pipe launch first (Windows, silent in-game join dialog), falls back to API self-invite (client teleports on accept) when pipe unavailable. Accepts location (worldId:instanceId) or worldId+instanceId separately.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        location: { type: 'string', description: 'Full location string, e.g. wrld_x:12345~hidden(usr_x)~region(jp). If provided, worldId/instanceId are ignored.' },
+        worldId: { type: 'string', description: 'World id (wrld_...) — ignored if location is provided' },
+        instanceId: { type: 'string', description: 'Instance id (full format with ~region etc.) — ignored if location is provided' },
+        forceApi: { type: 'boolean', description: 'Skip pipe detection and force API self-invite (remote/test scenarios)' },
+      },
+    },
+  },
+  {
+    name: 'open_world',
+    description: '[write·vrchat] Open a world/instance in the running VRChat client. If only worldId given, creates a new instance first (hidden jp default), then: named-pipe launch (VRChatURLLaunchPipe → silent in-game join dialog, Windows, 1 step) with API self-invite fallback (invite notification) when pipe unavailable. Core: core/vrchat-launch.js openInstance.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        worldId: { type: 'string', description: 'World id (wrld_...) — creates a new instance (type/region) then opens it' },
+        location: { type: 'string', description: 'Full instance location to open directly, e.g. wrld_x:12345~hidden(usr_x)~region(jp). If given, worldId/type/region are ignored.' },
+        type: { type: 'string', description: 'Instance type when creating from worldId: public/hidden/friends/private/group (default hidden)' },
+        region: { type: 'string', description: 'Region when creating from worldId: us/eu/jp (default jp)' },
+        shortName: { type: 'string', description: 'Optional room short name shown in the launch menu' },
+        forceApi: { type: 'boolean', description: 'Skip pipe detection and force API self-invite (remote/test scenarios)' },
+      },
+    },
+  },
+
   {
     name: 'send_friend_request',
     description: '[write·vrchat] Send a friend request to a user. Supports userId or exact displayName match.',
@@ -938,9 +983,10 @@ function computeEntryScore(ctx, entry) {
       const comfy = learning && learning.preferredCrowdRange;
       let inComfort = false;
       if (comfy) {
-        const m = comfy.match(/^(\d+)-(\d+)\+?人?$/);
+        // 兼容「4-8人」和「61+人」两种格式（61+ 无连字符）
+        const m = comfy.match(/^(\d+)(?:-(\d+))?\+?人?$/);
         if (m) {
-          const lo = parseInt(m[1], 10), hi = m[2] === '' ? Infinity : parseInt(m[2], 10);
+          const lo = parseInt(m[1], 10), hi = m[2] ? parseInt(m[2], 10) : Infinity;
           inComfort = instanceUsers >= lo && instanceUsers <= hi;
         }
       }
@@ -1449,9 +1495,9 @@ async function handleRecordJoinChoice({ userId, displayName } = {}) {
 async function handleGetJoinLearning() {
   try {
     const raw = storage.getConfig('join_learning');
-    const learning = raw ? JSON.parse(raw) : analyzeJoinLearning();
-    const count = storage._query('SELECT COUNT(*) AS c FROM join_choices')[0].c;
-    return { choicesCount: count, learning };
+    // 旧缓存可能缺 preferredCrowdRange/worldType 字段——缺则重新分析
+    const cached = raw ? JSON.parse(raw) : null;
+    const learning = (cached && 'preferredCrowdRange' in cached && 'worldType' in cached) ? cached : analyzeJoinLearning();
   } catch (e) {
     return { error: `读取失败: ${e.message}` };
   }
@@ -1698,6 +1744,100 @@ async function handleSendFriendRequest({ userId, displayName }) {
   if (r.status >= 400) throw new Error(`API error ${r.status}`);
   return { userId: target.id, displayName, method: 'displayName', ok: true };
 }
+
+
+async function handleCreateInstance({ worldId, type, region, instanceId, groupAccessType }) {
+  if (!worldId || !String(worldId).startsWith('wrld_')) {
+    throw new Error('worldId 必须是 wrld_ 开头（如 wrld_xxxx）');
+  }
+  const instType = type || 'hidden';
+  const body = {
+    worldId,
+    type: instType,
+    region: region || 'jp',
+  };
+  if (instanceId) body.instanceId = instanceId;
+  if (groupAccessType) body.groupAccessType = groupAccessType;
+  // 非 public 实例必须显式带 ownerId（=当前用户），否则 API 400 "Invalid owner ID"（2026-08-09 实测）
+  if (instType !== 'public') {
+    await api.ensureAuth();
+    const me = (api.currentUser && api.currentUser.id) || null;
+    if (!me) throw new Error('无法获取当前用户 ID，不能创建非公开实例');
+    body.ownerId = me;
+  }
+  const r = await api._request('POST', '/instances', body);
+  if (r.status >= 400) {
+    throw new Error(`创建实例失败 API ${r.status}: ${JSON.stringify(r.data).slice(0, 200)}`);
+  }
+  const d = r.data || {};
+  return {
+    success: true,
+    worldId: d.worldId || worldId,
+    type: d.type || body.type,
+    region: d.region || body.region,
+    instanceId: d.instanceId || d.id || null,
+    location: d.location || null,
+    shortName: d.shortName || null,
+    capacity: d.capacity || null,
+  };
+}
+
+async function handleInviteMyself({ location, worldId, instanceId, forceApi }) {
+  // 统一入口（与 open_world 同一套）：管道直发优先（游戏内静默弹加入菜单），
+  // 管道不可用/非 Windows 时静默回退 API 自我邀请（客户端收到通知接受后传送）
+  let loc = location;
+  if (loc && typeof loc === 'string') {
+    const idx = loc.indexOf(':');
+    if (idx <= 0) throw new Error('location 格式应为 worldId:instanceId（如 wrld_x:12345~hidden(usr_x)~region(jp)）');
+    if (!String(loc).startsWith('wrld_')) throw new Error('location 必须是 wrld_ 开头的完整实例串');
+  } else {
+    if (!worldId || !String(worldId).startsWith('wrld_')) throw new Error('worldId 必须是 wrld_ 开头');
+    if (!instanceId) throw new Error('instanceId 不能为空（可用 create_instance 返回的 location）');
+    loc = `${worldId}:${instanceId}`;
+  }
+  const res = await openInstance({ location: loc, api, forceApi: !!forceApi });
+  if (!res.success) throw new Error(res.error || '邀请自己失败');
+  const wId = loc.slice(0, loc.indexOf(':'));
+  const iId = loc.slice(loc.indexOf(':') + 1);
+  return {
+    success: true,
+    method: res.method,
+    worldId: wId,
+    instanceId: iId,
+    notificationId: res.notificationId || null,
+    notificationType: null,
+    detail: res.detail || null,
+  };
+}
+
+async function handleOpenWorld({ worldId, location, type, region, shortName, forceApi }) {
+  // 1) 定位目标实例：直接给 location 就用它；只给 worldId 就先建实例（复用 handleCreateInstance）
+  let loc = location;
+  let sn = shortName || null;
+  if (!loc || typeof loc !== 'string') {
+    if (!worldId || !String(worldId).startsWith('wrld_')) {
+      throw new Error('需要 worldId（wrld_ 开头，自动建实例后打开）或 location（完整实例串直接打开）');
+    }
+    const inst = await handleCreateInstance({ worldId, type, region });
+    if (!inst.location) throw new Error('创建实例成功但未返回 location，无法打开');
+    loc = inst.location;
+    sn = sn || inst.shortName || null;
+  } else if (!String(loc).startsWith('wrld_')) {
+    throw new Error('location 必须是 wrld_ 开头的完整实例串（如 wrld_x:12345~hidden(usr_x)~region(jp)）');
+  }
+  // 2) 统一入口：管道直发（静默弹窗）→ 探测失败静默回退 API 自我邀请
+  const res = await openInstance({ location: loc, shortName: sn, api, forceApi: !!forceApi });
+  if (!res.success) throw new Error(res.error || '打开实例失败');
+  return {
+    success: true,
+    method: res.method,
+    location: loc,
+    shortName: sn,
+    notificationId: res.notificationId || null,
+    detail: res.detail || null,
+  };
+}
+
 
 async function handleRemoveFriend({ userId, displayName, confirm }) {
   if (!userId && !displayName) throw new Error('userId or displayName is required');
@@ -1995,7 +2135,7 @@ async function handleScanNewWorlds({ days = 7, dryRun = false }) {
   const selfUserId = serverState.authUser?.id;
   if (!selfUserId) throw new Error('Not authenticated');
 
-  const { fresh, candidates } = await fetchFreshWorlds(api, rateLimiter, { days, maxFetch: 200 });
+  const { fresh } = await fetchFreshWorlds(api, rateLimiter, { days, maxFetch: 200 });
 
   const visitedRows = storage._query(
     `SELECT DISTINCT world_id FROM events
@@ -2801,6 +2941,18 @@ async function handleRpc(rpc, session, res) {
             }));
             if (r.status >= 400) throw new Error(`API error ${r.status}`);
             result = { success: true, userId: args.userId, requestSent: true };
+            break;
+          }
+          case 'create_instance': {
+            result = await rateLimiter.execute(() => handleCreateInstance(args));
+            break;
+          }
+          case 'invite_myself': {
+            result = await rateLimiter.execute(() => handleInviteMyself(args));
+            break;
+          }
+          case 'open_world': {
+            result = await rateLimiter.execute(() => handleOpenWorld(args));
             break;
           }
           case 'send_friend_request': {

--- a/start-monitor.js
+++ b/start-monitor.js
@@ -20,7 +20,6 @@ import { EventPipeline } from './core/event-pipeline.js';
 import { backupDatabase } from './core/backup.js';
 import { FriendStateManager } from './core/friend-state.js';
 import { isJunkWorld, worldScore, classifyWorlds, fetchFreshWorlds } from './core/new-worlds.js';
-import { openInstance } from './core/vrchat-launch.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const PORT = 8799;
@@ -314,49 +313,6 @@ const CUSTOM_TOOLS = [
         message: { type: 'string' },
       },
       required: ['userId'],
-    },
-  },
-  {
-    name: 'create_instance',
-    description: '[write·vrchat] Create a new instance (room) for a world. Returns instance location ready for invite_myself. Region defaults to jp.',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        worldId: { type: 'string', description: 'World id (wrld_...)' },
-        type: { type: 'string', description: 'Instance type: public/hidden/friends/private/group (default hidden)' },
-        region: { type: 'string', description: 'Region: us/eu/jp (default jp)' },
-        instanceId: { type: 'string', description: 'Optional: existing instance id (shortName or full) to join instead of creating fresh' },
-        groupAccessType: { type: 'string', description: 'Required when type=group: members/plus/public' },
-      },
-      required: ['worldId'],
-    },
-  },
-  {
-    name: 'invite_myself',
-    description: '[write·vrchat] Open an instance in the running VRChat client (same engine as open_world): named-pipe launch first (Windows, silent in-game join dialog), falls back to API self-invite (client teleports on accept) when pipe unavailable. Accepts location (worldId:instanceId) or worldId+instanceId separately.',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        location: { type: 'string', description: 'Full location string, e.g. wrld_x:12345~hidden(usr_x)~region(jp). If provided, worldId/instanceId are ignored.' },
-        worldId: { type: 'string', description: 'World id (wrld_...) — ignored if location is provided' },
-        instanceId: { type: 'string', description: 'Instance id (full format with ~region etc.) — ignored if location is provided' },
-        forceApi: { type: 'boolean', description: 'Skip pipe detection and force API self-invite (remote/test scenarios)' },
-      },
-    },
-  },
-  {
-    name: 'open_world',
-    description: '[write·vrchat] Open a world/instance in the running VRChat client. If only worldId given, creates a new instance first (hidden jp default), then: named-pipe launch (VRChatURLLaunchPipe → silent in-game join dialog, Windows, 1 step) with API self-invite fallback (invite notification) when pipe unavailable. Core: core/vrchat-launch.js openInstance.',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        worldId: { type: 'string', description: 'World id (wrld_...) — creates a new instance (type/region) then opens it' },
-        location: { type: 'string', description: 'Full instance location to open directly, e.g. wrld_x:12345~hidden(usr_x)~region(jp). If given, worldId/type/region are ignored.' },
-        type: { type: 'string', description: 'Instance type when creating from worldId: public/hidden/friends/private/group (default hidden)' },
-        region: { type: 'string', description: 'Region when creating from worldId: us/eu/jp (default jp)' },
-        shortName: { type: 'string', description: 'Optional room short name shown in the launch menu' },
-        forceApi: { type: 'boolean', description: 'Skip pipe detection and force API self-invite (remote/test scenarios)' },
-      },
     },
   },
   {
@@ -728,7 +684,7 @@ const CUSTOM_TOOLS = [
   },
   {
     name: 'peek_group_announcement',
-    description: '[group] Peek a group announcement: joins if joinState=open, reads announcement, then leaves. Requires confirm: true. Non-open groups return peekable:false.',
+    description: '[group] Peek a group announcement: joins if joinState=open, reads announcement, then leaves. Non-open groups return peekable:false.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -823,6 +779,42 @@ function parseLocation(loc) {
   };
 }
 
+async function handleGetOnlineFriends() {
+  const r = await api._request('GET', '/auth/user/friends?offline=false');
+  if (r.status !== 200) throw new Error(`API error: ${r.status}`);
+  const friends = Array.isArray(r.data) ? r.data : [];
+  const online = friends.filter(f => f.location && f.location !== 'offline');
+
+  const nicknames = storage.getNicknames({});
+  const nicknameMap = new Map();
+  for (const item of nicknames) {
+    if (item.userId) nicknameMap.set(item.userId, item.nickname);
+  }
+
+  return {
+    online: online.length,
+    total: friends.length,
+    friends: online.map(f => ({
+      userId: f.id,
+      displayName: f.displayName,
+      location: f.location || 'private',
+      status: f.status,
+      statusDescription: f.statusDescription,
+      platform: f.platform,
+      avatarImageUrl: f.currentAvatarThumbnailImageUrl,
+      nickname: nicknameMap.get(f.id) || null,
+      locationParsed: parseLocation(f.location || 'private'),
+    })),
+  };
+}
+
+/**
+ * 好友收藏夹位置列表
+ * 1. 拉取全部好友收藏分组（/favorite/groups?type=friend）
+ * 2. 指定分组：拉组内好友（/favorites?type=friend&groupId=xxx），逐个查 /users/{id} 拿在线状态与位置
+ * 3. 推荐度排序：在线 + 实例可加入（public/friends/group，排除 private）在前，
+ *    按实例玩家数/容量比 + 好友收藏热度综合评分
+ */
 // ── 共享评分系统（recommend_join 与 get_favorite_friends_locations 共用同一套）──
 // 两个工具只是从不同集合选人（全部在线好友 / 收藏夹成员），评分逻辑完全一致
 
@@ -842,9 +834,11 @@ function buildScoreContext() {
   }
   const isExplicitPref = joinPrefs.crowd && joinPrefs.crowd !== 'normal';
   const CROWD = joinPrefs.crowd || (learning && learning.crowd) || 'normal';
-  const famMult = isExplicitPref ? 1 : (learning ? learning.familiarityMult : 1);
-  const crowdMult = CROWD === 'avoid' ? 1.5 : (CROWD === 'love' ? 4 : 3);
-  const fullPenalty = CROWD === 'avoid' ? 80 : (CROWD === 'love' ? 20 : 40);
+  // 动态调整保持均衡（成对系数，比例受控 0.72~1.55）：人数权重降 ↔ 熟悉度反向升
+  const famAdjust = CROWD === 'avoid' ? 1.15 : (CROWD === 'love' ? 0.9 : 1);
+  const famMult = Math.min((isExplicitPref ? 1 : (learning ? learning.familiarityMult : 1)) * famAdjust, 1.3);
+  const crowdMult = CROWD === 'avoid' ? 0.75 : (CROWD === 'love' ? 1.25 : 1);
+  const fullPenalty = CROWD === 'avoid' ? 60 : (CROWD === 'love' ? 30 : 50);
   const coldPenalty = CROWD === 'avoid' ? 0 : (CROWD === 'love' ? 15 : 10);
   const prefTag = CROWD === 'normal' ? '' : (isExplicitPref ? `偏好[${CROWD === 'avoid' ? '避人潮' : '爱热闹'}]` : `学习[${CROWD === 'avoid' ? '避人潮' : '爱热闹'}]`);
   // 睡觉图集合（new_worlds.sleep_ok=1）+ 安静图名字判定
@@ -913,14 +907,15 @@ async function buildGroupMap() {
 function computeEntryScore(ctx, entry) {
   // 统一评分：熟悉度 + 收藏夹权重 + 安静图场景 + 实例人数/类型 + 偏好/学习调节
   const { CROWD, famMult, crowdMult, fullPenalty, coldPenalty, prefTag, sleepWorlds, isQuietWorldName, learning } = ctx;
-  const { loc, worldName, instanceUsers, fillRatio, status, groupName, groupWeight, isContact, familiarity } = entry;
+  const { loc, worldName, worldTags, instanceUsers, fillRatio, status, groupName, groupWeight, isContact, familiarity } = entry;
   let score = 0;
   const reasons = [];
   if (isContact) { score -= 40; reasons.push('活动联系人-40'); }
   else {
-    const famScore = famMult !== 1 ? Math.min(Math.round(familiarity.score * famMult), 100) : Math.min(familiarity.score, 100);
+    // 熟悉度（×1.5，上限 132）与地图属性（人数×1+黄金区30 等）同量级——均衡，互不碾压
+    const famScore = famMult !== 1 ? Math.min(Math.round(familiarity.score * famMult * 1.5), 132) : Math.min(familiarity.score * 1.5, 132);
     score += famScore;
-    reasons.push(`熟悉度${famScore}${famMult !== 1 ? `(学习加权×${famMult})` : ''}(30天${familiarity.recentMatchCount}次)`);
+    reasons.push(`熟悉度${famScore}${famMult !== 1 ? `(加权×${Math.round(famMult*10)/10})` : ''}(30天${familiarity.recentMatchCount}次)`);
     if (groupName) {
       const bonus = Math.min(groupWeight, 10);
       if (bonus !== 0) { score += bonus; reasons.push(`[${groupName}]+${bonus}`); }
@@ -939,16 +934,33 @@ function computeEntryScore(ctx, entry) {
     } else {
       // 热闹图：人多正向，黄金区最理想（人数权重/爆满/冷清受偏好调节）
       if (instanceUsers < 3 && instanceUsers > 0) { score -= 15; reasons.push(`人少${instanceUsers}人可能私聊-15`); }
-      if (fillRatio >= 0.3 && fillRatio <= 0.8) { score += 50; reasons.push(`黄金区${Math.round(fillRatio*100)}%+50`); }
-      else if (fillRatio > 0.9) { score -= fullPenalty; reasons.push(`${prefTag}爆满-${fullPenalty}`); }
+      // 个性化黄金区：学习到人数舒适区时按绝对人数判断，否则用固定填充率 30-80%
+      const comfy = learning && learning.preferredCrowdRange;
+      let inComfort = false;
+      if (comfy) {
+        const m = comfy.match(/^(\d+)-(\d+)\+?人?$/);
+        if (m) {
+          const lo = parseInt(m[1], 10), hi = m[2] === '' ? Infinity : parseInt(m[2], 10);
+          inComfort = instanceUsers >= lo && instanceUsers <= hi;
+        }
+      }
+      if (comfy && inComfort) { score += 30; reasons.push(`舒适区${comfy}+30`); }
+      else if (comfy) { score -= 10; reasons.push(`舒适区${comfy}外-10`); }
+      else if (fillRatio >= 0.3 && fillRatio <= 0.8) { score += 30; reasons.push(`黄金区${Math.round(fillRatio*100)}%+30`); }
+      if (fillRatio > 0.9) { score -= fullPenalty; reasons.push(`${prefTag}爆满-${fullPenalty}`); }
       else if (fillRatio < 0.1) { score -= coldPenalty; reasons.push(`${prefTag}冷清-${coldPenalty}`); }
-      score += instanceUsers * crowdMult; reasons.push(`人数${instanceUsers}${CROWD === 'normal' ? '' : `×${crowdMult}`}`);
+      score += Math.round(instanceUsers * crowdMult); reasons.push(`人数${instanceUsers}${CROWD === 'normal' ? '' : `×${crowdMult}`}`);
     }
   }
-  if (loc.type === 'public') { score += 20; reasons.push('public+20'); }
-  else if (loc.type === 'friends' || loc.type === 'hidden') { score += 10; reasons.push(loc.type === 'hidden' ? 'friend++10' : 'friends+10'); }
-  else if (loc.type === 'group') { score += 5; reasons.push('group+5'); }
-  if (status === 'active') { score += 10; reasons.push('active+10'); }
+  // 类型偏好：学习到的 author_tag 命中 → 加分（安静图类型由 quietBias 单独处理）
+  if (learning && learning.worldType) {
+    const tagHit = Array.isArray(worldTags) && worldTags.includes('author_tag_' + learning.worldType);
+    if (tagHit) { score += 15; reasons.push(`类型[${learning.worldType}]+15`); }
+  }
+  if (loc.type === 'public') { score += 10; reasons.push('public+10'); }
+  else if (loc.type === 'friends' || loc.type === 'hidden') { score += 5; reasons.push(loc.type === 'hidden' ? 'friend++5' : 'friends+5'); }
+  else if (loc.type === 'group') { score += 3; reasons.push('group+3'); }
+  if (status === 'active') { score += 5; reasons.push('active+5'); }
   return { score: Math.round(score), reasons, isQuietWorld, isSleepWorld };
 }
 
@@ -1125,25 +1137,27 @@ async function handleGetFavoriteFriendsLocations({ groupName, favoriteGroupId, s
   const ctx = buildScoreContext();
   const { familiarityScore } = await buildFamiliarityScorer();
   const groupMap = await buildGroupMap();
-  //    位置解析 + 世界名缓存；实例详情批量查（限流）
   const worldCache = new Map();
   const instanceInfo = new Map();
-
+  //    位置解析 + 世界名缓存；实例详情批量查（限流）
   async function getWorldNameSafe(worldId) {
     if (worldCache.has(worldId)) return worldCache.get(worldId);
     let name = worldId;
+    let tags = [];
     const cached = storage.getWorldName(worldId);
     if (cached && cached.name) {
       name = cached.name;
+      tags = Array.isArray(cached.tags) ? cached.tags : (typeof cached.tags === 'string' && cached.tags ? JSON.parse(cached.tags) : []);
     } else {
       const r = await rateLimiter.execute(() => api._request('GET', `/worlds/${worldId}`));
       if (r.status === 200 && r.data && r.data.name) {
         name = r.data.name;
-        try { storage.upsertWorld({ worldId, name, authorId: r.data.authorId || '', authorName: r.data.authorName || '' }); } catch (e) {}
+        tags = Array.isArray(r.data.tags) ? r.data.tags.filter(t => t.startsWith('author_tag_')) : [];
+        try { storage.upsertWorld({ worldId, name, authorId: r.data.authorId || '', authorName: r.data.authorName || '', tags: JSON.stringify(tags) }); } catch (e) {}
       }
     }
-    worldCache.set(worldId, name);
-    return name;
+    worldCache.set(worldId, { name, tags });
+    return { name, tags };
   }
 
   const detailed = [];
@@ -1159,13 +1173,16 @@ async function handleGetFavoriteFriendsLocations({ groupName, favoriteGroupId, s
     // traveling 也跳过（不在具体世界）
     if (loc.type === 'traveling') continue;
 
-    const worldName = await getWorldNameSafe(loc.worldId);
+    const wInfo = await getWorldNameSafe(loc.worldId);
+    const worldName = wInfo.name;
+    const worldTags = wInfo.tags;
     const entry = {
       userId: m.userId,
       displayName: m.displayName,
       location: m.location,
       worldId: loc.worldId,
       worldName,
+      worldTags,
       instanceType: loc.type,
       instanceId: loc.instanceId || '',
       region: loc.region || '',
@@ -1214,7 +1231,7 @@ async function handleGetFavoriteFriendsLocations({ groupName, favoriteGroupId, s
     }
     const fam = await familiarityScore(m.userId);
     const scored = computeEntryScore(ctx, {
-      loc, worldName: entry.worldName, instanceUsers: entry.instanceUsers,
+      loc, worldName: entry.worldName, worldTags: entry.worldTags, instanceUsers: entry.instanceUsers,
       fillRatio: entry.fillRatio, status: m.status,
       groupName, groupWeight, isContact, familiarity: fam,
     });
@@ -1308,32 +1325,85 @@ function analyzeJoinLearning() {
   const MIN_SAMPLES = 5;
   const rows = storage._query('SELECT * FROM join_choices ORDER BY id DESC LIMIT 20');
   if (rows.length < MIN_SAMPLES) {
-    return { enabled: false, samples: rows.length, minSamples: MIN_SAMPLES, crowd: null, familiarityMult: 1, quietBias: false };
+    return { enabled: false, samples: rows.length, minSamples: MIN_SAMPLES, crowd: null, familiarityMult: 1, quietBias: false, preferredCrowdRange: null, worldType: null };
   }
   const avg = (arr) => (arr.length ? arr.reduce((s, v) => s + v, 0) / arr.length : 0);
   const avgChosenUsers = avg(rows.map(r => r.instance_users));
   const avgListUsers = avg(rows.map(r => r.list_avg_users));
   const avgFam = avg(rows.map(r => r.familiarity_score));
   const quietRatio = rows.filter(r => r.is_quiet_world).length / rows.length;
-  // 人数倾向：选择平均人数 vs 当时列表平均人数（<60% 避人潮，>130% 爱热闹）
+
+  // ── 维度1 重复选同一人：同一 userId 占比 ≥60% → 强熟人信号（不依赖熟悉度绝对值）──
+  const userCounts = {};
+  for (const r of rows) userCounts[r.user_id] = (userCounts[r.user_id] || 0) + 1;
+  const topUser = Object.entries(userCounts).sort((a, b) => b[1] - a[1])[0] || null;
+  const repeatRatio = topUser ? topUser[1] / rows.length : 0;
+  const repeatPrefer = repeatRatio >= 0.6;
+
+  // ── 维度2 熟悉度偏好：60% 以上选择熟悉度>=15 的好友（辅助，重复选择已覆盖）──
+  const famPrefer = !repeatPrefer && avgFam >= 15 && rows.filter(r => r.familiarity_score >= 15).length >= Math.ceil(rows.length * 0.6);
+
+  // ── 维度3 人数舒适区：选择人数分桶 ≥60% 集中 → 个性化黄金区 ──
+  const CROWD_BUCKETS = [
+    { label: '0-3人', min: 0, max: 3 },
+    { label: '4-8人', min: 4, max: 8 },
+    { label: '9-15人', min: 9, max: 15 },
+    { label: '16-30人', min: 16, max: 30 },
+    { label: '31-60人', min: 31, max: 60 },
+    { label: '61+人', min: 61, max: Infinity },
+  ];
+  let preferredCrowdRange = null;
+  const chosenUsersArr = rows.map(r => r.instance_users).filter(n => n > 0);
+  if (chosenUsersArr.length >= Math.ceil(rows.length * 0.6)) {
+    for (const b of CROWD_BUCKETS) {
+      const ratio = chosenUsersArr.filter(n => n >= b.min && n <= b.max).length / chosenUsersArr.length;
+      if (ratio >= 0.6) { preferredCrowdRange = b.label; break; }
+    }
+  }
+
+  // ── 维度4 人数倾向（舒适区细化为 avoid/love，舒适区未命中时用旧逻辑）──
   let crowd = null;
-  if (avgListUsers > 3 && avgChosenUsers < avgListUsers * 0.6) crowd = 'avoid';
-  else if (avgListUsers > 3 && avgChosenUsers > avgListUsers * 1.3) crowd = 'love';
-  // 熟悉度倾向：60% 以上选择熟悉度>=15 的好友 → 熟悉度加权
-  const famPrefer = avgFam >= 15 && rows.filter(r => r.familiarity_score >= 15).length >= Math.ceil(rows.length * 0.6);
-  // 安静图倾向：50% 以上选择安静图 → 安静图偏好
+  if (preferredCrowdRange) {
+    if (preferredCrowdRange === '0-3人' || preferredCrowdRange === '4-8人') crowd = 'avoid';
+    else if (preferredCrowdRange === '31-60人' || preferredCrowdRange === '61+人') crowd = 'love';
+  }
+  if (!crowd && avgListUsers > 3 && avgChosenUsers < avgListUsers * 0.6) crowd = 'avoid';
+  else if (!crowd && avgListUsers > 3 && avgChosenUsers > avgListUsers * 1.3) crowd = 'love';
+
+  // ── 维度5 类型偏好：某 author_tag 出现在 ≥60% 的选择行中 → 类型加分 ──
+  // 按选择行数占比判定（世界通常带多个标签，按标签次数占比过严会被稀释）
+  let worldType = null;
+  const tagCounts = {};
+  for (const r of rows) {
+    let tags = [];
+    try { tags = r.world_tags ? JSON.parse(r.world_tags) : []; } catch (e) {}
+    for (const t of tags) tagCounts[t] = (tagCounts[t] || 0) + 1;
+  }
+  const topTag = Object.entries(tagCounts).sort((a, b) => b[1] - a[1])[0] || null;
+  if (topTag && topTag[1] / rows.length >= 0.6) {
+    worldType = topTag[0].replace('author_tag_', '');
+  }
+
+  // ── 安静图倾向：50% 以上选择安静图（并入类型体系，保留独立信号）──
   const quietBias = quietRatio >= 0.5;
+
   const learning = {
     enabled: true,
     samples: rows.length,
     crowd,
-    familiarityMult: famPrefer ? 1.2 : 1,
+    // 重复选同一人 → 1.3（最强信号）；熟悉度偏好 → 1.2；否则 1
+    familiarityMult: repeatPrefer ? 1.3 : (famPrefer ? 1.2 : 1),
     quietBias,
+    preferredCrowdRange,
+    worldType,
     stats: {
       avgChosenUsers: Math.round(avgChosenUsers * 10) / 10,
       avgListUsers: Math.round(avgListUsers * 10) / 10,
       avgFamiliarity: Math.round(avgFam * 10) / 10,
       quietRatio: Math.round(quietRatio * 100) / 100,
+      repeatRatio: Math.round(repeatRatio * 100) / 100,
+      repeatUser: repeatPrefer ? (topUser ? topUser[0].slice(0, 12) : null) : null,
+      topTag: worldType ? 'author_tag_' + worldType : null,
     },
     updatedAt: new Date().toISOString(),
   };
@@ -1355,8 +1425,8 @@ async function handleRecordJoinChoice({ userId, displayName } = {}) {
   const rank = top.indexOf(hit) + 1;
   const baseline = lastRecommendSnapshot.baseline;
   storage._run(
-    `INSERT INTO join_choices (user_id, display_name, world_id, world_name, instance_type, instance_users, instance_capacity, fill_ratio, familiarity_score, is_quiet_world, recommend_score, rank_in_list, list_count, list_avg_users, list_avg_fill, list_quiet_ratio)
-     VALUES ($userId, $displayName, $worldId, $worldName, $instanceType, $instanceUsers, $instanceCapacity, $fillRatio, $familiarityScore, $isQuietWorld, $recommendScore, $rank, $listCount, $listAvgUsers, $listAvgFill, $listQuietRatio)`,
+    `INSERT INTO join_choices (user_id, display_name, world_id, world_name, instance_type, instance_users, instance_capacity, fill_ratio, familiarity_score, is_quiet_world, recommend_score, rank_in_list, list_count, list_avg_users, list_avg_fill, list_quiet_ratio, world_tags)
+     VALUES ($userId, $displayName, $worldId, $worldName, $instanceType, $instanceUsers, $instanceCapacity, $fillRatio, $familiarityScore, $isQuietWorld, $recommendScore, $rank, $listCount, $listAvgUsers, $listAvgFill, $listQuietRatio, $worldTags)`,
     {
       $userId: hit.userId, $displayName: hit.displayName, $worldId: hit.worldId || '',
       $worldName: hit.worldName || '', $instanceType: hit.instanceType || '',
@@ -1365,6 +1435,7 @@ async function handleRecordJoinChoice({ userId, displayName } = {}) {
       $isQuietWorld: hit.isQuietWorld ? 1 : 0, $recommendScore: hit.recommendScore || 0,
       $rank: rank, $listCount: baseline.list_count, $listAvgUsers: baseline.list_avg_users,
       $listAvgFill: baseline.list_avg_fill, $listQuietRatio: baseline.list_quiet_ratio,
+      $worldTags: Array.isArray(hit.worldTags) ? JSON.stringify(hit.worldTags) : '',
     },
   );
   const learning = analyzeJoinLearning();
@@ -1412,21 +1483,27 @@ async function handleRecommendJoin({ limit = 10, minScore = 0 } = {}) {
     if (!loc || loc.type === 'private' || loc.type === 'traveling' ||
         f.location === 'private' || f.location === 'offline' || f.location === 'traveling') continue;
 
-    // 世界名
+    // 世界名 + 标签（类型偏好学习用）
     let worldName = f.worldId || loc.worldId || '';
+    let worldTags = [];
     if (loc.worldId) {
-      if (worldCache.has(loc.worldId)) worldName = worldCache.get(loc.worldId);
-      else {
+      if (worldCache.has(loc.worldId)) {
+        const c = worldCache.get(loc.worldId);
+        worldName = c.name; worldTags = c.tags;
+      } else {
         const cached = storage.getWorldName(loc.worldId);
-        if (cached && cached.name) worldName = cached.name;
-        else {
+        if (cached && cached.name) {
+          worldName = cached.name;
+          worldTags = Array.isArray(cached.tags) ? cached.tags : (typeof cached.tags === 'string' && cached.tags ? JSON.parse(cached.tags) : []);
+        } else {
           const r = await rateLimiter.execute(() => api._request('GET', `/worlds/${loc.worldId}`));
           if (r.status === 200 && r.data && r.data.name) {
             worldName = r.data.name;
-            try { storage.upsertWorld({ worldId: loc.worldId, name: r.data.name, authorId: r.data.authorId || '', authorName: r.data.authorName || '' }); } catch (e) {}
+            worldTags = Array.isArray(r.data.tags) ? r.data.tags.filter(t => t.startsWith('author_tag_')) : [];
+            try { storage.upsertWorld({ worldId: loc.worldId, name: r.data.name, authorId: r.data.authorId || '', authorName: r.data.authorName || '', tags: JSON.stringify(worldTags) }); } catch (e) {}
           }
         }
-        worldCache.set(loc.worldId, worldName);
+        worldCache.set(loc.worldId, { name: worldName, tags: worldTags });
       }
     }
 
@@ -1461,7 +1538,7 @@ async function handleRecommendJoin({ limit = 10, minScore = 0 } = {}) {
 
     // 综合评分（共享评分系统：熟悉度 + 收藏夹权重 + 安静图场景 + 实例 + 偏好/学习）
     const scored = computeEntryScore(ctx, {
-      loc, worldName, instanceUsers, fillRatio, status: f.status,
+      loc, worldName, worldTags, instanceUsers, fillRatio, status: f.status,
       groupName, groupWeight, isContact, familiarity: fam,
     });
     const { score, reasons, isQuietWorld } = scored;
@@ -1471,6 +1548,7 @@ async function handleRecommendJoin({ limit = 10, minScore = 0 } = {}) {
       displayName: f.displayName,
       worldId: loc.worldId,
       worldName,
+      worldTags,
       instanceType: loc.type,
       instanceTypeDisplay: loc.type === 'hidden' ? 'friend+' : loc.type,
       instanceUsers, instanceCapacity, fillRatio,
@@ -1497,35 +1575,6 @@ async function handleRecommendJoin({ limit = 10, minScore = 0 } = {}) {
     method: 'familiarity+group+scene+instance',
     preference: isExplicitPref ? { crowd: CROWD, label: joinPrefs.label || '' } : null,
     learning: (!isExplicitPref && learning) ? { crowd: learning.crowd, familiarityMult: learning.familiarityMult, quietBias: learning.quietBias, samples: learning.samples } : null,
-  };
-}
-
-async function handleGetOnlineFriends() {
-  const r = await api._request('GET', '/auth/user/friends?offline=false');
-  if (r.status !== 200) throw new Error(`API error: ${r.status}`);
-  const friends = Array.isArray(r.data) ? r.data : [];
-  const online = friends.filter(f => f.location && f.location !== 'offline');
-
-  const nicknames = storage.getNicknames({});
-  const nicknameMap = new Map();
-  for (const item of nicknames) {
-    if (item.userId) nicknameMap.set(item.userId, item.nickname);
-  }
-
-  return {
-    online: online.length,
-    total: friends.length,
-    friends: online.map(f => ({
-      userId: f.id,
-      displayName: f.displayName,
-      location: f.location || 'private',
-      status: f.status,
-      statusDescription: f.statusDescription,
-      platform: f.platform,
-      avatarImageUrl: f.currentAvatarThumbnailImageUrl,
-      nickname: nicknameMap.get(f.id) || null,
-      locationParsed: parseLocation(f.location || 'private'),
-    })),
   };
 }
 
@@ -1648,98 +1697,6 @@ async function handleSendFriendRequest({ userId, displayName }) {
   const r = await api.sendFriendRequest(target.id);
   if (r.status >= 400) throw new Error(`API error ${r.status}`);
   return { userId: target.id, displayName, method: 'displayName', ok: true };
-}
-
-async function handleCreateInstance({ worldId, type, region, instanceId, groupAccessType }) {
-  if (!worldId || !String(worldId).startsWith('wrld_')) {
-    throw new Error('worldId 必须是 wrld_ 开头（如 wrld_xxxx）');
-  }
-  const instType = type || 'hidden';
-  const body = {
-    worldId,
-    type: instType,
-    region: region || 'jp',
-  };
-  if (instanceId) body.instanceId = instanceId;
-  if (groupAccessType) body.groupAccessType = groupAccessType;
-  // 非 public 实例必须显式带 ownerId（=当前用户），否则 API 400 "Invalid owner ID"（2026-08-09 实测）
-  if (instType !== 'public') {
-    await api.ensureAuth();
-    const me = (api.currentUser && api.currentUser.id) || null;
-    if (!me) throw new Error('无法获取当前用户 ID，不能创建非公开实例');
-    body.ownerId = me;
-  }
-  const r = await api._request('POST', '/instances', body);
-  if (r.status >= 400) {
-    throw new Error(`创建实例失败 API ${r.status}: ${JSON.stringify(r.data).slice(0, 200)}`);
-  }
-  const d = r.data || {};
-  return {
-    success: true,
-    worldId: d.worldId || worldId,
-    type: d.type || body.type,
-    region: d.region || body.region,
-    instanceId: d.instanceId || d.id || null,
-    location: d.location || null,
-    shortName: d.shortName || null,
-    capacity: d.capacity || null,
-  };
-}
-
-async function handleInviteMyself({ location, worldId, instanceId, forceApi }) {
-  // 统一入口（与 open_world 同一套）：管道直发优先（游戏内静默弹加入菜单），
-  // 管道不可用/非 Windows 时静默回退 API 自我邀请（客户端收到通知接受后传送）
-  let loc = location;
-  if (loc && typeof loc === 'string') {
-    const idx = loc.indexOf(':');
-    if (idx <= 0) throw new Error('location 格式应为 worldId:instanceId（如 wrld_x:12345~hidden(usr_x)~region(jp)）');
-    if (!String(loc).startsWith('wrld_')) throw new Error('location 必须是 wrld_ 开头的完整实例串');
-  } else {
-    if (!worldId || !String(worldId).startsWith('wrld_')) throw new Error('worldId 必须是 wrld_ 开头');
-    if (!instanceId) throw new Error('instanceId 不能为空（可用 create_instance 返回的 location）');
-    loc = `${worldId}:${instanceId}`;
-  }
-  const res = await openInstance({ location: loc, api, forceApi: !!forceApi });
-  if (!res.success) throw new Error(res.error || '邀请自己失败');
-  const wId = loc.slice(0, loc.indexOf(':'));
-  const iId = loc.slice(loc.indexOf(':') + 1);
-  return {
-    success: true,
-    method: res.method,
-    worldId: wId,
-    instanceId: iId,
-    notificationId: res.notificationId || null,
-    notificationType: null,
-    detail: res.detail || null,
-  };
-}
-
-async function handleOpenWorld({ worldId, location, type, region, shortName, forceApi }) {
-  // 1) 定位目标实例：直接给 location 就用它；只给 worldId 就先建实例（复用 handleCreateInstance）
-  let loc = location;
-  let sn = shortName || null;
-  if (!loc || typeof loc !== 'string') {
-    if (!worldId || !String(worldId).startsWith('wrld_')) {
-      throw new Error('需要 worldId（wrld_ 开头，自动建实例后打开）或 location（完整实例串直接打开）');
-    }
-    const inst = await handleCreateInstance({ worldId, type, region });
-    if (!inst.location) throw new Error('创建实例成功但未返回 location，无法打开');
-    loc = inst.location;
-    sn = sn || inst.shortName || null;
-  } else if (!String(loc).startsWith('wrld_')) {
-    throw new Error('location 必须是 wrld_ 开头的完整实例串（如 wrld_x:12345~hidden(usr_x)~region(jp)）');
-  }
-  // 2) 统一入口：管道直发（静默弹窗）→ 探测失败静默回退 API 自我邀请
-  const res = await openInstance({ location: loc, shortName: sn, api, forceApi: !!forceApi });
-  if (!res.success) throw new Error(res.error || '打开实例失败');
-  return {
-    success: true,
-    method: res.method,
-    location: loc,
-    shortName: sn,
-    notificationId: res.notificationId || null,
-    detail: res.detail || null,
-  };
 }
 
 async function handleRemoveFriend({ userId, displayName, confirm }) {
@@ -2038,7 +1995,7 @@ async function handleScanNewWorlds({ days = 7, dryRun = false }) {
   const selfUserId = serverState.authUser?.id;
   if (!selfUserId) throw new Error('Not authenticated');
 
-  const { fresh } = await fetchFreshWorlds(api, rateLimiter, { days, maxFetch: 200 });
+  const { fresh, candidates } = await fetchFreshWorlds(api, rateLimiter, { days, maxFetch: 200 });
 
   const visitedRows = storage._query(
     `SELECT DISTINCT world_id FROM events
@@ -2062,15 +2019,17 @@ async function handleScanNewWorlds({ days = 7, dryRun = false }) {
 
   if (!dryRun) {
     const upsert = storage.db.prepare(
-      `INSERT INTO new_worlds (world_id, world_name, author_name, created_at, first_seen_at, favorites, occupants, popularity, visited, visited_at)
-       VALUES (@world_id, @world_name, @author_name, @created_at, @first_seen_at, @favorites, @occupants, @popularity, @visited, @visited_at)
+      `INSERT INTO new_worlds (world_id, world_name, author_name, created_at, first_seen_at, favorites, occupants, popularity, visited, visited_at, tags, description)
+       VALUES (@world_id, @world_name, @author_name, @created_at, @first_seen_at, @favorites, @occupants, @popularity, @visited, @visited_at, @tags, @description)
        ON CONFLICT(world_id) DO UPDATE SET
          world_name = excluded.world_name,
          favorites = excluded.favorites,
          occupants = excluded.occupants,
          popularity = excluded.popularity,
          visited = excluded.visited,
-         visited_at = excluded.visited_at`
+         visited_at = excluded.visited_at,
+         tags = excluded.tags,
+         description = excluded.description`
     );
     const markVisited = storage.db.prepare(
       `UPDATE new_worlds SET visited = 1, visited_at = @visited_at
@@ -2090,6 +2049,8 @@ async function handleScanNewWorlds({ days = 7, dryRun = false }) {
           popularity: w.popularity || 0,
           visited: visited.has(w.id) ? 1 : 0,
           visited_at: visited.has(w.id) ? now : null,
+          tags: Array.isArray(w.tags) ? JSON.stringify(w.tags) : '',
+          description: w.description || '',
         });
         written++;
       }
@@ -2840,18 +2801,6 @@ async function handleRpc(rpc, session, res) {
             }));
             if (r.status >= 400) throw new Error(`API error ${r.status}`);
             result = { success: true, userId: args.userId, requestSent: true };
-            break;
-          }
-          case 'create_instance': {
-            result = await rateLimiter.execute(() => handleCreateInstance(args));
-            break;
-          }
-          case 'invite_myself': {
-            result = await rateLimiter.execute(() => handleInviteMyself(args));
-            break;
-          }
-          case 'open_world': {
-            result = await rateLimiter.execute(() => handleOpenWorld(args));
             break;
           }
           case 'send_friend_request': {

--- a/start-monitor.js
+++ b/start-monitor.js
@@ -1498,6 +1498,8 @@ async function handleGetJoinLearning() {
     // 旧缓存可能缺 preferredCrowdRange/worldType 字段——缺则重新分析
     const cached = raw ? JSON.parse(raw) : null;
     const learning = (cached && 'preferredCrowdRange' in cached && 'worldType' in cached) ? cached : analyzeJoinLearning();
+    const count = storage._query('SELECT COUNT(*) AS c FROM join_choices')[0].c;
+    return { choicesCount: count, learning };
   } catch (e) {
     return { error: `读取失败: ${e.message}` };
   }


### PR DESCRIPTION
## 需求来源

PR #6（推荐工具集）合并后的实际使用反馈：学习系统（`record_join_choice` / `get_join_learning`）只识别「避人潮 / 爱热闹 / 熟悉度绝对值」三个粗信号，存在三个盲区：

1. **用户 5 次都选同一个好友**（最典型的"我就爱跟这人玩"信号）——当前实现依赖「熟悉度 ≥15」的绝对门槛，新认识但特别合拍的朋友（熟悉度 3）**完全学不到**；
2. **用户有固定的人数舒适区**（如总选 4-8 人的小房）——当前只有"选人少/选人多"二分，没有个性化黄金区；
3. **用户有世界类型偏好**（如总选舞蹈房/日式图）——完全没有类型维度。

## 实现方式

**学习系统扩展为 5 维度**（`analyzeJoinLearning`）：

| 维度 | 判定 | 学到 |
|---|---|---|
| 重复选同一人 | 同一 userId 占比 ≥60% | familiarityMult **1.3**（最强信号，不依赖熟悉度绝对值） |
| 人数舒适区 | 选择人数分桶（0-3/4-8/9-15/16-30/31-60/61+）≥60% 集中 | `preferredCrowdRange` 个性化黄金区 |
| 类型偏好 | 某 `author_tag_*` 出现在 ≥60% 选择行 | `worldType` 类型加分 +15 |
| 安静图偏好 | 安静图占比 ≥50%（原有） | quietBias |
| 熟悉度偏好 | 平均 ≥15 且 60% 选熟人（原有，重复选择时降权） | familiarityMult 1.2 |

**数据链路**：`join_choices` 新增 `world_tags` 列（幂等迁移，PRAGMA 检查 + 条件 ALTER，兼容 SQLite <3.35）；`recommend_join` / `get_favorite_friends_locations` 输出补 `worldTags`（优先 world_cache 缓存，未命中走 API 并回写缓存）。

**权重应用**（`computeEntryScore`）：
- 舒适区命中 +30 / 区外 -10（替代固定 30-80% 黄金区，更个性化）
- 类型命中 +15（`类型[dance]+15`）

**评分基线均衡**（用户核心要求：熟悉度与地图属性均衡、互不碾压）：
- 熟悉度 ×1.5（上限 132）vs 地图属性（人数 ×1 + 黄金区 30）——同量级
- 动态调整成对系数、比例受控：avoid → 熟悉度 ×1.15 / 人数 ×0.75；love → 熟悉度 ×0.9 / 人数 ×1.25；familiarityMult 封顶 1.3
- 任何时刻熟悉度/地图比例在 0.72~1.55 之间，偏好可体现但不碾压

## 验证过程与结果

**静态 + 场景单测 18/18 全过**（hermes-verify 脚本，临时文件已清理）：

| 场景（5 条选择记录） | 期望 | 实测 |
|---|---|---|
| 5 次不同人 + 安静图 | quietBias + crowd=avoid + familiarityMult=1 | ✅ 3/3 |
| 5 次同一人（熟悉度 3） | **familiarityMult=1.3** + repeatRatio=1.0 | ✅ 2/2 |
| 5 次 4-8 人房 | preferredCrowdRange=**4-8人** + crowd=avoid | ✅ 2/2 |
| 5 次 dance 标签世界 | worldType=**dance** | ✅ 1/1 |

- `node --check` 三文件通过；无个人硬编码（分组示例已通用化）；
- **PR 分支代码真实起服务实测**：auth/ws 正常，`get_join_learning` 返回新字段（preferredCrowdRange/worldType）正确；
- init-db.sql 幂等迁移（CREATE IF NOT EXISTS + storage.js PRAGMA 条件 ALTER）对存量库实测补列成功。

**复现**：`record_join_choice` 积累 5 次选择后 `get_join_learning` 可见各维度学习结果，评分 reasons 会带 `舒适区[4-8人]+30` / `类型[dance]+15` / `(加权×1.3)` 标注。
