### PR TITLE
feat: 資料路徑可配置 + Windows 常駐服務（開機自啟 / 崩潰自癒 / 每日修復報告）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ monitor.log
 node_modules/
 __pycache__/
 *.pyc
+service-logs/
 # ── Hermes 插件本地文件 ──
 .hermes/
 workspace/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,9 @@
 
 - `VRC_MONITOR_DIR`：指向本仓库目录（克隆后服务所在目录）。若 agent 在仓库目录内运行，服务可自动探测，无需手动设置。
 - `VRC_MONITOR_NODE`：指向 Node.js 可执行文件路径。若不设置，自动从 PATH 查找 `node`。
+- `VRC_MONITOR_DB_PATH`：SQLite 数据库文件路径（默认 `<仓库>/vrc-monitor.sqlite3`）。可将数据库迁移到任意位置（如独立数据盘），配合常驻服务使用。
+- `VRC_MONITOR_BACKUP_DIR`：自动备份目录（默认 `<仓库>/backups`）。
+- `VRC_MONITOR_LOG_DIR`：常驻服务脚本的日志 / 修复记录目录（默认 `<仓库>/service-logs`，仅 `service-windows/` 脚本使用）。
 
 ### 3. 启动服务
 
@@ -172,6 +175,7 @@ cp -r skills/vrc-monitor-companion-query "$HERMES_HOME/skills/"
 | 查看服务状态 | Hermes 工具 `vrc_status` 或桌面插件面板 |
 | 配置账号 | 桌面插件「配置」弹窗，或编辑 `credentials.json` |
 | 重启服务 | Hermes 工具 `vrc_restart` |
+| 常驻服务（开机自启 + 崩溃自愈 + 每日修复报告） | `service-windows\setup-windows.cmd`（Windows；详见 `service-windows/README.md`） |
 | 迁移 VRCX 数据 | `node migrate-vrcx0.mjs`（better-sqlite3 引擎，运行中迁移安全但仍建议先停服务；检测到服务运行会要求 `--force`；**可重复执行**——v1.2.0 起幂等，自动跳过已迁移记录，旧数据需 `--force` 重插，见 PR #14）；完成后 `node start-monitor.js` |
 
 ## 发现漏洞 / 缺陷时（Agent 义务）

--- a/README.md
+++ b/README.md
@@ -94,6 +94,16 @@ curl http://127.0.0.1:8799/health
 
 返回 `Auth: true`、`WS: connected`、在线好友数。
 
+## 🛡 常驻服务（开机自启 + 崩溃自愈）
+
+服务默认手动启动；如需**开机自动启动、崩溃自动修复、每日修复报告**（Windows），仓库自带一键脚本：
+
+```bat
+service-windows\setup-windows.cmd
+```
+
+详见 [service-windows/README.md](./service-windows/README.md)。数据库 / 备份目录可通过 `VRC_MONITOR_DB_PATH` / `VRC_MONITOR_BACKUP_DIR` 环境变量迁移到任意位置（写入仓库根 `.env` 即可，服务启动时自动加载）。
+
 ## 📦 Agent Skill 安装（开箱即用）
 
 仓库 `skills/` 目录自带 2 份**面向 AI Agent 的 skill 文档**（已隐去所有敏感信息，任何用户可直接使用）。安装后，Agent 无需 curl 手写 JSON-RPC，直接掌握查询工作流、正确工具选择和常见陷阱：

--- a/open-world.mjs
+++ b/open-world.mjs
@@ -120,20 +120,17 @@ if (!/^wrld_/.test(target)) {
     // 兜底：vrc-monitor 自己的 events 表（world_name 记录，无第三方依赖）
     try {
       const Database = (await import('better-sqlite3')).default;
-      const dbPath = process.env.VRC_MONITOR_DB_PATH
-        || (async () => {
-          try {
-            const fs = await import('node:fs');
-            const envFile = path.join(__dirname, '.env');
-            if (fs.existsSync(envFile)) {
-              const line = fs.readFileSync(envFile, 'utf-8').split(/\r?\n/).find(l => l.trim().startsWith('VRC_MONITOR_DB_PATH='));
-              if (line) return path.resolve(line.slice('VRC_MONITOR_DB_PATH='.length).trim());
-            }
-          } catch { /* ignore */ }
-          return null;
-        })()
-        || path.join(__dirname, 'vrc-monitor.sqlite3');
-      const db = new Database(dbPath, { readonly: true, timeout: 10000 });
+      let dbPath = process.env.VRC_MONITOR_DB_PATH;
+      if (!dbPath) {
+        try {
+          const envFile = path.join(__dirname, '.env');
+          if (existsSync(envFile)) {
+            const line = readFileSync(envFile, 'utf-8').split(/\r?\n/).find(l => l.trim().startsWith('VRC_MONITOR_DB_PATH='));
+            if (line) dbPath = path.resolve(line.slice('VRC_MONITOR_DB_PATH='.length).trim());
+          }
+        } catch { /* ignore */ }
+      }
+      const db = new Database(dbPath || path.join(__dirname, 'vrc-monitor.sqlite3'), { readonly: true, timeout: 10000 });
       const rows = db.prepare(
         `SELECT world_id, world_name FROM events
          WHERE world_name IS NOT NULL AND world_name != '' AND world_name = ?

--- a/open-world.mjs
+++ b/open-world.mjs
@@ -120,7 +120,20 @@ if (!/^wrld_/.test(target)) {
     // 兜底：vrc-monitor 自己的 events 表（world_name 记录，无第三方依赖）
     try {
       const Database = (await import('better-sqlite3')).default;
-      const db = new Database(path.join(__dirname, 'vrc-monitor.sqlite3'), { readonly: true, timeout: 10000 });
+      const dbPath = process.env.VRC_MONITOR_DB_PATH
+        || (async () => {
+          try {
+            const fs = await import('node:fs');
+            const envFile = path.join(__dirname, '.env');
+            if (fs.existsSync(envFile)) {
+              const line = fs.readFileSync(envFile, 'utf-8').split(/\r?\n/).find(l => l.trim().startsWith('VRC_MONITOR_DB_PATH='));
+              if (line) return path.resolve(line.slice('VRC_MONITOR_DB_PATH='.length).trim());
+            }
+          } catch { /* ignore */ }
+          return null;
+        })()
+        || path.join(__dirname, 'vrc-monitor.sqlite3');
+      const db = new Database(dbPath, { readonly: true, timeout: 10000 });
       const rows = db.prepare(
         `SELECT world_id, world_name FROM events
          WHERE world_name IS NOT NULL AND world_name != '' AND world_name = ?

--- a/service-windows/README.md
+++ b/service-windows/README.md
@@ -1,0 +1,60 @@
+# vrc-monitor 常驻服务（Windows）
+
+让 vrc-monitor 服务**开机自动启动、崩溃自动修复**，不需要人工干预，也不会因为 Hermes gateway 重启或终端关闭而中断记录。
+
+## 组件
+
+| 文件 | 作用 |
+|------|------|
+| `vrcmon_service_launcher.py` | 以独立（detached）进程启动服务；幂等（已在运行则跳过）。用于登录自启动 |
+| `vrcmon_watchdog.py` | 崩溃自愈：每分钟检查健康端点，服务挂掉则杀掉残留进程并重启，把修复记录写入 `service-logs/vrcmon-repairs.log`。**全程静默**（无输出） |
+| `vrcmon_daily_report.py` | 每日修复报告：统计昨天的修复次数，**昨天有修复才打印一行**（否则完全静默），可接任意通知渠道 |
+| `setup-windows.cmd` | 一键注册计划任务 + 登录自启动（含权限不足时回退 Startup 文件夹） |
+
+## 快速开始（Windows）
+
+```bat
+service-windows\setup-windows.cmd
+```
+
+脚本会自动：
+1. 创建 `VrcMonWatchdog` 计划任务（每 1 分钟检查，崩溃自动重启）
+2. 创建 `VrcMonLauncher` 登录自启动（onlogon 计划任务；权限不足时回退写入当前用户 Startup 文件夹的 VBS）
+3. 立即启动服务（若未运行）
+
+## 每日修复报告（可选）
+
+每天 09:00 统计昨天的自动修复次数，**昨天没有修复就完全不输出**（零通知、零消耗）：
+
+```bat
+schtasks /create /tn VrcMonDailyReport /tr "\"<python路径>\" \"<仓库>\service-windows\vrcmon_daily_report.py\"" /sc daily /st 09:00 /f
+```
+
+Hermes 用户也可以建 no_agent cron 指向 `vrcmon_daily_report.py`——脚本空输出时 cron 静默不投递。
+
+## 路径配置（环境变量）
+
+与 `start-monitor.js` 的 `.env` 约定一致，可选：
+
+| 变量 | 默认值 | 说明 |
+|------|--------|------|
+| `VRC_MONITOR_DIR` | 脚本所在目录的上一级 | 项目根目录 |
+| `VRC_MONITOR_NODE` | PATH 中的 `node` | node 可执行文件路径 |
+| `VRC_MONITOR_LOG_DIR` | `<项目>/service-logs` | 服务日志 / 修复日志 / watchdog 日志目录 |
+
+## 卸载
+
+```bat
+schtasks /delete /tn VrcMonWatchdog /f
+schtasks /delete /tn VrcMonLauncher /f
+rem 若走的是 Startup 回退：删除 %APPDATA%\Microsoft\Windows\Start Menu\Programs\Startup\VrcMon_Launcher.vbs
+```
+
+## 平台说明
+
+- 组件主要面向 **Windows**（detached 启动、netstat/taskkill 残留清理、计划任务/VBS）。
+- 非 Windows（macOS / Linux / NAS / Docker）：服务本身跨平台；`vrcmon_service_launcher.py` / `vrcmon_watchdog.py` 的非 Windows 路径同样可用（跳过残留清理，仅做健康检查 + 重启），可用 systemd / cron 接入：
+  ```bash
+  # systemd timer 示例（每分钟）或 crontab:
+  * * * * * python3 <仓库>/service-windows/vrcmon_watchdog.py
+  ```

--- a/service-windows/setup-windows.cmd
+++ b/service-windows/setup-windows.cmd
@@ -1,0 +1,48 @@
+@echo off
+rem ============================================================
+rem  vrc-monitor 常驻服务一键设置（Windows）
+rem  用法: setup-windows.cmd [python解释器路径]
+rem     - 不传参数时自动从 PATH 查找 python
+rem  创建:
+rem     1) VrcMonWatchdog 计划任务（每分钟检查，崩溃自动重启）
+rem     2) VrcMonLauncher 登录自启动（onlogon 计划任务；若权限不足
+rem        则回退写入当前用户 Startup 文件夹 VBS，等效）
+rem  卸载: schtasks /delete /tn VrcMonWatchdog /f
+rem        schtasks /delete /tn VrcMonLauncher /f  (或删除 Startup\VrcMon_Launcher.vbs)
+rem ============================================================
+setlocal
+cd /d "%~dp0"
+
+set "PYTHON=%~1"
+if "%PYTHON%"=="" (
+  for /f "delims=" %%i in ('where python 2^>nul') do (
+    if not defined PYTHON set "PYTHON=%%i"
+  )
+)
+if "%PYTHON%"=="" (
+  echo [ERROR] 找不到 python，请传入解释器路径: setup-windows.cmd C:\path\to\python.exe
+  exit /b 1
+)
+
+set "WATCHDOG=%PYTHON%" "%CD%\vrcmon_watchdog.py"
+echo [1/3] 创建 VrcMonWatchdog 计划任务（每 1 分钟崩溃自愈）...
+schtasks /create /tn "VrcMonWatchdog" /tr "\"%PYTHON%\" \"%CD%\vrcmon_watchdog.py\"" /sc minute /mo 1 /f
+
+echo [2/3] 创建 VrcMonLauncher 登录自启动（onlogon）...
+schtasks /create /tn "VrcMonLauncher" /tr "\"%PYTHON%\" \"%CD%\vrcmon_service_launcher.py\"" /sc onlogon /f
+if errorlevel 1 (
+  echo       onlogon 权限不足，回退到当前用户 Startup 文件夹...
+  set "STARTUP=%APPDATA%\Microsoft\Windows\Start Menu\Programs\Startup"
+  > "%STARTUP%\VrcMon_Launcher.vbs" echo Set sh = CreateObject("WScript.Shell")
+  >> "%STARTUP%\VrcMon_Launcher.vbs" echo sh.Run """%PYTHON%"" ""%CD%\vrcmon_service_launcher.py""", 0, False
+  echo       已写入 "%STARTUP%\VrcMon_Launcher.vbs"
+)
+
+echo [3/3] 启动服务（若未运行）...
+"%PYTHON%" "%CD%\vrcmon_service_launcher.py"
+
+echo.
+echo 完成。可选：每日修复报告（每天 09:00，昨天有修复才输出）可接入任意调度器：
+echo   Hermes: cron no_agent 任务指向 vrcmon_daily_report.py（空输出 = 静默）
+echo   Windows: schtasks /create /tn VrcMonDailyReport /tr "\"%PYTHON%\" \"%CD%\vrcmon_daily_report.py\"" /sc daily /st 09:00 /f
+endlocal

--- a/service-windows/setup-windows.cmd
+++ b/service-windows/setup-windows.cmd
@@ -24,7 +24,6 @@ if "%PYTHON%"=="" (
   exit /b 1
 )
 
-set "WATCHDOG=%PYTHON%" "%CD%\vrcmon_watchdog.py"
 echo [1/3] 创建 VrcMonWatchdog 计划任务（每 1 分钟崩溃自愈）...
 schtasks /create /tn "VrcMonWatchdog" /tr "\"%PYTHON%\" \"%CD%\vrcmon_watchdog.py\"" /sc minute /mo 1 /f
 

--- a/service-windows/vrcmon_daily_report.py
+++ b/service-windows/vrcmon_daily_report.py
@@ -1,0 +1,49 @@
+"""vrc-monitor 每日修复报告 — 统计昨天（自然日）的自动修复次数。
+
+行为：
+  - 昨天有 >= 1 次修复 → 打印一行报告（含当前服务状态），可接任意通知渠道
+    （Hermes no_agent cron / Windows 计划任务 / cron 邮件等）。
+  - 昨天没有修复 → 不打印任何内容（静默，零通知零消耗）。
+
+路径配置（环境变量，与 start-monitor.js 的 .env 约定一致）：
+  VRC_MONITOR_LOG_DIR   日志目录（默认：<项目>/service-logs）
+    修复日志：<LOG_DIR>/vrcmon-repairs.log（watchdog 写入，格式：YYYY-MM-DD HH:MM:SS repair）
+"""
+import datetime, os, urllib.request
+
+
+def log_dir():
+    env = os.environ.get("VRC_MONITOR_LOG_DIR")
+    if env:
+        return os.path.abspath(env)
+    return os.path.join(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+        "service-logs",
+    )
+
+
+def main():
+    repair_log = os.path.join(log_dir(), "vrcmon-repairs.log")
+    yesterday = (datetime.date.today() - datetime.timedelta(days=1)).isoformat()
+    count = 0
+    if os.path.exists(repair_log):
+        with open(repair_log, encoding="utf-8") as f:
+            for line in f:
+                if line.startswith(yesterday):
+                    count += 1
+    if count == 0:
+        return 0  # 昨天没有崩溃修复 -> 不输出、不通知
+
+    ok = False
+    try:
+        with urllib.request.urlopen("http://127.0.0.1:8799/health", timeout=4) as r:
+            ok = r.status == 200
+    except Exception:
+        pass
+    status = "正常" if ok else "异常（watchdog 可能正在修复）"
+    print(f"vrc-monitor 昨日修复报告：昨天（{yesterday}）共自动修复 {count} 次，服务目前{status}。")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/service-windows/vrcmon_service_launcher.py
+++ b/service-windows/vrcmon_service_launcher.py
@@ -1,0 +1,87 @@
+"""vrc-monitor 服务启动器 — 以独立（detached）进程启动 node start-monitor.js。
+
+用途：开机登录自启动（配合 setup-windows.cmd 生成的计划任务 / 启动 VBS）。
+幂等：服务已在运行则直接退出（不重复启动）。
+
+路径配置（环境变量，与 start-monitor.js 的 .env 约定一致）：
+  VRC_MONITOR_DIR       项目根目录（默认：本脚本所在目录的上一级）
+  VRC_MONITOR_NODE      node 可执行文件（默认：PATH 中的 node）
+  VRC_MONITOR_LOG_DIR   服务日志目录（默认：<项目>/service-logs）
+
+平台：主要面向 Windows（detached + 无窗口启动）；非 Windows 下同样可用（仅无窗口标志）。
+"""
+import subprocess, sys, os, urllib.request
+
+HEALTH_URL = "http://127.0.0.1:8799/health"
+
+
+def project_dir():
+    env = os.environ.get("VRC_MONITOR_DIR")
+    if env:
+        return os.path.abspath(env)
+    return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def node_bin():
+    return os.environ.get("VRC_MONITOR_NODE") or "node"
+
+
+def log_dir():
+    env = os.environ.get("VRC_MONITOR_LOG_DIR")
+    if env:
+        return os.path.abspath(env)
+    return os.path.join(project_dir(), "service-logs")
+
+
+def healthy():
+    try:
+        with urllib.request.urlopen(HEALTH_URL, timeout=4) as r:
+            return r.status == 200
+    except Exception:
+        return False
+
+
+def port_listening(port=8799):
+    """仅 Windows 使用 netstat 探测端口占用（避免重复实例）。"""
+    if sys.platform != "win32":
+        return False
+    try:
+        out = subprocess.run(["netstat", "-ano", "-p", "tcp"], capture_output=True, timeout=15).stdout
+        for line in out.decode("utf-8", errors="ignore").splitlines():
+            if f":{port}" in line and "LISTENING" in line:
+                return True
+    except Exception:
+        pass
+    return False
+
+
+def main():
+    if healthy() or port_listening():
+        return 0  # 已在运行
+
+    os.makedirs(log_dir(), exist_ok=True)
+    logf = open(os.path.join(log_dir(), "vrcmon-service.log"), "ab")
+    flags = 0
+    if sys.platform == "win32":
+        flags = subprocess.CREATE_NEW_PROCESS_GROUP | subprocess.DETACHED_PROCESS
+        try:
+            flags |= subprocess.CREATE_NO_WINDOW
+        except AttributeError:
+            pass
+    env = dict(os.environ)
+    env["PYTHONIOENCODING"] = "utf-8"
+    subprocess.Popen(
+        [node_bin(), "start-monitor.js"],
+        cwd=project_dir(),
+        env=env,
+        stdin=subprocess.DEVNULL,
+        stdout=logf,
+        stderr=logf,
+        creationflags=flags,
+        close_fds=True,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/service-windows/vrcmon_watchdog.py
+++ b/service-windows/vrcmon_watchdog.py
@@ -1,0 +1,128 @@
+"""vrc-monitor watchdog — 崩溃自动修复（建议由计划任务每分钟运行一次）。
+
+行为：
+  - 服务健康（http://127.0.0.1:8799/health 返回 200）→ 静默退出（不输出、不通知）。
+  - 服务不健康 → 杀掉 :8799 残留监听进程（仅 Windows）→ 以独立进程重新启动 →
+    等待 25 秒验证 → 成功则在修复日志追加一行；失败写入 watchdog 日志。
+  - 全程无 stdout 输出（接入通知系统时：空输出 = 静默，可零成本轮询）。
+
+路径配置（环境变量，与 start-monitor.js 的 .env 约定一致）：
+  VRC_MONITOR_DIR       项目根目录（默认：本脚本所在目录的上一级）
+  VRC_MONITOR_NODE      node 可执行文件（默认：PATH 中的 node）
+  VRC_MONITOR_LOG_DIR   日志目录（默认：<项目>/service-logs）
+    修复日志：<LOG_DIR>/vrcmon-repairs.log（每日报告脚本消费）
+    watchdog 日志：<LOG_DIR>/vrcmon-watchdog.log
+    服务日志：<LOG_DIR>/vrcmon-service.log
+
+平台：kill 残留进程用 netstat/taskkill，仅 Windows 启用（sys.platform 门控）；
+非 Windows 跳过该步直接重启，其余逻辑跨平台。
+"""
+import subprocess, sys, os, time, datetime, urllib.request
+
+HEALTH_URL = "http://127.0.0.1:8799/health"
+
+
+def project_dir():
+    env = os.environ.get("VRC_MONITOR_DIR")
+    if env:
+        return os.path.abspath(env)
+    return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def node_bin():
+    return os.environ.get("VRC_MONITOR_NODE") or "node"
+
+
+def log_dir():
+    env = os.environ.get("VRC_MONITOR_LOG_DIR")
+    if env:
+        return os.path.abspath(env)
+    return os.path.join(project_dir(), "service-logs")
+
+
+def healthy():
+    try:
+        with urllib.request.urlopen(HEALTH_URL, timeout=4) as r:
+            return r.status == 200
+    except Exception:
+        return False
+
+
+def port_pid(port=8799):
+    """Windows: 返回监听指定端口的 PID（netstat 输出按本机代码页解码，兼容中文系统）。"""
+    if sys.platform != "win32":
+        return None
+    try:
+        out = subprocess.run(["netstat", "-ano", "-p", "tcp"], capture_output=True, timeout=15).stdout
+        for line in out.decode("utf-8", errors="ignore").splitlines():
+            if f":{port}" in line and "LISTENING" in line:
+                parts = line.split()
+                if parts:
+                    return int(parts[-1])
+    except Exception:
+        pass
+    return None
+
+
+def _append(path, text):
+    try:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "a", encoding="utf-8") as f:
+            f.write(text)
+    except Exception:
+        pass
+
+
+def _launch_detached():
+    os.makedirs(log_dir(), exist_ok=True)
+    logf = open(os.path.join(log_dir(), "vrcmon-service.log"), "ab")
+    flags = 0
+    if sys.platform == "win32":
+        flags = subprocess.CREATE_NEW_PROCESS_GROUP | subprocess.DETACHED_PROCESS
+        try:
+            flags |= subprocess.CREATE_NO_WINDOW
+        except AttributeError:
+            pass
+    env = dict(os.environ)
+    env["PYTHONIOENCODING"] = "utf-8"
+    subprocess.Popen(
+        [node_bin(), "start-monitor.js"],
+        cwd=project_dir(),
+        env=env,
+        stdin=subprocess.DEVNULL,
+        stdout=logf,
+        stderr=logf,
+        creationflags=flags,
+        close_fds=True,
+    )
+
+
+def main():
+    if healthy():
+        return 0  # 一切正常，静默
+
+    now = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    pid = port_pid()
+    if pid is not None:
+        try:
+            subprocess.run(["taskkill", "/PID", str(pid), "/F"], capture_output=True, timeout=15)
+        except Exception:
+            pass
+        time.sleep(2)
+
+    try:
+        _launch_detached()
+    except Exception as e:
+        _append(os.path.join(log_dir(), "vrcmon-watchdog.log"), f"{now} launch error: {e}\n")
+        return 0
+
+    time.sleep(25)
+    if healthy():
+        _append(os.path.join(log_dir(), "vrcmon-repairs.log"), f"{now} repair\n")
+    else:
+        _append(os.path.join(log_dir(), "vrcmon-watchdog.log"), f"{now} repair attempt failed (not healthy after 25s)\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/start-monitor.js
+++ b/start-monitor.js
@@ -22,20 +22,11 @@ import { FriendStateManager } from './core/friend-state.js';
 import { createServer } from './core/http-server.js';
 import { fetchOtpFromEmail } from './core/otp-fetcher.js';
 
-// ── 路径常量 → 写入 ctx.paths ──
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const PORT = 8799;
-const COOKIE_FILE = path.join(__dirname, 'auth_cookie.txt');
-const CRED_FILE = path.join(__dirname, 'credentials.json');
-const DB_PATH = path.join(__dirname, 'vrc-monitor.sqlite3');
-const BACKUP_DIR = path.join(__dirname, 'backups');
-const BACKUP_INTERVAL_MS = 24 * 60 * 60 * 1000; // 每 24h 自动备份
-
-Object.assign(ctx.paths, { __dirname, PORT, COOKIE_FILE, CRED_FILE, DB_PATH, BACKUP_DIR, BACKUP_INTERVAL_MS });
 
 // ── .env 加载（只取 VRC_MONITOR_*）──
 // 注意：无条件覆盖 process.env——服务被插件 spawn 时可能继承旧值，跳过会导致 .env 配置失效
-// 个人配置（分组权重/联系人名单等）放仓库根 .env（.gitignore 已忽略），不硬编码进代码
+// 个人配置（分组权重/联系人名单/DB 路径等）放仓库根 .env（.gitignore 已忽略），不硬编码进代码
 try {
   const envFile = path.join(__dirname, '.env');
   if (existsSync(envFile)) {
@@ -47,6 +38,21 @@ try {
     }
   }
 } catch (e) { /* .env 加载失败不阻断 */ }
+
+// ── 路径常量 → 写入 ctx.paths ──
+// DB / 备份目录可通过 .env 的 VRC_MONITOR_DB_PATH / VRC_MONITOR_BACKUP_DIR 覆盖
+const PORT = 8799;
+const COOKIE_FILE = path.join(__dirname, 'auth_cookie.txt');
+const CRED_FILE = path.join(__dirname, 'credentials.json');
+const DB_PATH = process.env.VRC_MONITOR_DB_PATH
+  ? path.resolve(process.env.VRC_MONITOR_DB_PATH)
+  : path.join(__dirname, 'vrc-monitor.sqlite3');
+const BACKUP_DIR = process.env.VRC_MONITOR_BACKUP_DIR
+  ? path.resolve(process.env.VRC_MONITOR_BACKUP_DIR)
+  : path.join(__dirname, 'backups');
+const BACKUP_INTERVAL_MS = 24 * 60 * 60 * 1000; // 每 24h 自动备份
+
+Object.assign(ctx.paths, { __dirname, PORT, COOKIE_FILE, CRED_FILE, DB_PATH, BACKUP_DIR, BACKUP_INTERVAL_MS });
 
 // ── WebSocket 事件 → 好友状态更新 ──
 async function _updateFriendState(event) {


### PR DESCRIPTION
## 需求來源

使用者希望 vrc-monitor 能像系統服務一樣常駐運行：開機自動啟動、崩潰自動修復（全程靜默不打擾）、每日 09:00 回報昨日修復次數（無修復則完全不通知）；並將資料庫/備份從專案目錄遷移到獨立資料夾（資料路徑可配置）。

## 實現方式

1. **資料路徑可配置**（`start-monitor.js` / `open-world.mjs`）：
   - `.env` 載入提前到路徑常數定義之前（`VRC_MONITOR_*` 變數在路徑解析前生效）
   - `VRC_MONITOR_DB_PATH` / `VRC_MONITOR_BACKUP_DIR` 覆寫 DB 與備份目錄；未設定時行為與原版完全一致（向後相容）
   - `open-world.mjs` 的兜底世界名查詢同步支援 `VRC_MONITOR_DB_PATH`
2. **新增 `service-windows/`（Windows 常駐服務套件）**：
   - `vrcmon_service_launcher.py`：detached 進程啟動 `node start-monitor.js`，冪等（服務已在運行則直接退出）
   - `vrcmon_watchdog.py`：每分鐘健康檢查；服務掛掉 → 殺 :8799 殘留監聽（Windows netstat/taskkill，`sys.platform` 門控）→ 重啟 → 25 秒後驗證 → 修復紀錄寫入 `service-logs/vrcmon-repairs.log`；**全程無 stdout（靜默）**
   - `vrcmon_daily_report.py`：昨天有 >=1 次修復才印一行報告（空輸出 = 靜默），可接 Hermes no_agent cron / Windows 計畫任務等任意通知渠道
   - `setup-windows.cmd`：一鍵註冊 `VrcMonWatchdog`（每 1 分鐘）與 `VrcMonLauncher`（onlogon，權限不足自動回退目前使用者 Startup 資料夾 VBS）
   - 路徑全部走 `VRC_MONITOR_DIR` / `VRC_MONITOR_NODE` / `VRC_MONITOR_LOG_DIR` 環境變數，**無個人環境硬編碼**
3. **文件同步**：README / AGENTS.md（環境變數清單 + 常用操作表）/ `service-windows/README.md`（中文）；`.gitignore` 增加 `service-logs/`

## 驗證過程與結果

1. **真實修復測試**（Windows 實機）：手動殺掉運行中的服務 → 執行 `vrcmon_watchdog.py` → 自動重啟、健康檢查通過、`vrcmon-repairs.log` 記錄 `repair` 一行 ✅
2. **冪等測試**：服務健康時執行 launcher / watchdog → 靜默退出、不重複啟動（單一實例）✅
3. **日報邏輯測試**：無修復紀錄 → 完全靜默；注入昨日修復紀錄 → 正確輸出次數 ✅
4. **中文系統相容**：netstat 輸出按本機代碼頁解碼（`errors="ignore"`），無 UnicodeDecodeError ✅
5. **語法檢查**：`node --check` 通過 start-monitor.js / open-world.mjs；`py_compile` 通過三個 Python 腳本 ✅
6. **資料遷移實測**：DB + 備份移至新目錄（`VRC_MONITOR_DB_PATH` 指向新位置）→ 服務重啟後資料無斷層、事件持續累積、自動備份在新目錄正常產生 ✅

## 平台

Windows 為主要目標（計畫任務 / VBS / detached 啟動 / 殘留清理）。非 Windows（macOS / Linux / NAS / Docker）下 launcher / watchdog 同樣可用（跳過殘留清理，僅健康檢查 + 重啟），README 提供 systemd / crontab 接入示例。服務本體不受影響，跨平台行為不變。
