### PR TITLE
feat(online-friends): get_online_friends 增强——世界名 worldName + 停留时长 durationMinutes/enteredAt

### DIFF
--- a/core/handlers/friends.js
+++ b/core/handlers/friends.js
@@ -22,6 +22,34 @@ export async function handleGetOnlineFriends() {
   const latestLocations = storage.getLatestFriendLocations(online.map(f => f.id));
   const nowMs = Date.now();
 
+  // 世界名：缓存优先，缺失批量 API 查询并写 world_cache
+  // （懒刷新节奏由 get_world_name 控制；rateLimiter 已在 RPC case 层包裹本 handler，
+  //   内部直接串行 api._request，与 get_weekly_report 同款模式——勿再套 rateLimiter.execute）
+  const worldNameMap = {};
+  const missingWorlds = [];
+  for (const f of online) {
+    const lp = parseLocation(f.location || 'private');
+    if (!lp.worldId) continue;
+    const cached = storage.getWorldName(lp.worldId);
+    if (cached && cached.name) worldNameMap[lp.worldId] = cached.name;
+    else missingWorlds.push(lp.worldId);
+  }
+  for (const wid of missingWorlds) {
+    try {
+      const wr = await api._request('GET', `/worlds/${wid}`);
+      if (wr.status === 200 && wr.data) {
+        const w = wr.data;
+        worldNameMap[wid] = w.name || wid;
+        storage.upsertWorld({
+          worldId: w.id, name: w.name, authorName: w.authorName,
+          capacity: w.capacity, favorites: w.favorites,
+          releaseStatus: w.releaseStatus, tags: w.tags || [],
+          description: w.description || '', imageUrl: w.imageUrl || '',
+        });
+      } else worldNameMap[wid] = wid;
+    } catch { worldNameMap[wid] = wid; }
+  }
+
   return {
     online: online.length,
     total: friends.length,
@@ -39,12 +67,7 @@ export async function handleGetOnlineFriends() {
           }
         } catch (e) { /* 解析失败视为未知 */ }
       }
-      // 世界名：只读本地缓存，不强制 API（懒刷新节奏由 get_world_name 控制）
-      let worldName = null;
-      if (lp.worldId) {
-        const w = storage.getWorldName(lp.worldId);
-        if (w && w.name) worldName = w.name;
-      }
+      const worldName = lp.worldId ? (worldNameMap[lp.worldId] || null) : null;
       return {
         userId: f.id,
         displayName: f.displayName,

--- a/core/handlers/friends.js
+++ b/core/handlers/friends.js
@@ -20,6 +20,8 @@ export async function handleGetOnlineFriends() {
   // 停留时长：每个好友最新一条 friend-location 事件，若其 location 与当前一致，
   // 事件时间即进入时间 → durationMinutes = now - created_at（2026-08-16 用户需求固化）
   const latestLocations = storage.getLatestFriendLocations(online.map(f => f.id));
+  // 在线时长：会话起点 = 最近 friend-offline 之后最早 friend-online（重复推送被 MIN 跳过）
+  const sessionStarts = storage.getOnlineSessionStarts(online.map(f => f.id));
   const nowMs = Date.now();
 
   // 世界名：缓存优先，缺失批量 API 查询并写 world_cache
@@ -55,6 +57,10 @@ export async function handleGetOnlineFriends() {
     total: friends.length,
     friends: online.map(f => {
       const lp = parseLocation(f.location || 'private');
+      const sessionStart = sessionStarts.get(f.id);
+      const sessionStartMs = sessionStart ? new Date(sessionStart).getTime() : 0;
+      // 停留时长：进入时间 = max(会话起点, 最新位置事件时间)——防跨会话污染
+      // （本次会话无位置变化事件时，进入时间以上线时间为准；否则以上次换房时间为准）
       let durationMinutes = null;
       let enteredAt = null;
       const last = latestLocations.get(f.id);
@@ -62,12 +68,20 @@ export async function handleGetOnlineFriends() {
         try {
           const evLoc = JSON.parse(last.content).location || '';
           if (evLoc === f.location) {
-            enteredAt = last.createdAt;
-            durationMinutes = Math.max(0, Math.floor((nowMs - new Date(last.createdAt).getTime()) / 60000));
+            const enterMs = Math.max(new Date(last.createdAt).getTime(), sessionStartMs);
+            enteredAt = new Date(enterMs).toISOString();
+            durationMinutes = Math.max(0, Math.floor((nowMs - enterMs) / 60000));
           }
         } catch (e) { /* 解析失败视为未知 */ }
       }
       const worldName = lp.worldId ? (worldNameMap[lp.worldId] || null) : null;
+      // 在线时长（本次会话）：sessionStart 有值 → onlineMinutes = now - sessionStart
+      let onlineMinutes = null;
+      let onlineSince = null;
+      if (sessionStart) {
+        onlineSince = sessionStart;
+        onlineMinutes = Math.max(0, Math.floor((nowMs - sessionStartMs) / 60000));
+      }
       return {
         userId: f.id,
         displayName: f.displayName,
@@ -81,6 +95,8 @@ export async function handleGetOnlineFriends() {
         worldName,
         durationMinutes,
         enteredAt,
+        onlineMinutes,
+        onlineSince,
       };
     }),
   };

--- a/core/handlers/friends.js
+++ b/core/handlers/friends.js
@@ -17,20 +17,49 @@ export async function handleGetOnlineFriends() {
     if (item.userId) nicknameMap.set(item.userId, item.nickname);
   }
 
+  // 停留时长：每个好友最新一条 friend-location 事件，若其 location 与当前一致，
+  // 事件时间即进入时间 → durationMinutes = now - created_at（2026-08-16 用户需求固化）
+  const latestLocations = storage.getLatestFriendLocations(online.map(f => f.id));
+  const nowMs = Date.now();
+
   return {
     online: online.length,
     total: friends.length,
-    friends: online.map(f => ({
-      userId: f.id,
-      displayName: f.displayName,
-      location: f.location || 'private',
-      status: f.status,
-      statusDescription: f.statusDescription,
-      platform: f.platform,
-      avatarImageUrl: f.currentAvatarThumbnailImageUrl,
-      nickname: nicknameMap.get(f.id) || null,
-      locationParsed: parseLocation(f.location || 'private'),
-    })),
+    friends: online.map(f => {
+      const lp = parseLocation(f.location || 'private');
+      let durationMinutes = null;
+      let enteredAt = null;
+      const last = latestLocations.get(f.id);
+      if (last && f.location && f.location !== 'traveling') {
+        try {
+          const evLoc = JSON.parse(last.content).location || '';
+          if (evLoc === f.location) {
+            enteredAt = last.createdAt;
+            durationMinutes = Math.max(0, Math.floor((nowMs - new Date(last.createdAt).getTime()) / 60000));
+          }
+        } catch (e) { /* 解析失败视为未知 */ }
+      }
+      // 世界名：只读本地缓存，不强制 API（懒刷新节奏由 get_world_name 控制）
+      let worldName = null;
+      if (lp.worldId) {
+        const w = storage.getWorldName(lp.worldId);
+        if (w && w.name) worldName = w.name;
+      }
+      return {
+        userId: f.id,
+        displayName: f.displayName,
+        location: f.location || 'private',
+        status: f.status,
+        statusDescription: f.statusDescription,
+        platform: f.platform,
+        avatarImageUrl: f.currentAvatarThumbnailImageUrl,
+        nickname: nicknameMap.get(f.id) || null,
+        locationParsed: lp,
+        worldName,
+        durationMinutes,
+        enteredAt,
+      };
+    }),
   };
 }
 

--- a/core/handlers/friends.js
+++ b/core/handlers/friends.js
@@ -27,6 +27,8 @@ export async function handleGetOnlineFriends() {
   // 世界名：缓存优先，缺失批量 API 查询并写 world_cache
   // （懒刷新节奏由 get_world_name 控制；rateLimiter 已在 RPC case 层包裹本 handler，
   //   内部直接串行 api._request，与 get_weekly_report 同款模式——勿再套 rateLimiter.execute）
+  // ⚠️ 节流：高频工具，内部串行 API 查询加小 sleep 防突发 N 连发（PR #36 审核 W4）；
+  //   查询失败置 null（不泄漏 worldId 内部 ID，W2）；失败不写缓存 → 下次调用会重试（W3，已知行为）
   const worldNameMap = {};
   const missingWorlds = [];
   for (const f of online) {
@@ -37,19 +39,20 @@ export async function handleGetOnlineFriends() {
     else missingWorlds.push(lp.worldId);
   }
   for (const wid of missingWorlds) {
+    await new Promise(r => setTimeout(r, 300));  // 小 sleep 节流
     try {
       const wr = await api._request('GET', `/worlds/${wid}`);
       if (wr.status === 200 && wr.data) {
         const w = wr.data;
-        worldNameMap[wid] = w.name || wid;
+        worldNameMap[wid] = w.name;
         storage.upsertWorld({
           worldId: w.id, name: w.name, authorName: w.authorName,
           capacity: w.capacity, favorites: w.favorites,
           releaseStatus: w.releaseStatus, tags: w.tags || [],
           description: w.description || '', imageUrl: w.imageUrl || '',
         });
-      } else worldNameMap[wid] = wid;
-    } catch { worldNameMap[wid] = wid; }
+      } else worldNameMap[wid] = null;
+    } catch { worldNameMap[wid] = null; }
   }
 
   return {

--- a/core/storage.js
+++ b/core/storage.js
@@ -173,8 +173,10 @@ export class Storage {
    * 口径：会话起点 = 最近一次 friend-offline 之后最早的一条 friend-online。
    * 为何不能直接取最新 friend-online：VRChat WS 重连/状态同步会重复推送 friend-online
    * （实测 24h 527 条 vs ~30 人在线），最新一条会严重低估时长；MIN(>last_off) 天然跳过重复推送。
-   * 无 offline 记录的用户取最早一条 friend-online（数据库记录以来首次上线）。
-   * 返回 Map<userId, sessionStartIso>；无 friend-online 事件则不在 Map 中。
+   * 仅当用户从未有过 offline 记录时才取最早一条 friend-online（数据库记录以来首次上线）；
+   * 有 offline 但 offline 后无 online（事件丢失/数据不一致）→ 返回 NULL，调用方安全降级
+   * （避免把离线前时间当会话起点导致 onlineMinutes 高估，PR #36 审核 W1）。
+   * 返回 Map<userId, sessionStartIso|null>；无 friend-online 事件则不在 Map 中。
    */
   getOnlineSessionStarts(userIds) {
     if (!userIds || userIds.length === 0) return new Map();
@@ -187,10 +189,9 @@ export class Storage {
          WHERE type='friend-offline' AND user_id IN (${ph}) GROUP BY user_id
        )
        SELECT e.user_id,
-              COALESCE(
-                MIN(CASE WHEN o.last_off IS NULL OR e.created_at > o.last_off THEN e.created_at END),
-                MIN(e.created_at)
-              ) AS session_start
+              CASE WHEN o.last_off IS NULL THEN MIN(e.created_at)
+                   ELSE MIN(CASE WHEN e.created_at > o.last_off THEN e.created_at END) END
+              AS session_start
        FROM events e
        LEFT JOIN offs o ON e.user_id = o.user_id
        WHERE e.type = 'friend-online' AND e.user_id IN (${ph})
@@ -198,7 +199,7 @@ export class Storage {
       params
     );
     const map = new Map();
-    for (const r of rows) map.set(r.user_id, r.session_start);
+    for (const r of rows) map.set(r.user_id, r.session_start || null);
     return map;
   }
 

--- a/core/storage.js
+++ b/core/storage.js
@@ -168,6 +168,40 @@ export class Storage {
     return map;
   }
 
+  /**
+   * 批量取每个用户本次在线会话的起点（get_online_friends 在线时长用，2026-08-16 新增）。
+   * 口径：会话起点 = 最近一次 friend-offline 之后最早的一条 friend-online。
+   * 为何不能直接取最新 friend-online：VRChat WS 重连/状态同步会重复推送 friend-online
+   * （实测 24h 527 条 vs ~30 人在线），最新一条会严重低估时长；MIN(>last_off) 天然跳过重复推送。
+   * 无 offline 记录的用户取最早一条 friend-online（数据库记录以来首次上线）。
+   * 返回 Map<userId, sessionStartIso>；无 friend-online 事件则不在 Map 中。
+   */
+  getOnlineSessionStarts(userIds) {
+    if (!userIds || userIds.length === 0) return new Map();
+    const ph = userIds.map((_, i) => `$u${i}`).join(',');
+    const params = {};
+    userIds.forEach((id, i) => { params[`$u${i}`] = id; });
+    const rows = this._query(
+      `WITH offs AS (
+         SELECT user_id, MAX(created_at) AS last_off FROM events
+         WHERE type='friend-offline' AND user_id IN (${ph}) GROUP BY user_id
+       )
+       SELECT e.user_id,
+              COALESCE(
+                MIN(CASE WHEN o.last_off IS NULL OR e.created_at > o.last_off THEN e.created_at END),
+                MIN(e.created_at)
+              ) AS session_start
+       FROM events e
+       LEFT JOIN offs o ON e.user_id = o.user_id
+       WHERE e.type = 'friend-online' AND e.user_id IN (${ph})
+       GROUP BY e.user_id`,
+      params
+    );
+    const map = new Map();
+    for (const r of rows) map.set(r.user_id, r.session_start);
+    return map;
+  }
+
   getRecentEvents({ limit = 50, type } = {}) {
     let sql = `SELECT * FROM events`;
     const params = {};

--- a/core/storage.js
+++ b/core/storage.js
@@ -144,6 +144,30 @@ export class Storage {
     return this._query(sql, params);
   }
 
+  /**
+   * 批量取多个用户各自最新一条 friend-location 事件（get_online_friends 停留时长用）。
+   * 返回 Map<userId, {createdAt, content}>；某用户无事件则不在 Map 中。
+   * 窗口函数 PARTITION BY user_id 一次查询拿全，避免 N 次点查。
+   */
+  getLatestFriendLocations(userIds) {
+    if (!userIds || userIds.length === 0) return new Map();
+    const ph = userIds.map((_, i) => `$u${i}`).join(',');
+    const params = {};
+    userIds.forEach((id, i) => { params[`$u${i}`] = id; });
+    const rows = this._query(
+      `SELECT user_id, created_at, content_json FROM (
+         SELECT user_id, created_at, content_json,
+                ROW_NUMBER() OVER (PARTITION BY user_id ORDER BY created_at DESC) AS rn
+         FROM events
+         WHERE type = 'friend-location' AND user_id IN (${ph})
+       ) WHERE rn = 1`,
+      params
+    );
+    const map = new Map();
+    for (const r of rows) map.set(r.user_id, { createdAt: r.created_at, content: r.content_json });
+    return map;
+  }
+
   getRecentEvents({ limit = 50, type } = {}) {
     let sql = `SELECT * FROM events`;
     const params = {};

--- a/skills/vrc-monitor-agent/SKILL.md
+++ b/skills/vrc-monitor-agent/SKILL.md
@@ -21,7 +21,7 @@ metadata:
 
 | 工具 | 说明 |
 |------|------|
-| `get_online_friends` | 当前在线好友列表（含昵称 nickname + 房型解析 locationParsed：worldId/instanceId/type/ownerId/region） |
+| `get_online_friends` | 当前在线好友列表（含昵称 nickname + 房型解析 locationParsed：worldId/instanceId/type/ownerId/region + 世界名 worldName + 停留时长 durationMinutes/enteredAt；durationMinutes = 最新 friend-location 事件位置与当前一致时的停留分钟数，null=未知） |
 | `get_friend_info` | 好友详细信息 |
 | `search_users` | 按名字搜索用户（API 优先；API 无匹配时自动回退本地好友库模糊搜索 display_name/备注，结果带 `source: local_friends` 标记） |
 | `search_groups` | 按名字搜索群组（API 用 query 参数，不是 search） |

--- a/skills/vrc-monitor-agent/SKILL.md
+++ b/skills/vrc-monitor-agent/SKILL.md
@@ -21,7 +21,7 @@ metadata:
 
 | 工具 | 说明 |
 |------|------|
-| `get_online_friends` | 当前在线好友列表（含昵称 nickname + 房型解析 locationParsed：worldId/instanceId/type/ownerId/region + 世界名 worldName + 停留时长 durationMinutes/enteredAt；durationMinutes = 最新 friend-location 事件位置与当前一致时的停留分钟数，null=未知） |
+| `get_online_friends` | 当前在线好友列表（含昵称 nickname + 房型解析 locationParsed：worldId/instanceId/type/ownerId/region + 世界名 worldName（未缓存自动 API 补查）+ 房间停留时长 durationMinutes/enteredAt + **在线时长 onlineMinutes/onlineSince**；durationMinutes 进入时间 = max(会话起点, 最新位置事件)防跨会话污染；onlineMinutes = 最近 friend-offline 之后最早 friend-online 起算，重复推送被 MIN 跳过） |
 | `get_friend_info` | 好友详细信息 |
 | `search_users` | 按名字搜索用户（API 优先；API 无匹配时自动回退本地好友库模糊搜索 display_name/备注，结果带 `source: local_friends` 标记） |
 | `search_groups` | 按名字搜索群组（API 用 query 参数，不是 search） |


### PR DESCRIPTION
## 需求来源

使用者提出：查询好友在线列表时，需要直接看到好友的名字（有昵称用昵称）、所在世界、房间类型、在该房间停留了多久、以及本次在线了多久——希望一次 `tools/call` 拿全，而不是 Agent 跑孤立脚本 + sqlite 直连（孤立脚本违反 DEVELOPMENT.md §5「新功能默认做成 MCP 工具」）。

## 实现方式

增强 `get_online_friends`（方案 A：只增字段，向后兼容，现有字段一个不删）：

- `core/storage.js` 新增 `getLatestFriendLocations(userIds)`：窗口函数 `ROW_NUMBER() OVER (PARTITION BY user_id ORDER BY created_at DESC)` 一次 SQL 取每个用户最新一条 `friend-location` 事件（有 `idx_events_user_time` 索引）
- `core/storage.js` 新增 `getOnlineSessionStarts(userIds)`：会话起点 = 最近一次 `friend-offline` 之后最早的一条 `friend-online`；仅无 offline 记录才取最早 online；有 offline 但 offline 后无 online（事件丢失）→ null 安全降级
- `core/handlers/friends.js` handler 新增字段：
  - `worldName`：世界名（缓存优先，未缓存批量 API 查询并写 world_cache；查询失败置 null 不泄漏 worldId）
  - `durationMinutes` / `enteredAt`：房间停留时长，进入时间 = max(会话起点, 最新位置事件时间)（防跨会话污染）
  - `onlineMinutes` / `onlineSince`：本次在线时长，从会话起点起算
- 缺失世界名串行查询加 300ms 小 sleep 节流（高频工具防突发 N 连发）
- `skills/vrc-monitor-agent/SKILL.md` 工具表已同步登记

## 验证过程与结果

- `node --check` 改动文件均通过
- 重启服务后 MCP 实测 `get_online_friends`（35 人在线）：
  - 字段完整性：全部记录含 `worldName` / `durationMinutes` / `enteredAt` / `onlineMinutes` / `onlineSince`
  - 停留时长防污染：Sugar83 从误算 15h46m 修正为 50 分钟（本次会话无位置变化 → 进入时间 = 上线时间）；全量校验「停留 > 在线」= 0
  - 在线时长口径：wsadwa 530h（22 天挂机，friend-active 持续佐证）；Sugar83 58 分钟（重复推送被 MIN 跳过，未低估）
  - 世界名：未缓存世界自动 API 补查（如「奶龙之屋1.21版本」「咖啡厅v1.31」），worldId 泄漏 = 0
- PR 审核建议 W1/W2/W4 已采纳修复并复测通过（W3 失败不写缓存为已知行为，代码注释注明）
