### PR TITLE
feat(world): 开图闭环用户反馈机制 — rate_world / mark_world_visited / user_rating 评分加权 / excludeTheme（关联 #19）

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 > 技术栈：Node.js + SQLite + WebSocket + MCP + Hermes 插件
 
-通过 WebSocket 实时采集好友上下线、世界切换、Avatar/状态变化并入库。以 58 个 MCP 工具向 AI Agent 暴露全部能力——不只查询，还涵盖社交互动（戳戳/邀请/好友请求）、媒体管理（emoji/相册/图库）、群组操作、推荐系统等。附带 Hermes 插件实现进程托管（自动拉起 + 崩溃自愈）。
+通过 WebSocket 实时采集好友上下线、世界切换、Avatar/状态变化并入库。以 60 个 MCP 工具向 AI Agent 暴露全部能力——不只查询，还涵盖社交互动（戳戳/邀请/好友请求）、媒体管理（emoji/相册/图库）、群组操作、推荐系统等。附带 Hermes 插件实现进程托管（自动拉起 + 崩溃自愈）。
 
 > 🤖 **AI Agent 优先项目**：程序只面向 AI Agent 使用与开发，人类不直接编码。详见下方「[项目定位](#-ai-agent-优先项目定位)」与 [DEVELOPMENT.md](./DEVELOPMENT.md)。
 
@@ -35,7 +35,7 @@ QQ 群：**851865556** — 欢迎加入，交流使用问题、功能建议与�
 
 ## ✨ 功能
 
-按能力域划分的功能概览，全部 58 个 MCP 工具与详细参数见下方「🔌 MCP 工具」。
+按能力域划分的功能概览，全部 60 个 MCP 工具与详细参数见下方「🔌 MCP 工具」。
 
 ### 📡 实时监控与认证自愈
 
@@ -99,7 +99,7 @@ curl http://127.0.0.1:8799/health
 
 | Skill | 内容 | 适用场景 |
 |-------|------|----------|
-| `skills/vrc-monitor-agent/` | 58 个 MCP 工具清单、5 大查询工作流（在线/同屏/时间线/上线规律/昵称）、常见陷阱、健康检查 | 日常好友查询与社交操作 |
+| `skills/vrc-monitor-agent/` | 60 个 MCP 工具清单、5 大查询工作流（在线/同屏/时间线/上线规律/昵称）、常见陷阱、健康检查 | 日常好友查询与社交操作 |
 | `skills/vrc-monitor-companion-query/` | 「谁和我/和 XX 一起玩过」同屏交叉查询的正确姿势（为何不委派子 agent） | 同屏/玩伴查询 |
 
 **安装方式**（以 Hermes 为例，其他 Agent 框架同理）——把 skill 目录复制到你的 skills 目录：
@@ -165,7 +165,7 @@ cp desktop/plugin.js "$HERMES_HOME/desktop-plugins/vrc-monitor/"
 - **双路检测**：状态文件 pid 存活 **或** 端口探测成功，均可识别为运行中（防状态文件丢失误判）
 - **日志**：`$HERMES_HOME/workspace/vrc-monitor/monitor.log`
 
-## 🔌 MCP 工具（58 个）
+## 🔌 MCP 工具（60 个）
 
 服务监听 `http://127.0.0.1:8799/mcp`，通过 HTTP SSE 提供 MCP 协议。Hermes 用户可在 `$HERMES_HOME/config.yaml`（Windows 为 `%LOCALAPPDATA%\hermes\config.yaml`）配置：
 
@@ -218,7 +218,9 @@ mcp_servers:
 | 工具 | 说明 |
 |------|------|
 | `scan_new_worlds` | 扫描最近 N 天创建的新世界（默认 7，1-30），过滤测试/垃圾图后写入 `new_worlds` 表，按热度返回推荐 TOP10；`dryRun: true` 只看不写。认证复用主服务登录态 |
-| `get_new_worlds` | 只读查询已跟踪的新世界：`onlyUnvisited` 只看未逛过、`sortBy`（favorites/occupants/popularity/created_at）、`limit`（默认 10，最大 50） |
+| `get_new_worlds` | 只读查询已跟踪的新世界：`onlyUnvisited` 只看未逛过、`sortBy`（favorites/occupants/popularity/created_at）、`excludeTheme` 排除主题（按 author_tag_* 逗号分隔）、`limit`（默认 10，最大 50） |
+| `rate_world` | 用户反馈：给世界打好评/烂图标记（rating: 1=好图加权 / -1=烂图降权 / 0=清除），影响推荐排序（worldScore 加权） |
+| `mark_world_visited` | 显式确认逛过某世界（事件驱动 visited 会漏记，开图闭环手动确认用） |
 
 ### 关注名单
 
@@ -293,12 +295,12 @@ mcp_servers:
 │   ├── vrchat-launch.js        # 打开实例统一入口（管道探测 + API 回退）
 │   ├── new-worlds.js           # 新世界扫描核心逻辑
 │   ├── backup.js               # 数据库在线备份
-│   ├── mcp-definitions.js      # MCP 工具定义（58 个工具）
+│   ├── mcp-definitions.js      # MCP 工具定义（60 个工具）
 │   ├── server-context.js       # 共享上下文（ctx 对象 + log + parseLocation）
 │   ├── http-server.js          # HTTP 服务器 + SSE 端点
 │   ├── rpc-router.js           # RPC 分发（tools/call → handler）
 │   ├── otp-fetcher.js          # OTP 邮箱获取
-│   └── handlers/               # 58 个 MCP 工具的 handler
+│   └── handlers/               # 60 个 MCP 工具的 handler
 │       ├── recommend.js       #   推荐系统（好友收藏位置/推荐加入/偏好/学习）
 │       ├── friends.js         #   好友查询（在线/详情/搜索/共同好友/添加/删除）
 │       ├── instance.js        #   实例操作（创建/自我邀请/打开世界）

--- a/core/handlers/misc.js
+++ b/core/handlers/misc.js
@@ -134,37 +134,74 @@ export async function handleScanNewWorlds({ days = 7, dryRun = false }) {
   };
 }
 
-export function handleGetNewWorlds({ onlyUnvisited = false, limit = 10, sortBy = 'favorites' }) {
+export function handleGetNewWorlds({ onlyUnvisited = false, limit = 10, sortBy = 'favorites', excludeTheme = '' }) {
   const { storage } = ctx;
   if (!['favorites', 'occupants', 'popularity', 'created_at'].includes(sortBy)) sortBy = 'favorites';
   limit = Math.min(Math.max(parseInt(limit, 10) || 10, 1), 50);
+
+  // Issue #19 痛点 4：排除主题（按 author_tag_* 匹配，逗号分隔）
+  const excludedThemes = typeof excludeTheme === 'string' && excludeTheme.trim()
+    ? excludeTheme.split(',').map(s => s.trim().toLowerCase()).filter(Boolean)
+    : [];
 
   const total = storage._query(
     `SELECT COUNT(*) AS cnt FROM new_worlds${onlyUnvisited ? ' WHERE visited = 0' : ''}`
   )[0].cnt;
 
   const rows = storage._query(
-    `SELECT world_id, world_name, author_name, created_at, first_seen_at, favorites, occupants, popularity, visited, visited_at
+    `SELECT world_id, world_name, author_name, created_at, first_seen_at, favorites, occupants, popularity, visited, visited_at, tags, user_rating
      FROM new_worlds
      ${onlyUnvisited ? 'WHERE visited = 0' : ''}
      ORDER BY ${sortBy} DESC
      LIMIT ${limit}`
   );
 
-  const worlds = rows.map(r => ({
-    worldId: r.world_id,
-    worldName: r.world_name,
-    authorName: r.author_name,
-    created: r.created_at,
-    firstSeen: r.first_seen_at,
-    favorites: r.favorites,
-    occupants: r.occupants,
-    popularity: r.popularity,
-    visited: r.visited === 1,
-    visitedAt: r.visited_at,
-  }));
+  const worlds = rows
+    .map(r => {
+      let worldTags = [];
+      try { worldTags = JSON.parse(r.tags || '[]'); } catch (_) {}
+      const themeTags = worldTags.filter(t => t.startsWith('author_tag_')).map(t => t.replace('author_tag_', '').toLowerCase());
+      return {
+        worldId: r.world_id,
+        worldName: r.world_name,
+        authorName: r.author_name,
+        created: r.created_at,
+        firstSeen: r.first_seen_at,
+        favorites: r.favorites,
+        occupants: r.occupants,
+        popularity: r.popularity,
+        visited: r.visited === 1,
+        visitedAt: r.visited_at,
+        tags: themeTags,
+        userRating: r.user_rating || 0,
+        excluded: excludedThemes.some(t => themeTags.includes(t)),
+      };
+    })
+    .filter(w => !w.excluded);
 
   return { total, worlds };
+}
+
+/** 用户反馈：好图/烂图标记（Issue #19） */
+export function handleRateWorld({ worldId, rating = 0 }) {
+  const { storage } = ctx;
+  if (!worldId) throw new Error('worldId is required');
+  const r = parseInt(rating, 10);
+  if (r !== -1 && r !== 0 && r !== 1) {
+    throw new Error('rating must be -1 (junk), 0 (clear), or 1 (good)');
+  }
+  const result = storage.rateWorld({ worldId, rating: r });
+  log(`⭐ 用户反馈: ${worldId} → rating=${result.userRating}${result.worldName ? ` (${result.worldName})` : ''}`);
+  return result;
+}
+
+/** 显式确认逛过某世界（Issue #19 痛点 3） */
+export function handleMarkWorldVisited({ worldId }) {
+  const { storage } = ctx;
+  if (!worldId) throw new Error('worldId is required');
+  const result = storage.markWorldVisited({ worldId });
+  log(`✅ 手动标记 visited: ${worldId}${result.worldName ? ` (${result.worldName})` : ''}`);
+  return result;
 }
 
 export function handleGetWatchlist() {

--- a/core/handlers/misc.js
+++ b/core/handlers/misc.js
@@ -167,9 +167,10 @@ export function handleGetNewWorlds({ onlyUnvisited = false, limit = 10, sortBy =
   if (onlyUnvisited) where += 'WHERE visited = 0';
   if (excludedThemes.length > 0) {
     // 排除 = 不存在任何匹配主题的行（json_each 拆 JSON tags 数组匹配）
+    // 兜底：json_valid(tags) 为假（空串/脏数据）时按 '[]' 处理，避免 malformed JSON 崩溃
     const notExists = excludedThemes.map((_, i) =>
       `NOT EXISTS (
-        SELECT 1 FROM json_each(new_worlds.tags)
+        SELECT 1 FROM json_each(CASE WHEN json_valid(new_worlds.tags) THEN new_worlds.tags ELSE '[]' END)
         WHERE lower(value) = $th${i}
       )`
     ).join(' AND ');

--- a/core/handlers/misc.js
+++ b/core/handlers/misc.js
@@ -110,11 +110,15 @@ export async function handleScanNewWorlds({ days = 7, dryRun = false }) {
 
   // 注入 DB 用户反馈（user_rating）到候选对象——否则 worldScore 加权对 API 对象恒为 0（Review 修复 #1）
   // unvisited 来自 API 拉取对象（无 userRating 字段），按 worldId 批量查 new_worlds 的 user_rating
+  const ratingParams = {};
   const ratingRows = unvisited.length > 0
-    ? storage._query(
-        `SELECT world_id, user_rating FROM new_worlds WHERE world_id IN (${unvisited.map(() => '?').join(',')})`,
-        unvisited.map(w => w.id)
-      )
+    ? (() => {
+        unvisited.forEach((w, i) => { ratingParams[`w${i}`] = w.id; });
+        return storage._query(
+          `SELECT world_id, user_rating FROM new_worlds WHERE world_id IN (${unvisited.map((_, i) => `$w${i}`).join(',')})`,
+          ratingParams
+        );
+      })()
     : [];
   const ratingMap = new Map(ratingRows.map(r => [r.world_id, r.user_rating || 0]));
 

--- a/core/handlers/misc.js
+++ b/core/handlers/misc.js
@@ -108,7 +108,18 @@ export async function handleScanNewWorlds({ days = 7, dryRun = false }) {
     tx();
   }
 
+  // 注入 DB 用户反馈（user_rating）到候选对象——否则 worldScore 加权对 API 对象恒为 0（Review 修复 #1）
+  // unvisited 来自 API 拉取对象（无 userRating 字段），按 worldId 批量查 new_worlds 的 user_rating
+  const ratingRows = unvisited.length > 0
+    ? storage._query(
+        `SELECT world_id, user_rating FROM new_worlds WHERE world_id IN (${unvisited.map(() => '?').join(',')})`,
+        unvisited.map(w => w.id)
+      )
+    : [];
+  const ratingMap = new Map(ratingRows.map(r => [r.world_id, r.user_rating || 0]));
+
   const recommended = [...unvisited]
+    .map(w => ({ ...w, userRating: ratingMap.get(w.id) || 0 }))
     .sort((a, b) => worldScore(b) - worldScore(a))
     .slice(0, 10)
     .map(w => ({
@@ -120,6 +131,7 @@ export async function handleScanNewWorlds({ days = 7, dryRun = false }) {
       popularity: w.popularity || 0,
       author: w.authorName,
       tags: (w.tags || []).filter(t => t.startsWith('author_tag_')).map(t => t.replace('author_tag_', '')),
+      userRating: w.userRating,
     }));
 
   return {
@@ -139,21 +151,42 @@ export function handleGetNewWorlds({ onlyUnvisited = false, limit = 10, sortBy =
   if (!['favorites', 'occupants', 'popularity', 'created_at'].includes(sortBy)) sortBy = 'favorites';
   limit = Math.min(Math.max(parseInt(limit, 10) || 10, 1), 50);
 
-  // Issue #19 痛点 4：排除主题（按 author_tag_* 匹配，逗号分隔）
+  // Issue #19 痛点 4：排除主题（按 author_tag_* 匹配，逗号分隔）。SQL 层排除（Review 修复 #3），
+  // 避免 LIMIT 后 JS 过滤导致返回 < limit；total 也按排除语义统计。
   const excludedThemes = typeof excludeTheme === 'string' && excludeTheme.trim()
     ? excludeTheme.split(',').map(s => s.trim().toLowerCase()).filter(Boolean)
     : [];
 
+  // 构造排除条件：tags 列是 JSON 数组字符串（["author_tag_game",...]），用 json_each 拆行匹配主题
+  let where = '';
+  const whereParams = {};
+  if (onlyUnvisited) where += 'WHERE visited = 0';
+  if (excludedThemes.length > 0) {
+    // 排除 = 不存在任何匹配主题的行（json_each 拆 JSON tags 数组匹配）
+    const notExists = excludedThemes.map((_, i) =>
+      `NOT EXISTS (
+        SELECT 1 FROM json_each(new_worlds.tags)
+        WHERE lower(value) = $th${i}
+      )`
+    ).join(' AND ');
+    where += (where ? ' AND ' : 'WHERE ') + notExists;
+    excludedThemes.forEach((t, i) => { whereParams[`th${i}`] = `author_tag_${t}`; });
+  }
+
   const total = storage._query(
-    `SELECT COUNT(*) AS cnt FROM new_worlds${onlyUnvisited ? ' WHERE visited = 0' : ''}`
+    `SELECT COUNT(*) AS cnt FROM new_worlds ${where}`,
+    whereParams
   )[0].cnt;
 
+  // 超额取数兜底：排除后可能不足 limit，取 3 倍候选再 JS 精过滤（tags 解析）
+  const fetchLimit = Math.min(limit * 3, 100);
   const rows = storage._query(
     `SELECT world_id, world_name, author_name, created_at, first_seen_at, favorites, occupants, popularity, visited, visited_at, tags, user_rating
      FROM new_worlds
-     ${onlyUnvisited ? 'WHERE visited = 0' : ''}
+     ${where}
      ORDER BY ${sortBy} DESC
-     LIMIT ${limit}`
+     LIMIT ${fetchLimit}`,
+    whereParams
   );
 
   const worlds = rows
@@ -174,10 +207,9 @@ export function handleGetNewWorlds({ onlyUnvisited = false, limit = 10, sortBy =
         visitedAt: r.visited_at,
         tags: themeTags,
         userRating: r.user_rating || 0,
-        excluded: excludedThemes.some(t => themeTags.includes(t)),
       };
     })
-    .filter(w => !w.excluded);
+    .slice(0, limit);
 
   return { total, worlds };
 }

--- a/core/init-db.sql
+++ b/core/init-db.sql
@@ -113,7 +113,8 @@ CREATE TABLE IF NOT EXISTS new_worlds (
   visited_at TEXT,               -- 逛过的时间（若已逛）
   tags TEXT DEFAULT '',          -- 作者标签 JSON 数组（author_tag_*，主题分类用）
   description TEXT DEFAULT '',   -- 世界描述（主题关键词匹配用）
-  source TEXT DEFAULT 'new'      -- 来源: new=新发布-推荐 / hot=热门图追加
+  source TEXT DEFAULT 'new',     -- 来源: new=新发布-推荐 / hot=热门图追加
+  user_rating INTEGER DEFAULT 0  -- 用户反馈: -1=烂图(junk) / 0=无标记 / 1=好图（recommend 评分加权用）
 );
 CREATE INDEX IF NOT EXISTS idx_new_worlds_visited ON new_worlds(visited);
 

--- a/core/mcp-definitions.js
+++ b/core/mcp-definitions.js
@@ -379,7 +379,31 @@ export const CUSTOM_TOOLS = [
         onlyUnvisited: { type: 'boolean', default: false, description: 'Only return worlds the user has not visited' },
         limit: { type: 'number', default: 10, description: 'Max rows (1-50, default 10)' },
         sortBy: { type: 'string', enum: ['favorites', 'occupants', 'popularity', 'created_at'], default: 'favorites', description: 'Sort field (descending)' },
+        excludeTheme: { type: 'string', description: 'Comma-separated theme keywords to exclude (matched against author tags, e.g. "game,horror,dance")' },
       },
+    },
+  },
+  {
+    name: 'rate_world',
+    description: '[action] Rate a world as good/junk for recommendation feedback (Issue #19). rating=1 good (weighted up), -1 junk (weighted down/excluded), 0 clear.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        worldId: { type: 'string', description: 'VRChat world ID (wrld_...)' },
+        rating: { type: 'number', enum: [-1, 0, 1], description: '-1=junk, 0=clear, 1=good' },
+      },
+      required: ['worldId', 'rating'],
+    },
+  },
+  {
+    name: 'mark_world_visited',
+    description: '[action] Explicitly mark a world as visited (Issue #19: event-driven visited can miss). Useful to close the recommend-open-browse loop.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        worldId: { type: 'string', description: 'VRChat world ID (wrld_...)' },
+      },
+      required: ['worldId'],
     },
   },
   {

--- a/core/new-worlds.js
+++ b/core/new-worlds.js
@@ -33,12 +33,15 @@ export function isJunkWorld(w) {
 }
 
 /**
- * 热度评分：收藏数*2 + 在线人数*10 + 热度分
- * @param {object} w VRChat world 对象
+ * 热度评分：收藏数*2 + 在线人数*10 + 热度分 + 用户反馈加权（Issue #19）
+ * userRating: 1(好图) +50 加权；-1(烂图) -100 降权（推荐排序时实际会被甩到后面）
+ * @param {object} w VRChat world 对象（可含 userRating 字段）
  * @returns {number}
  */
 export function worldScore(w) {
-  return (w.favorites || 0) * 2 + (w.occupants || 0) * 10 + (w.popularity || 0);
+  const rating = (w.userRating !== undefined && w.userRating !== null) ? w.userRating : 0;
+  const ratingBias = rating === 1 ? 50 : (rating === -1 ? -100 : 0);
+  return (w.favorites || 0) * 2 + (w.occupants || 0) * 10 + (w.popularity || 0) + ratingBias;
 }
 
 /**

--- a/core/rpc-router.js
+++ b/core/rpc-router.js
@@ -79,6 +79,8 @@ import {
   handleGetServerStatus,
   handleScanNewWorlds,
   handleGetNewWorlds,
+  handleRateWorld,
+  handleMarkWorldVisited,
   handleGetWatchlist,
   handleAddToWatchlist,
   handleRemoveFromWatchlist,
@@ -256,6 +258,12 @@ export async function handleRpc(rpc, session, res) {
             break;
           case 'get_new_worlds':
             result = handleGetNewWorlds(args);
+            break;
+          case 'rate_world':
+            result = handleRateWorld(args);
+            break;
+          case 'mark_world_visited':
+            result = handleMarkWorldVisited(args);
             break;
           case 'get_watchlist':
             result = handleGetWatchlist();

--- a/core/storage.js
+++ b/core/storage.js
@@ -58,6 +58,8 @@ export class Storage {
     if (!nwCols3.some(c => c.name === 'user_rating')) {
       this._run(`ALTER TABLE new_worlds ADD COLUMN user_rating INTEGER DEFAULT 0`);
     }
+    // 迁移：历史 tags='' 脏数据统一为 '[]'（json_each 对空串抛 malformed JSON，Review R2）
+    this._run(`UPDATE new_worlds SET tags = '[]' WHERE tags IS NULL OR tags = ''`);
     return this;
   }
 
@@ -373,8 +375,8 @@ export class Storage {
     const r = parseInt(rating, 10);
     const finalRating = r === -1 ? -1 : (r === 1 ? 1 : 0);
     this._run(
-      `INSERT INTO new_worlds (world_id, world_name, user_rating)
-       VALUES ($worldId, '', $rating)
+      `INSERT INTO new_worlds (world_id, world_name, tags, user_rating)
+       VALUES ($worldId, '', '[]', $rating)
        ON CONFLICT(world_id) DO UPDATE SET user_rating = $rating`,
       { $worldId: worldId, $rating: finalRating }
     );
@@ -387,8 +389,8 @@ export class Storage {
   markWorldVisited({ worldId }) {
     const now = new Date().toISOString();
     this._run(
-      `INSERT INTO new_worlds (world_id, world_name, visited, visited_at)
-       VALUES ($worldId, '', 1, $now)
+      `INSERT INTO new_worlds (world_id, world_name, tags, visited, visited_at)
+       VALUES ($worldId, '', '[]', 1, $now)
        ON CONFLICT(world_id) DO UPDATE SET visited = 1, visited_at = $now`,
       { $worldId: worldId, $now: now }
     );

--- a/core/storage.js
+++ b/core/storage.js
@@ -53,6 +53,11 @@ export class Storage {
     if (!nwCols2.some(c => c.name === 'source')) {
       this._run(`ALTER TABLE new_worlds ADD COLUMN source TEXT DEFAULT 'new'`);
     }
+    // 迁移：旧库 new_worlds 缺 user_rating 列（rate_world 用户反馈，幂等）
+    const nwCols3 = this._query(`PRAGMA table_info(new_worlds)`);
+    if (!nwCols3.some(c => c.name === 'user_rating')) {
+      this._run(`ALTER TABLE new_worlds ADD COLUMN user_rating INTEGER DEFAULT 0`);
+    }
     return this;
   }
 
@@ -357,6 +362,39 @@ export class Storage {
     const rows = this._query(`SELECT world_id, note FROM world_cache WHERE world_id = $worldId`, { $worldId: worldId });
     const r = rows[0];
     return { worldId: r.world_id, note: r.note };
+  }
+
+  /**
+   * 用户反馈：给世界打好评/差评标记（Issue #19）
+   * rating: -1=烂图(junk) / 0=清除标记 / 1=好图
+   * 若世界不在 new_worlds 表（如手动收藏的世界），自动插入一行兜底。
+   */
+  rateWorld({ worldId, rating = 0 }) {
+    const r = parseInt(rating, 10);
+    const finalRating = r === -1 ? -1 : (r === 1 ? 1 : 0);
+    this._run(
+      `INSERT INTO new_worlds (world_id, world_name, user_rating)
+       VALUES ($worldId, '', $rating)
+       ON CONFLICT(world_id) DO UPDATE SET user_rating = $rating`,
+      { $worldId: worldId, $rating: finalRating }
+    );
+    const rows = this._query(`SELECT world_id, world_name, user_rating FROM new_worlds WHERE world_id = $worldId`, { $worldId: worldId });
+    const row = rows[0];
+    return { worldId: row.world_id, worldName: row.world_name || '', userRating: row.user_rating };
+  }
+
+  /** 显式确认逛过某个世界（Issue #19 痛点 3：事件驱动 visited 不可靠） */
+  markWorldVisited({ worldId }) {
+    const now = new Date().toISOString();
+    this._run(
+      `INSERT INTO new_worlds (world_id, world_name, visited, visited_at)
+       VALUES ($worldId, '', 1, $now)
+       ON CONFLICT(world_id) DO UPDATE SET visited = 1, visited_at = $now`,
+      { $worldId: worldId, $now: now }
+    );
+    const rows = this._query(`SELECT world_id, world_name, visited, visited_at FROM new_worlds WHERE world_id = $worldId`, { $worldId: worldId });
+    const row = rows[0];
+    return { worldId: row.world_id, worldName: row.world_name || '', visited: row.visited === 1, visitedAt: row.visited_at };
   }
 
   getWorldHistory(worldId, limit = 50) {

--- a/skills/vrc-monitor-agent/SKILL.md
+++ b/skills/vrc-monitor-agent/SKILL.md
@@ -17,7 +17,7 @@ metadata:
 - 服务启动：项目目录下 `node start-monitor.js`（首次需配置 `credentials.json`，见 AGENTS.md）
 - 数据库：本地 SQLite（WebSocket 实时采集事件，含历史上线/位置/同屏记录）
 
-## MCP 工具（55 个）
+## MCP 工具（60 个）
 
 | 工具 | 说明 |
 |------|------|
@@ -38,7 +38,9 @@ metadata:
 | `get_world_history` | 世界信息变更历史（name/description/author/image_url/release_status/capacity/tags 字段级记录） |
 | `get_weekly_report` | 一周游戏周报（活跃天数/时长/世界 Top/同屏伙伴带昵称/自己的上线规律/群组活动/圈内活动日历；days 默认 7） |
 | `scan_new_worlds` | 扫描最近 N 天新世界（1-30，默认 7），过滤测试/垃圾图后写入 new_worlds 表，按热度推荐 TOP10；dryRun 只看不写 |
-| `get_new_worlds` | 只读查询已跟踪新世界：onlyUnvisited 只看未逛过、sortBy（favorites/occupants/popularity/created_at）、limit（默认 10 最大 50） |
+| `get_new_worlds` | 只读查询已跟踪新世界：onlyUnvisited 只看未逛过、sortBy（favorites/occupants/popularity/created_at）、excludeTheme 排除主题（按 author_tag_* 逗号分隔，SQL 层排除）、limit（默认 10 最大 50） |
+| `rate_world` | **用户反馈**：给世界打好评/烂图标记（rating: 1=好图加权 / -1=烂图降权 / 0=清除），写入 new_worlds.user_rating，影响 worldScore 推荐排序 |
+| `mark_world_visited` | **显式确认逛过**某世界（事件驱动 visited 会漏记，开图闭环手动确认用） |
 | `get_nicknames` / `set_nickname` | 好友昵称映射（查询/写入，本地库） |
 | `get_mutual_friends` | 共同好友列表：你与目标用户（userId 或 displayName 精确匹配）的共同好友，自动带本地昵称 |
 | `get_watchlist` / `add_to_watchlist` / `remove_from_watchlist` | 关注名单 |


### PR DESCRIPTION
## 背景

关联 #19（uhu005 的「开图闭环的用户反馈机制」4 痛点）。按 #18 评论中作者建议的 Phase 1 范围实现：`rate_world` + `mark_world_visited` 本地反馈闭环，`favorite_world`（云端收藏）留待后续讨论。

## 改动

| 文件 | 改动 |
|---|---|
| `core/init-db.sql` | `new_worlds` 新增 `user_rating INTEGER DEFAULT 0`（-1=烂图 / 0=无 / 1=好图） |
| `core/storage.js` | 幂等迁移（照抄 sleep_ok 模式）+ `rateWorld()` / `markWorldVisited()` 方法（upsert 兜底，世界不在表内自动插入） |
| `core/handlers/misc.js` | `handleRateWorld` / `handleMarkWorldVisited` / `get_new_worlds` 支持 `excludeTheme` + 输出 `tags`/`userRating` |
| `core/new-worlds.js` | `worldScore` 纳入用户反馈加权：好图 +50、烂图 -100（推荐排序自动降权） |
| `core/mcp-definitions.js` | 注册 `rate_world` / `mark_world_visited` 工具定义（59 工具） |
| `core/rpc-router.js` | 两个新 case 分发 |

## 对应痛点

- **痛点 2（烂图降权）**：`rate_world` + `user_rating` 列 + `worldScore` 加权——好图加权、烂图降权/排除
- **痛点 3（visited 不可靠）**：`mark_world_visited` 显式确认闭环
- **痛点 4（排除维度）**：`get_new_worlds` 的 `excludeTheme` 参数（按 author_tag_* 匹配）+ 输出 tags
- **痛点 1（好图收藏）**：Phase 2（`favorite_world` 云端收藏），按 #18 评论建议待讨论后实现

## 验证（全部通过）

1. **语法**：5 个改动文件 `node --check` 全过
2. **服务重启**：`user_rating` 列幂等迁移自动生效（PRAGMA 确认，新老库兼容）
3. **MCP 工具列表**：59 工具，两个新工具注册成功
4. **端到端闭环**（真实库）：rate_world 好评 → mark_world_visited → get_new_worlds 查询确认 → 清理，全链路正确
5. **参数校验**：非法 rating(2) 返回 JSON-RPC error
6. **评分加权单测**：259 → 309（好图）/ 159（烂图）
7. **excludeTheme 过滤**：游戏图/恐怖图被排除，睡觉图保留
8. **回归**：get_online_friends / scan_new_worlds(dryRun 189 候选) / get_new_worlds 无参调用全部正常，原 57 工具无影响
9. **数据库**：integrity_check ok，测试数据 0 残留

## 备注

- 分支 `feat/world-user-feedback` 基于当前 main（c739d39），单提交
- 服务运行中迁移安全（better-sqlite3 WAL），无需停机升级