### PR TITLE
fix: search_users 无匹配时返回不相关用户 + API 无匹配回退本地好友模糊搜索

### DIFF
--- a/core/handlers/friends.js
+++ b/core/handlers/friends.js
@@ -76,15 +76,24 @@ export async function handleSearchUsers({ query, limit = 10 }) {
   const { api } = ctx;
   const r = await api._request('GET', `/users?search=${encodeURIComponent(query)}&n=${limit}`);
   if (r.status !== 200) throw new Error(`API error: ${r.status}`);
+
+  // VRChat API 的 /users?search= 是子串模糊匹配：当查询含 API 无法精确命中的部分
+  // （如中文/特殊字符）时，会退化匹配查询中的 ASCII 尾巴，返回完全不相关的用户
+  // （实测 query="不存在的名字xyz" 返回一堆名字含 "xyz" 的无关用户）。
+  // 这里做客户端二次过滤：displayName 必须包含完整查询串（不区分大小写）才算命中，
+  // 剔除 API 的退化匹配结果。正常模糊搜索语义不受影响（"abc" 仍命中 "Abc~" 等）。
+  const q = query.toLowerCase();
   return {
     query,
-    results: (Array.isArray(r.data) ? r.data : []).map(u => ({
-      userId: u.id,
-      displayName: u.displayName,
-      bio: (u.bio || '').slice(0, 100),
-      status: u.status,
-      isFriend: u.isFriend,
-    })),
+    results: (Array.isArray(r.data) ? r.data : [])
+      .filter(u => u.displayName && u.displayName.toLowerCase().includes(q))
+      .map(u => ({
+        userId: u.id,
+        displayName: u.displayName,
+        bio: (u.bio || '').slice(0, 100),
+        status: u.status,
+        isFriend: u.isFriend,
+      })),
   };
 }
 


### PR DESCRIPTION
## 需求来源

1. 用户反馈：`search_users` 搜索无匹配时，会错误返回不相关的非好友玩家（关联 issue #20）。
2. 用户细化需求：当精确搜索失败时，应**优先模糊搜索本地好友**是否含有相关字眼。

## 根因

VRChat API 的 `GET /users?search=` 是**子串模糊匹配**。当查询串含 API 无法命中的部分（中文/特殊字符）时，API 退化匹配查询中的 ASCII 尾巴——实测 `不存在的名字xyz` 返回一堆名字含 `xyz` 的无关用户（XYZ、×Xyz× 等，均非好友）。`handleSearchUsers` 直接透传 API 结果，未做二次过滤，也无本地好友回退。

## 实现方式（2 个提交）

1. **fix**：`handleSearchUsers`（`core/handlers/friends.js`）客户端二次过滤——displayName 必须包含完整查询串（不区分大小写）才算命中，剔除 API 退化匹配。与 `handleGetMutualFriends` 既有过滤模式一致。
2. **feat**：API 过滤后无结果时，自动回退**本地好友库模糊搜索**（`storage.searchFriends`：display_name/备注 LIKE 匹配）——覆盖 API 中文搜索差/好友只有备注名的场景。结果标记 `source: 'local_friends'` 并附 `trustLevel`/`online`，`isFriend` 恒为 true。**不新增 API 调用**（复用本地库），limit 收敛到 1-50。

**不改变工具签名与返回结构**（向后兼容，无 DB 变更、无新依赖、无个人环境硬编码）。

## 验证过程与结果

本地实测（MCP `tools/call`，服务重启加载新代码后）：

| 查询 | 行为 |
|------|------|
| `HaruHaraZ`（API 命中） | API 结果，无回退 ✓ |
| `九璃`（中文，API 可命中） | API 结果，好友 `-九璃-` 排第一 ✓ |
| `zz` / `abc`（正常模糊搜索） | API 正常返回 ✓ |
| `不存在的名字xyz`（无匹配） | `fallback: local_friends`，0 结果 ✓ |
| `IZI利兹`（API 搜不到，好友 `LIZI利兹1295`） | **回退本地好友命中**，`source: local_friends` ✓ |
| `viathan_莉`（API 搜不到，好友 `Leviathan_莉维坦`） | **回退本地好友命中** ✓ |

- 分支基于当前 main（d47f8a7）新建，2 个提交，仅改 `core/handlers/friends.js` + 文档同步（README + skill 工具表）
- 限流：API 路径仍走 `rateLimiter.execute`，回退路径零 API 调用