### PR TITLE
feat: 迁移/分析脚本支持跨平台自动探测 VRCX 数据库路径

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,9 +34,10 @@
 | 状态变更 | `feed_status` | 好友状态文本变更 |
 | Bio 变更 | `feed_bio` | 好友个人简介变更 |
 
-> **数据库位置**：迁移脚本会自动探测以下路径（Windows）：
-> -  VRCX：`%USERPROFILE%\AppData\Roaming\VRCX\VRCX.sqlite3`
-> -  VRCX-0：`%USERPROFILE%\AppData\Roaming\VRCX-0\VRCX-0.sqlite3`
+> **数据库位置**：迁移脚本会按平台自动探测以下路径：
+> -  **Windows**：`%USERPROFILE%\AppData\Roaming\VRCX\VRCX.sqlite3`（VRCX-0：`%USERPROFILE%\AppData\Roaming\VRCX-0\VRCX-0.sqlite3`）
+> -  **Linux**：`~/.config/VRCX/VRCX.sqlite3`（原生 Electron 版）；若通过 Wine 运行 Windows 版：`~/.wine/drive_c/users/<user>/AppData/Roaming/VRCX/VRCX.sqlite3`（自定义 Wine 前缀可用 `WINEPREFIX` 环境变量指定）
+> -  **macOS**：`~/Library/Application Support/VRCX/VRCX.sqlite3`
 >
 > 若自动探测失败，Agent 可让用户提供数据库路径手动指定：`node migrate-vrcx0.mjs <VRCX数据库路径> <userId>`。
 

--- a/analyze-db.mjs
+++ b/analyze-db.mjs
@@ -1,12 +1,19 @@
 /**
  * VRCX-0 数据库结构分析 v2
  * 用法: node analyze-db.mjs [VRCX数据库路径]
- * 默认路径按平台自动探测（Windows VRCX-0 默认安装位置）
+ * 默认路径按平台自动探测（规则见 core/vrcx-db-paths.js）
  * 引擎: better-sqlite3（只读打开，与 migrate-vrcx0.mjs 同步迁移，移除 sql.js）
  */
 import Database from 'better-sqlite3';
+import { findVrcxDb } from './core/vrcx-db-paths.js';
 
-const DB_PATH = process.argv[2] || 'C:/Users/<用户名>/AppData/Roaming/VRCX-0/VRCX-0.sqlite3';
+const DB_PATH = process.argv[2] || findVrcxDb();
+
+if (!DB_PATH) {
+  console.log('❌ 未找到 VRCX 数据库文件');
+  console.log('   请提供正确的数据库路径: node analyze-db.mjs <VRCX数据库路径>');
+  process.exit(1);
+}
 
 async function main() {
   const db = new Database(DB_PATH, { readonly: true, fileMustExist: true });

--- a/core/vrcx-db-paths.js
+++ b/core/vrcx-db-paths.js
@@ -1,0 +1,62 @@
+/**
+ * VRCX 数据库路径探测（跨平台）
+ *
+ * 供 migrate-vrcx0.mjs（数据迁移）与 analyze-db.mjs（结构分析）等工具复用，
+ * 避免平台路径逻辑在多处重复。
+ *
+ * 探测规则（按平台）:
+ *   Windows: %USERPROFILE%\AppData\Roaming\VRCX[(-0)]\VRCX[(-0)].sqlite3
+ *   macOS:   ~/Library/Application Support/VRCX/VRCX.sqlite3
+ *   Linux:   ~/.config/VRCX/VRCX.sqlite3（原生 Electron 版）
+ *            ~/.wine/drive_c/users/<user>/AppData/Roaming/VRCX/VRCX.sqlite3
+ *            （Wine 运行 Windows 版；WINEPREFIX 环境变量可覆盖默认前缀 ~/.wine）
+ */
+import { existsSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+export function candidateVrcxDbPaths() {
+  const home = os.homedir();
+  const paths = [];
+  const addHome = (...segs) => paths.push(path.join(home, ...segs));
+
+  if (process.platform === 'win32') {
+    addHome('AppData', 'Roaming', 'VRCX', 'VRCX.sqlite3');
+    addHome('AppData', 'Roaming', 'VRCX-0', 'VRCX-0.sqlite3');
+  } else if (process.platform === 'darwin') {
+    addHome('Library', 'Application Support', 'VRCX', 'VRCX.sqlite3');
+  } else {
+    // Linux 及其他类 Unix
+    // 原生 Electron 版 VRCX 使用 XDG 配置目录（.NET ApplicationData → ~/.config）
+    const configHome = process.env.XDG_CONFIG_HOME || path.join(home, '.config');
+    paths.push(path.join(configHome, 'VRCX', 'VRCX.sqlite3'));
+    paths.push(path.join(configHome, 'VRCX-0', 'VRCX-0.sqlite3'));
+
+    // Wine 运行 Windows 版 VRCX（WINEPREFIX 可覆盖，默认 ~/.wine）
+    const prefixes = [process.env.WINEPREFIX, path.join(home, '.wine')].filter(Boolean);
+    for (const prefix of prefixes) {
+      const usersDir = path.join(prefix, 'drive_c', 'users');
+      let users = [];
+      try {
+        users = readdirSync(usersDir, { withFileTypes: true })
+          .filter((e) => e.isDirectory())
+          .map((e) => e.name);
+      } catch {
+        // 目录不存在则跳过
+      }
+      for (const user of users) {
+        paths.push(path.join(usersDir, user, 'AppData', 'Roaming', 'VRCX', 'VRCX.sqlite3'));
+        paths.push(path.join(usersDir, user, 'AppData', 'Roaming', 'VRCX-0', 'VRCX-0.sqlite3'));
+      }
+    }
+  }
+  return paths;
+}
+
+// 返回第一个实际存在的候选路径；都没有则返回 null
+export function findVrcxDb() {
+  for (const p of candidateVrcxDbPaths()) {
+    if (existsSync(p)) return p;
+  }
+  return null;
+}

--- a/migrate-vrcx0.mjs
+++ b/migrate-vrcx0.mjs
@@ -4,10 +4,16 @@
  * 从 VRCX SQLite 数据库导入历史数据到新系统
  *
  * 使用:
- *   自动模式:  node migrate-vrcx0.mjs                                   （自动探测数据库路径 + userId）
+ *   自动模式:  node migrate-vrcx0.mjs                                   （按平台自动探测数据库路径 + userId）
  *   手动模式:  node migrate-vrcx0.mjs <VRCX数据库路径> <userId>
  *   自定义目标: node migrate-vrcx0.mjs --db <目标数据库路径>             （默认: ./vrc-monitor.sqlite3）
  *   跳过检测:  node migrate-vrcx0.mjs --force                            （服务运行时强制迁移，风险自负）
+ *
+ * 数据库自动探测（跨平台）:
+ *   Windows: %USERPROFILE%\AppData\Roaming\VRCX[(-0)]\VRCX[(-0)].sqlite3
+ *   macOS:   ~/Library/Application Support/VRCX/VRCX.sqlite3
+ *   Linux:   ~/.config/VRCX/VRCX.sqlite3（原生 Electron 版）
+ *            ~/.wine/drive_c/users/<user>/AppData/Roaming/VRCX/VRCX.sqlite3（Wine 运行 Windows 版，支持 WINEPREFIX 覆盖）
  *
  * ⚠️ 引擎说明：v1.1.0 起改用 better-sqlite3（流式迁移 + 事务提交），
  *    不再整文件重写数据库（旧版 sql.js 的 export() 全量写出是 SQLITE_CORRUPT 根因）。
@@ -24,7 +30,7 @@ import { existsSync, rmSync } from 'node:fs';
 import net from 'node:net';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import path from 'node:path';
-import os from 'node:os';
+import { candidateVrcxDbPaths, findVrcxDb } from './core/vrcx-db-paths.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -72,23 +78,21 @@ const _args0 = parseArgs(process.argv);
 const MONITOR_DB = _args0.db ? path.resolve(_args0.db) : path.join(__dirname, 'vrc-monitor.sqlite3');
 const DDL_PATH = path.join(__dirname, 'core', 'init-db.sql');
 
-// ── 数据库路径解析（优先级：命令行参数 > 新版默认 > 旧版兜底）──
+// ── 数据库路径解析（优先级：命令行参数 > 按平台自动探测，见 core/vrcx-db-paths.js）──
 function resolve_vrcx0_db(positional) {
   // 1. 命令行显式指定
   if (positional[0]) return positional[0];
 
-  // 2. 新版 VRCX 默认路径
-  const newPath = path.join(os.homedir(), 'AppData', 'Roaming', 'VRCX', 'VRCX.sqlite3');
-  if (existsSync(newPath)) return newPath;
+  // 2. 按平台自动探测
+  const detected = findVrcxDb();
+  if (detected) return detected;
 
-  // 3. 旧版 VRCX-0 兜底路径
-  const oldPath = path.join(os.homedir(), 'AppData', 'Roaming', 'VRCX-0', 'VRCX-0.sqlite3');
-  if (existsSync(oldPath)) return oldPath;
-
-  // 4. 都找不到
+  // 3. 都找不到
   console.log('❌ 未找到 VRCX 数据库文件');
-  console.log(`   已尝试: ${newPath}`);
-  console.log(`            ${oldPath}`);
+  console.log('   已尝试:');
+  for (const p of candidateVrcxDbPaths()) {
+    console.log(`     ${p}`);
+  }
   console.log('   请提供正确的数据库路径: node migrate-vrcx0.mjs <VRCX数据库路径>');
   process.exit(1);
 }


### PR DESCRIPTION
**需求来源**：使用者提出需求——迁移脚本仅支持 Windows 路径，在 Linux 上无法自动定位 VRCX 数据库。

**实现方式**：
- 新增 `core/vrcx-db-paths.js` 共享探测模块，migrate-vrcx0.mjs / analyze-db.mjs 复用避免逻辑重复
- Windows 路径不变；Linux 支持原生 Electron 版（`~/.config/VRCX`，兼容 `XDG_CONFIG_HOME`）与 Wine 运行 Windows 版（`~/.wine/drive_c/users/<user>/...`，`WINEPREFIX` 可覆盖）
- macOS 补全（`~/Library/Application Support/VRCX/VRCX.sqlite3`）
- 未找到数据库时列出按平台生成的候选路径
- analyze-db.mjs 移除写死的 Windows 占位路径
- AGENTS.md 数据库位置文档同步为跨平台说明

**验证过程与结果**：
- fake HOME + 模拟 VRCX 库实测：原生 `~/.config` 路径、Wine 路径、WINEPREFIX 覆盖三场景自动探测并迁移成功，`PRAGMA integrity_check` ok
- 幂等重跑不重复插入；未找到时的候选路径提示正确
- `node --check` 全部通过；`scripts/check-doc-drift.py` 退出码 0 无漂移