### PR TITLE
fix: OTP 自动登录支持 VRC_MONITOR_PYTHON 指定解释器路径（修复重试循环刷验证码邮件）

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,7 @@
 - `VRC_MONITOR_DB_PATH`：SQLite 数据库文件路径（默认 `<仓库>/vrc-monitor.sqlite3`）。可将数据库迁移到任意位置（如独立数据盘），配合常驻服务使用。
 - `VRC_MONITOR_BACKUP_DIR`：自动备份目录（默认 `<仓库>/backups`）。
 - `VRC_MONITOR_LOG_DIR`：常驻服务脚本的日志 / 修复记录目录（默认 `<仓库>/service-logs`，仅 `service-windows/` 脚本使用）。
+- `VRC_MONITOR_PYTHON`：执行 fetch-otp.py 的 Python 解释器路径（默认 PATH 中的 `python`）。以计划任务 / systemd / 容器等方式运行且 PATH 中无 python 时必须设置，否则 OTP 自动登录失败会陷入重试循环（每次循环 VRChat 都会重新发送验证码邮件）。
 
 ### 3. 启动服务
 

--- a/core/otp-fetcher.js
+++ b/core/otp-fetcher.js
@@ -15,7 +15,8 @@ export async function fetchOtpFromEmail() {
   const creds = JSON.parse(readFileSync(CRED_FILE, 'utf-8'));
   const { execSync } = await import('node:child_process');
   const authCode = creds.imap_auth_code || creds.qqmail_auth_code || '';
-  let cmd = `python "${otpScript}" "${creds.email}" "${authCode}"`;
+  const pythonBin = process.env.VRC_MONITOR_PYTHON || 'python';
+  let cmd = `${pythonBin} "${otpScript}" "${creds.email}" "${authCode}"`;
   if (creds.imap_host) cmd += ` "${creds.imap_host}"`;
   const otp = execSync(cmd, { timeout: 15000, encoding: 'utf-8' }).trim();
   return otp;


### PR DESCRIPTION
## 需求來源

vrc-monitor 以计划任务 / watchdog 常驻方式运行时，认证 cookie 过期后的 OTP 自动登录**陷入无限重试循环**：每次循环 VRChat 都会重新发送一封验证码邮件（实测用户邮箱收到大量验证码）。根因：`core/otp-fetcher.js` 硬编码裸 `python` 执行 `fetch-otp.py`，而计划任务 / systemd / 容器等环境的 PATH 中没有 python（或只有 `python3` / WindowsApps 占位 stub），`execSync` 直接抛 "Command failed"，登录永远失败 → 冷却重试 → 再触发新验证码。

## 实现方式

- `core/otp-fetcher.js`：执行命令改用 `process.env.VRC_MONITOR_PYTHON || 'python'`——显式指定解释器路径可绕过 PATH 解析问题；未设置时行为与原版完全一致（向后兼容）。
- `AGENTS.md`：环境变量清单登记 `VRC_MONITOR_PYTHON`（含「PATH 无 python 时必须设置，否则陷入 OTP 重试循环」的说明）。

## 验证过程与结果

1. **本机实测（Windows + 计划任务常驻）**：cookie 过期后，服务日志持续出现 `OTP 自动登录失败: Command failed: python "D:\...\fetch-otp.py" ...`，邮箱不断收到验证码。
2. **IMAP 侧确认正常**：手动以绝对路径 python 执行 `fetch-otp.py <email> <imap_auth_code>` → exit 0，正确输出验证码（`165528`）。
3. **设置 `VRC_MONITOR_PYTHON=<绝对路径 python.exe>` 并重启服务后**：不再出现 "Command failed"；登录流程正常走到验证码步骤（之后因 VRChat 对循环尝试的临时 429 限流而短暂等待，属预期；限流解除后自动登录成功）。
4. `node --check` 语法通过。

## 平台

跨平台通用修复（Windows / macOS / Linux / NAS / 容器均适用）；`VRC_MONITOR_PYTHON` 遵循项目既有 `VRC_MONITOR_*` 环境变量约定。
