### PR TITLE
feat: search_users API 无匹配时回退本地好友库模糊搜索

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ mcp_servers:
 |------|------|
 | `get_online_friends` | 当前在线好友列表（含昵称 nickname + 房型解析 locationParsed：worldId/instanceId/type/ownerId/region） |
 | `get_friend_info` | 好友详细信息 |
-| `search_users` | 按名字搜索用户 |
+| `search_users` | 按名字搜索用户（API 优先；API 无匹配时自动回退本地好友库模糊搜索 display_name/备注，结果带 `source: local_friends` 标记） |
 | `search_groups` | 按名字搜索群组（API 用 query 参数，不是 search） |
 | `search_worlds` | 按名字搜索世界（英文/日文走 API；中文自动加本地缓存兜底） |
 | `search_planet_worlds` | **PlanetVRC 地图检索**（2026-08-13 新增）：planetvrchat.net 日文世界目录关键词搜索 → 世界名/wrld_id/平台/分类/收藏数；适合 VRChat API 搜不到的日文/小众图。`limit` 最大 8（每个结果抓详情页补 wrld_id/人数/访问量） |

--- a/core/handlers/friends.js
+++ b/core/handlers/friends.js
@@ -73,8 +73,9 @@ export async function handleGetFriendInfo({ userId, displayName }) {
 }
 
 export async function handleSearchUsers({ query, limit = 10 }) {
-  const { api } = ctx;
-  const r = await api._request('GET', `/users?search=${encodeURIComponent(query)}&n=${limit}`);
+  const { api, storage } = ctx;
+  const n = Math.max(1, Math.min(50, Number(limit) || 10));
+  const r = await api._request('GET', `/users?search=${encodeURIComponent(query)}&n=${n}`);
   if (r.status !== 200) throw new Error(`API error: ${r.status}`);
 
   // VRChat API 的 /users?search= 是子串模糊匹配：当查询含 API 无法精确命中的部分
@@ -83,18 +84,37 @@ export async function handleSearchUsers({ query, limit = 10 }) {
   // 这里做客户端二次过滤：displayName 必须包含完整查询串（不区分大小写）才算命中，
   // 剔除 API 的退化匹配结果。正常模糊搜索语义不受影响（"abc" 仍命中 "Abc~" 等）。
   const q = query.toLowerCase();
-  return {
-    query,
-    results: (Array.isArray(r.data) ? r.data : [])
-      .filter(u => u.displayName && u.displayName.toLowerCase().includes(q))
-      .map(u => ({
-        userId: u.id,
-        displayName: u.displayName,
-        bio: (u.bio || '').slice(0, 100),
-        status: u.status,
-        isFriend: u.isFriend,
-      })),
-  };
+  const apiResults = (Array.isArray(r.data) ? r.data : [])
+    .filter(u => u.displayName && u.displayName.toLowerCase().includes(q))
+    .map(u => ({
+      userId: u.id,
+      displayName: u.displayName,
+      bio: (u.bio || '').slice(0, 100),
+      status: u.status,
+      isFriend: u.isFriend,
+    }));
+
+  // API 无匹配时回退：优先在本地好友库模糊搜索（display_name / memo 含查询字眼）。
+  // 覆盖 API 中文搜索差 / 昵称备注场景——好友可能只有中文备注名或 API 搜不到。
+  // 仅返回本地好友，不额外调用 API，命中后标记 source 便于区分。
+  if (apiResults.length === 0) {
+    const localHits = storage.searchFriends(query)
+      .filter(f => f.display_name || f.memo)
+      .slice(0, n)
+      .map(f => ({
+        userId: f.user_id,
+        displayName: f.display_name || f.memo,
+        bio: f.memo || '',
+        status: f.status || '',
+        isFriend: true,
+        source: 'local_friends',
+        trustLevel: f.trust_level || null,
+        online: !!f.is_online,
+      }));
+    return { query, results: localHits, fallback: 'local_friends' };
+  }
+
+  return { query, results: apiResults };
 }
 
 export async function handleGetMutualFriends({ userId, displayName, limit = 100 }) {

--- a/skills/vrc-monitor-agent/SKILL.md
+++ b/skills/vrc-monitor-agent/SKILL.md
@@ -23,7 +23,7 @@ metadata:
 |------|------|
 | `get_online_friends` | 当前在线好友列表（含昵称 nickname + 房型解析 locationParsed：worldId/instanceId/type/ownerId/region） |
 | `get_friend_info` | 好友详细信息 |
-| `search_users` | 按名字搜索用户 |
+| `search_users` | 按名字搜索用户（API 优先；API 无匹配时自动回退本地好友库模糊搜索 display_name/备注，结果带 `source: local_friends` 标记） |
 | `search_groups` | 按名字搜索群组（API 用 query 参数，不是 search） |
 | `search_worlds` | 按名字搜索世界（英文/日文走 API；中文自动加本地缓存兜底） |
 | `search_planet_worlds` | **PlanetVRC 地图检索**（planetvrchat.net 日文世界目录）：关键词搜索 → 世界名/wrld_id/平台/分类/收藏数；适合 VRChat API 搜不到的日文/小众图。limit 最大 8（每个结果抓详情页补 wrld_id，约 1-2s/个） |


### PR DESCRIPTION
## 需求来源

用户细化需求：`search_users` 精确搜索失败时，应**优先模糊搜索本地好友**是否含有相关字眼（承接已合并的 #22 fix）。

## 实现方式

`handleSearchUsers`（`core/handlers/friends.js`）在 API 过滤后**无结果**时，自动回退**本地好友库模糊搜索**：

- 复用 `storage.searchFriends`（friends 表 `display_name`/`memo` LIKE 匹配，零新增 API 调用）
- 覆盖场景：API 中文搜索差、好友只有本地备注名/昵称、API 完全搜不到的小众名
- 回退结果标记 `source: 'local_friends'`，附 `trustLevel`/`online` 字段，`isFriend` 恒为 `true`，返回结构含 `fallback: 'local_friends'` 便于调用方区分
- limit 收敛 1-50；仅当 API 结果为空时启用，API 命中时行为与之前完全一致

**不改变工具签名**，API 命中路径的返回结构不变（向后兼容，无 DB 变更、无新依赖、无个人环境硬编码）。

## 验证过程与结果

本地实测（MCP `tools/call`，服务重启加载新代码后）：

| 查询 | 行为 |
|------|------|
| `HaruHaraZ`（API 命中） | API 结果，无回退 ✓ |
| `九璃`（中文，API 可命中） | API 结果，好友 `-九璃-` 排第一 ✓ |
| `zz`（正常模糊搜索） | API 正常返回 ✓ |
| `不存在的名字xyz`（无匹配，本地也无） | `fallback: local_friends`，0 结果 ✓ |
| `IZI利兹`（API 搜不到，好友 `LIZI利兹1295`） | **回退本地命中** `source: local_friends` ✓ |
| `viathan_莉`（API 搜不到，好友 `Leviathan_莉维坦`） | **回退本地命中** ✓ |

- 分支基于当前 main（2dd0836，含已合并的 #22 fix）新建，1 个提交
- 文档同步：README「好友查询」工具表 + `skills/vrc-monitor-agent/SKILL.md` 工具表