### PR TITLE
feat(service): 新增 Linux systemd 用户服务托管（service-linux/）

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,7 +91,7 @@
 - `VRC_MONITOR_NODE`：指向 Node.js 可执行文件路径。若不设置，自动从 PATH 查找 `node`。
 - `VRC_MONITOR_DB_PATH`：SQLite 数据库文件路径（默认 `<仓库>/vrc-monitor.sqlite3`）。可将数据库迁移到任意位置（如独立数据盘），配合常驻服务使用。
 - `VRC_MONITOR_BACKUP_DIR`：自动备份目录（默认 `<仓库>/backups`）。
-- `VRC_MONITOR_LOG_DIR`：常驻服务脚本的日志 / 修复记录目录（默认 `<仓库>/service-logs`，仅 `service-windows/` 脚本使用）。
+- `VRC_MONITOR_LOG_DIR`：常驻服务脚本的日志 / 修复记录目录（默认 `<仓库>/service-logs`，仅 `service-windows/` 脚本使用；Linux systemd 方案日志走 journald，无需设置）。
 - `VRC_MONITOR_PYTHON`：执行 fetch-otp.py 的 Python 解释器路径（默认 PATH 中的 `python`）。以计划任务 / systemd / 容器等方式运行且 PATH 中无 python 时必须设置，否则 OTP 自动登录失败会陷入重试循环（每次循环 VRChat 都会重新发送验证码邮件）。**路径含空格无需自带引号**（如 `C:\Program Files\Python311\python.exe`），脚本执行时会自动加引号。
 
 ### 3. 启动服务
@@ -124,7 +124,7 @@ hermes plugins enable vrc-monitor
 
 插件提供 `vrc_status` / `vrc_start` / `vrc_stop` / `vrc_restart` 工具，并在每次 Hermes 会话开始时自动拉起服务（on_session_start 钩子）。
 
-> **平台限制**：插件当前仅支持 Windows（`plugin.yaml` 中 `platforms: [windows]`）。macOS / Linux 用户需手动执行 `node start-monitor.js` 启动服务，或等待插件跨平台支持。Node.js 服务本身是跨平台的，仅 Hermes 插件托管层有此限制。
+> **平台限制**：插件当前仅支持 Windows（`plugin.yaml` 中 `platforms: [windows]`）。Linux 用户可用 `service-linux/`（systemd 用户服务，`bash service-linux/setup-linux.sh`）托管常驻，macOS 用户需手动执行 `node start-monitor.js` 启动服务，或等待插件跨平台支持。Node.js 服务本身是跨平台的，仅 Hermes 插件托管层有此限制。
 
 > 注意：`dashboard/` 子目录（manifest.json + plugin_api.py）是桌面插件和 `hermes dashboard` 的后端 API，复制时**不能遗漏**，否则桌面端「配置」功能不可用。
 >
@@ -201,7 +201,8 @@ cp -r skills/review-workflow "$HERMES_HOME/skills/"
 | 查看服务状态 | Hermes 工具 `vrc_status` 或桌面插件面板 |
 | 配置账号 | 桌面插件「配置」弹窗，或编辑 `credentials.json` |
 | 重启服务 | Hermes 工具 `vrc_restart` |
-| 常驻服务（开机自启 + 崩溃自愈 + 每日修复报告） | `service-windows\setup-windows.cmd`（Windows；详见 `service-windows/README.md`） |
+| 常驻服务（Windows：开机自启 + 崩溃自愈 + 每日修复报告） | `service-windows\setup-windows.cmd`（详见 `service-windows/README.md`） |
+| 常驻服务（Linux：systemd 用户服务，开机自启 + 崩溃自愈 + journal 日志） | `bash service-linux/setup-linux.sh`（详见 `service-linux/README.md`） |
 | 迁移 VRCX 数据 | `node migrate-vrcx0.mjs`（better-sqlite3 引擎，运行中迁移安全但仍建议先停服务；检测到服务运行会要求 `--force`；**可重复执行**——v1.2.0 起幂等，自动跳过已迁移记录，旧数据需 `--force` 重插，见 PR #14）；完成后 `node start-monitor.js` |
 
 ## X 博主世界推荐追踪

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@
 | [ARCHITECTURE.md](./ARCHITECTURE.md) | 系统架构：数据流、模块职责、依赖关系 | 理解代码结构 |
 | [docs/history/](./docs/history/INDEX.md) | 项目演进记录：里程碑时间线、每月发布/PR 与演进意义 | 新 Agent 上手先读 |
 | [service-windows/](./service-windows/README.md) | Windows 开机自启 + 崩溃自愈 + 每日修复报告（一键脚本） | Windows 常驻运行 |
+| [service-linux/](./service-linux/README.md) | Linux systemd 用户服务：开机自启 + 崩溃自愈 + journal 日志（一键脚本） | Linux 常驻运行 |
 
 **MCP 工具**：服务通过 MCP 暴露工具，覆盖好友查询、社交互动、媒体管理、群组操作、世界推荐、素材检索等能力域。**完整工具清单（全部工具）统一登记在 [skills/vrc-monitor-agent/SKILL.md](./skills/vrc-monitor-agent/SKILL.md)「MCP 工具」章节**，Agent 照此调用。其余 skill 为各能力域的工作流补充（不重复登记工具）：`vrchat-social-queries`（社交域：在线五要素/同屏/规律/昵称）、`vrchat-world-queries`（世界域：待逛/推荐/情报挖掘）、`vrchat-group-queries`（群组域：查询/公告分诊）、`booth-query-display`（BOOTH 检索/展示格式）、`vrchat-assistant-development`（开发规范）、`review-workflow`（审核工作流：PR/issue 审核、端到端实测、多轮复核、协作审核）。
 

--- a/docs/history/2026-08.md
+++ b/docs/history/2026-08.md
@@ -414,13 +414,14 @@
 
 **演进意义**：世界查询补齐「按作者」维度——此前只有按名字/热度/主题找图，没有「这个作者还做过什么」的聚合视图（作者维度对 Agent 的加权重/追更工作流是前置能力）；确立 **基础工具拆分优于组合魔法** 模式：用户诉求是「给当前作者全部图加权」，实现拆成两个可复用查询工具而非一次性批量标记，Agent 自由组合；修复 upsertWorld 不写 author_id 揭示「缓存缺字段」是关系链断裂的隐蔽根因。
 
-## 2026-08-18 · 新 PR：Linux systemd 用户服务托管（PR #42 @Menaed，OPEN，补记上次扫描遗漏）
+## 2026-08-18 · feat: Linux systemd 用户服务托管（service-linux/，PR #42 @Menaed，已合并）
 
-- `#42` (OPEN, 2026-08-18) feat(service): 新增 Linux systemd 用户服务托管（service-linux/）
+- `#42` (MERGED, 2026-08-18) feat(service): 新增 Linux systemd 用户服务托管（service-linux/）
   - 与 Windows 常驻服务（service-windows/，PR #30）平台互补：覆盖无头服务器 / VPS / NAS 场景
   - `vrc-monitor.service` systemd 用户单元（systemctl --user）：Restart=always + RestartSec=5 崩溃自愈（等价 Windows watchdog 轮询）、日志走 journald（符合 DEVELOPMENT.md §3.8 stdout 约定）、`%h` 路径占位零个人环境硬编码
-  - `setup-linux.sh` 一键安装/卸载：解析仓库路径与 node/python 可执行文件、烘焙 ExecStart、daemon-reload + enable --now；PATH 无 python 有 python3 时自动注入 VRC_MONITOR_PYTHON（规避 systemd 下 OTP 重试循环陷阱）；loginctl enable-linger 保证登出后继续运行（失败仅警告）
-  - 备注：本地工作区可见未跟踪 service-linux/ 目录（开发中）；合并后需同步演进记录状态标注
+  - `setup-linux.sh` 一键安装/卸载：解析仓库路径 / node / python 生成真实单元并 `enable --now` + `loginctl enable-linger`（登出后继续运行）；PATH 无 `python` 有 `python3` 时自动注入 `VRC_MONITOR_PYTHON=python3`，规避 OTP 登录重试循环陷阱；ExecStart 路径含空格时自动加引号（systemd 按空白拆分参数，nit 修复）
+  - 文档同步：AGENTS.md 常用操作表拆分 Windows/Linux 两行、插件平台限制说明补 Linux 方案；README 文档导航登记 `service-linux/`
+  - 审核修正记录：nixi-agent + sansuiUwU 双 Agent 审核 REQUEST_CHANGES（阻断项=docs/history 合并冲突）；rebase 后复验 APPROVE，两条 nit（ExecStart 空格引号、VRC_MONITOR_DIR 表述）已修复
 
 **演进意义**：平台托管矩阵补齐 Linux 侧——Windows 常驻服务（#30）确立 watchdog 模式后，Linux 用 systemd 用户服务实现等价能力（崩溃自愈/静默运行/日志可查），且天然规避 systemd 环境无 python 的 OTP 循环坑（自动注入 VRC_MONITOR_PYTHON，与 #38 的配置化约定衔接）；「Windows watchdog + Linux systemd」双方案让不同部署场景各取所需。
 

--- a/docs/history/2026-08.md
+++ b/docs/history/2026-08.md
@@ -414,9 +414,9 @@
 
 **演进意义**：世界查询补齐「按作者」维度——此前只有按名字/热度/主题找图，没有「这个作者还做过什么」的聚合视图（作者维度对 Agent 的加权重/追更工作流是前置能力）；确立 **基础工具拆分优于组合魔法** 模式：用户诉求是「给当前作者全部图加权」，实现拆成两个可复用查询工具而非一次性批量标记，Agent 自由组合；修复 upsertWorld 不写 author_id 揭示「缓存缺字段」是关系链断裂的隐蔽根因。
 
-## 2026-08-18 · feat: Linux systemd 用户服务托管（service-linux/，PR #42 @Menaed，已合并）
+## 2026-08-18 · feat: Linux systemd 用户服务托管（service-linux/，PR #42 @Menaed，OPEN）
 
-- `#42` (MERGED, 2026-08-18) feat(service): 新增 Linux systemd 用户服务托管（service-linux/）
+- `#42` (OPEN, 2026-08-18) feat(service): 新增 Linux systemd 用户服务托管（service-linux/）
   - 与 Windows 常驻服务（service-windows/，PR #30）平台互补：覆盖无头服务器 / VPS / NAS 场景
   - `vrc-monitor.service` systemd 用户单元（systemctl --user）：Restart=always + RestartSec=5 崩溃自愈（等价 Windows watchdog 轮询）、日志走 journald（符合 DEVELOPMENT.md §3.8 stdout 约定）、`%h` 路径占位零个人环境硬编码
   - `setup-linux.sh` 一键安装/卸载：解析仓库路径 / node / python 生成真实单元并 `enable --now` + `loginctl enable-linger`（登出后继续运行）；PATH 无 `python` 有 `python3` 时自动注入 `VRC_MONITOR_PYTHON=python3`，规避 OTP 登录重试循环陷阱；ExecStart 路径含空格时自动加引号（systemd 按空白拆分参数，nit 修复）

--- a/docs/history/2026-08.md
+++ b/docs/history/2026-08.md
@@ -419,7 +419,7 @@
 - `#42` (OPEN, 2026-08-18) feat(service): 新增 Linux systemd 用户服务托管（service-linux/）
   - 与 Windows 常驻服务（service-windows/，PR #30）平台互补：覆盖无头服务器 / VPS / NAS 场景
   - `vrc-monitor.service` systemd 用户单元（systemctl --user）：Restart=always + RestartSec=5 崩溃自愈（等价 Windows watchdog 轮询）、日志走 journald（符合 DEVELOPMENT.md §3.8 stdout 约定）、`%h` 路径占位零个人环境硬编码
-  - `setup-linux.sh` 一键安装/卸载：解析仓库路径 / node / python 生成真实单元并 `enable --now` + `loginctl enable-linger`（登出后继续运行）；PATH 无 `python` 有 `python3` 时自动注入 `VRC_MONITOR_PYTHON=python3`，规避 OTP 登录重试循环陷阱；ExecStart 路径含空格时自动加引号（systemd 按空白拆分参数，nit 修复）
+  - `setup-linux.sh` 一键安装/卸载：解析仓库路径 / node / python 生成真实单元并 `enable --now` + `loginctl enable-linger`（登出后继续运行）；PATH 无 `python` 有 `python3` 时自动注入 `VRC_MONITOR_PYTHON=python3`，规避 OTP 登录重试循环陷阱；ExecStart 路径含空格时自动对含空格 token 加引号（systemd 按空白拆分参数，nit 修复）——env 模式（node 不在 PATH，`/usr/bin/env node`）保持两个 token 仅对路径加引号，避免整体被当单个可执行文件路径（审核边界项修复）
   - 文档同步：AGENTS.md 常用操作表拆分 Windows/Linux 两行、插件平台限制说明补 Linux 方案；README 文档导航登记 `service-linux/`
   - 审核修正记录：nixi-agent + sansuiUwU 双 Agent 审核 REQUEST_CHANGES（阻断项=docs/history 合并冲突）；rebase 后复验 APPROVE，两条 nit（ExecStart 空格引号、VRC_MONITOR_DIR 表述）已修复
 

--- a/service-linux/README.md
+++ b/service-linux/README.md
@@ -1,0 +1,125 @@
+# vrc-monitor 常驻服务（Linux）
+
+让 vrc-monitor 服务在 Linux 上**开机自启、崩溃自动重启、日志集中采集**，不需要人工干预，也不会因为终端关闭或 Hermes gateway 重启而中断记录。方案基于 **systemd 用户服务**（`systemctl --user`），无 GUI 依赖，适用于无头服务器 / VPS / NAS（glibc 发行版）。
+
+## 组件
+
+| 文件 | 作用 |
+|------|------|
+| `vrc-monitor.service` | systemd 用户单元模板：`Restart=always` 崩溃自愈 + journald 日志 + `%h` 路径占位 |
+| `setup-linux.sh` | 一键安装 / 卸载：解析仓库路径 / node / python 生成真实单元并 `enable --now`，开启 linger |
+| `README.md` | 本说明 |
+
+## 快速开始
+
+```bash
+bash service-linux/setup-linux.sh
+```
+
+脚本会自动：
+
+1. 解析仓库目录（脚本所在目录的上一级）与 `node` / `python` 可执行文件
+2. 由模板生成 `~/.config/systemd/user/vrc-monitor.service`（`%h/vrchat-assistant` → 实际仓库路径，node 路径烘焙进 `ExecStart`）
+3. `systemctl --user daemon-reload` + `enable --now`（立即启动 + 开机自启）
+4. `loginctl enable-linger`（**登出后服务继续运行**，无头服务器必需）
+
+> 前置条件：系统使用 systemd（glibc 发行版）。容器 / WSL 无 systemd 用户实例时不适用，可改用 Hermes 插件或手动 `node start-monitor.js`。
+
+## 手动安装（可选）
+
+仓库位于 `~/vrchat-assistant` 时，模板可直接使用：
+
+```bash
+mkdir -p ~/.config/systemd/user
+cp service-linux/vrc-monitor.service ~/.config/systemd/user/
+systemctl --user daemon-reload
+systemctl --user enable --now vrc-monitor
+loginctl enable-linger    # 登出后继续运行
+```
+
+## 环境变量配置
+
+服务读取的 `VRC_MONITOR_*` 环境变量（与 AGENTS.md 约定一致）。systemd 用户服务有两种配置方式：
+
+1. **编辑单元文件**：`systemctl --user edit vrc-monitor`（drop-in，推荐，升级仓库不会覆盖）
+2. **仓库根 `.env`**：`start-monitor.js` 启动时自动加载 `VRC_MONITOR_*` 变量（与手动启动行为一致）
+
+| 变量 | 默认值 | 说明 |
+|------|--------|------|
+| `VRC_MONITOR_DIR` | 由 `WorkingDirectory` 隐含 | 项目根目录（systemd 方案无需手动设置） |
+| `VRC_MONITOR_NODE` | 安装脚本烘焙的 node 路径 | node 可执行文件路径 |
+| `VRC_MONITOR_PYTHON` | PATH 中的 `python` | 执行 fetch-otp.py 的解释器。**systemd 用户服务 PATH 较精简，安装脚本检测到 PATH 无 `python` 时会自动注入 `python3` 路径**；若手动安装且 PATH 无 python，必须自行设置，否则 OTP 自动登录失败会陷入重试循环 |
+| `VRC_MONITOR_DB_PATH` | `<仓库>/vrc-monitor.sqlite3` | 数据库文件位置（可迁移到独立数据盘） |
+| `VRC_MONITOR_BACKUP_DIR` | `<仓库>/backups` | 自动备份目录 |
+| `HTTPS_PROXY` / `HTTP_PROXY` | 无 | 网络代理（服务自动直连 6s 失败后回退 WS 代理） |
+
+示例（drop-in）：
+
+```bash
+systemctl --user edit vrc-monitor
+```
+
+```ini
+[Service]
+Environment=VRC_MONITOR_PYTHON=/usr/bin/python3
+Environment=HTTPS_PROXY=http://127.0.0.1:7892
+Environment=VRC_MONITOR_DB_PATH=/data/vrc-monitor.sqlite3
+```
+
+## 与 Windows 方案的差异
+
+| 能力 | Windows（service-windows/） | Linux（本目录） |
+|------|----------------------------|-----------------|
+| 开机自启 | 计划任务 VrcMonLauncher（onlogon） | systemd 用户服务 + linger |
+| 崩溃自愈 | VrcMonWatchdog 每分钟轮询健康端点 | systemd `Restart=always`（进程退出 5s 后自动重启） |
+| 日志 | `service-logs/` 文件（`VRC_MONITOR_LOG_DIR`） | journald（`journalctl --user -u vrc-monitor`） |
+| 每日修复报告 | `vrcmon_daily_report.py`（昨天有修复才输出一行） | 可复用同一脚本（见下） |
+
+**每日修复报告（可选）**：`service-windows/vrcmon_daily_report.py` 是跨平台的（README 注明非 Windows 可用），用 cron 指向它即可，空输出时 cron 静默不投递：
+
+```bash
+# crontab: 每天 09:00
+0 9 * * * python3 <仓库>/service-windows/vrcmon_daily_report.py
+```
+
+> systemd 方案下崩溃自愈由 systemd 承担，`vrcmon_repairs.log` 通常不会有修复记录——报告主要面向 Windows watchdog 场景。
+
+## 常用命令
+
+| 操作 | 命令 |
+|------|------|
+| 查看状态 | `systemctl --user status vrc-monitor` |
+| 实时日志 | `journalctl --user -u vrc-monitor -f` |
+| 最近日志 | `journalctl --user -u vrc-monitor -n 100 --no-pager` |
+| 重启服务 | `systemctl --user restart vrc-monitor` |
+| 停止服务 | `systemctl --user stop vrc-monitor` |
+| 健康检查 | `curl http://127.0.0.1:8799/health` |
+
+## 卸载
+
+```bash
+bash service-linux/setup-linux.sh --uninstall
+```
+
+会停止服务并删除用户单元文件。如需同时关闭 linger（影响所有用户服务）：
+
+```bash
+loginctl disable-linger <用户名>
+```
+
+## 故障排查
+
+**Q: 服务启动后登录失败（OTP 一直重试）？**
+A: 大概率是 systemd 用户服务 PATH 中没有 python。用 `systemctl --user edit vrc-monitor` 添加 `Environment=VRC_MONITOR_PYTHON=/usr/bin/python3`（安装脚本已自动处理常见情况）。
+
+**Q: 登出后服务就停了？**
+A: 执行 `loginctl enable-linger` 让用户服务在无登录会话时继续运行。
+
+**Q: `systemctl --user` 报错不可达？**
+A: 无 systemd 用户实例（容器 / WSL / SSH 无会话）。在桌面会话中执行，或用 Hermes 插件 / 手动启动。
+
+**Q: 日志在哪里？**
+A: journald：`journalctl --user -u vrc-monitor -f`。无需也不应设置 `VRC_MONITOR_LOG_DIR`（那是 Windows 文件日志目录）。
+
+**Q: 服务反复崩溃后 systemd 停止重启了？**
+A: systemd 默认启动限制（10 秒内最多 5 次）防止配置错误时无限循环重启。确认配置无误后可用 drop-in 放宽：`systemctl --user edit vrc-monitor` 添加 `[Service]` 段 `StartLimitIntervalSec=0`，再 `systemctl --user daemon-reload`。

--- a/service-linux/README.md
+++ b/service-linux/README.md
@@ -19,7 +19,7 @@ bash service-linux/setup-linux.sh
 脚本会自动：
 
 1. 解析仓库目录（脚本所在目录的上一级）与 `node` / `python` 可执行文件
-2. 由模板生成 `~/.config/systemd/user/vrc-monitor.service`（`%h/vrchat-assistant` → 实际仓库路径，node 路径烘焙进 `ExecStart`）
+2. 由模板生成 `~/.config/systemd/user/vrc-monitor.service`（`%h/vrchat-assistant` → 实际仓库路径，node 路径烘焙进 `ExecStart`；仓库或 node 路径含空格时自动对 `ExecStart` 参数加引号，避免 systemd 按空白拆分截断）
 3. `systemctl --user daemon-reload` + `enable --now`（立即启动 + 开机自启）
 4. `loginctl enable-linger`（**登出后服务继续运行**，无头服务器必需）
 
@@ -46,7 +46,7 @@ loginctl enable-linger    # 登出后继续运行
 
 | 变量 | 默认值 | 说明 |
 |------|--------|------|
-| `VRC_MONITOR_DIR` | 由 `WorkingDirectory` 隐含 | 项目根目录（systemd 方案无需手动设置） |
+| `VRC_MONITOR_DIR` | `start-monitor.js` 基于自身脚本目录自动探测 | 项目根目录（systemd 方案无需手动设置） |
 | `VRC_MONITOR_NODE` | 安装脚本烘焙的 node 路径 | node 可执行文件路径 |
 | `VRC_MONITOR_PYTHON` | PATH 中的 `python` | 执行 fetch-otp.py 的解释器。**systemd 用户服务 PATH 较精简，安装脚本检测到 PATH 无 `python` 时会自动注入 `python3` 路径**；若手动安装且 PATH 无 python，必须自行设置，否则 OTP 自动登录失败会陷入重试循环 |
 | `VRC_MONITOR_DB_PATH` | `<仓库>/vrc-monitor.sqlite3` | 数据库文件位置（可迁移到独立数据盘） |

--- a/service-linux/README.md
+++ b/service-linux/README.md
@@ -19,7 +19,7 @@ bash service-linux/setup-linux.sh
 脚本会自动：
 
 1. 解析仓库目录（脚本所在目录的上一级）与 `node` / `python` 可执行文件
-2. 由模板生成 `~/.config/systemd/user/vrc-monitor.service`（`%h/vrchat-assistant` → 实际仓库路径，node 路径烘焙进 `ExecStart`；仓库或 node 路径含空格时自动对 `ExecStart` 参数加引号，避免 systemd 按空白拆分截断）
+2. 由模板生成 `~/.config/systemd/user/vrc-monitor.service`（`%h/vrchat-assistant` → 实际仓库路径，node 路径烘焙进 `ExecStart`；仓库或 node 路径含空格时自动对 `ExecStart` 含空格 token 加引号，避免 systemd 按空白拆分截断；node 不在 PATH 的 env 模式（`/usr/bin/env node`）保持两个 token，仅对仓库路径加引号）
 3. `systemctl --user daemon-reload` + `enable --now`（立即启动 + 开机自启）
 4. `loginctl enable-linger`（**登出后服务继续运行**，无头服务器必需）
 

--- a/service-linux/setup-linux.sh
+++ b/service-linux/setup-linux.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# ============================================================
+#  vrc-monitor 常驻服务一键设置（Linux systemd 用户服务）
+#  用法: bash service-linux/setup-linux.sh [--uninstall]
+#    - 默认安装：解析仓库路径 / node / python → 生成用户单元
+#      ~/.config/systemd/user/vrc-monitor.service → enable --now
+#    - --uninstall：停止并删除用户单元
+#  说明:
+#    - 崩溃自愈由 systemd Restart=always 提供（等价 Windows 方案 watchdog）
+#    - 日志走 journald（journalctl --user -u vrc-monitor -f）
+#    - loginctl enable-linger 保证登出后服务继续运行（无头服务器必需）
+#    - 单元模板 service-linux/vrc-monitor.service 用 %h 占位，
+#      本脚本安装时替换为实际仓库路径（不引入个人环境硬编码）
+# ============================================================
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+UNIT_NAME="vrc-monitor.service"
+UNIT_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"
+UNIT_FILE="$UNIT_DIR/$UNIT_NAME"
+TEMPLATE="$SCRIPT_DIR/$UNIT_NAME"
+
+usage() {
+  cat <<'EOF'
+用法: bash service-linux/setup-linux.sh [选项]
+选项:
+  --uninstall   停止并删除 vrc-monitor 用户服务（linger 需手动关闭）
+  -h, --help    显示本帮助
+
+默认（无选项）执行安装：
+  1) 解析仓库目录 / node / python 可执行文件
+  2) 由模板生成用户单元（替换 %h/vrchat-assistant 为实际路径）
+  3) systemctl --user daemon-reload && enable --now
+  4) loginctl enable-linger（登出后继续运行）
+EOF
+}
+
+case "${1:-}" in
+  -h|--help)
+    usage
+    exit 0
+    ;;
+  --uninstall)
+    if [[ ! -f "$UNIT_FILE" ]]; then
+      echo "[ok] 用户单元不存在（$UNIT_FILE），无需卸载"
+      exit 0
+    fi
+    systemctl --user disable --now "$UNIT_NAME" 2>/dev/null || true
+    rm -f "$UNIT_FILE"
+    systemctl --user daemon-reload
+    echo "[ok] 已卸载 $UNIT_NAME"
+    echo "     服务已停止，用户单元文件已删除。"
+    echo "     linger 如需关闭：loginctl disable-linger ${USER:-$(id -un)}"
+    exit 0
+    ;;
+  "")
+    ;;
+  *)
+    echo "[error] 未知参数: $1"
+    usage
+    exit 1
+    ;;
+esac
+
+# ── 前置检查：systemd 用户管理器可达 ──
+if ! command -v systemctl >/dev/null 2>&1; then
+  echo "[error] 未找到 systemctl（系统无 systemd，容器 / WSL 等环境不适用本方案）"
+  echo "       可改用 hermes 插件或手动执行 node start-monitor.js"
+  exit 1
+fi
+if ! systemctl --user show-environment >/dev/null 2>&1; then
+  echo "[error] systemd 用户管理器不可达。常见原因与解决："
+  echo "  - SSH / 无桌面会话：用户管理器未随会话启动，可用 loginctl enable-linger 常驻后重试"
+  echo "  - 容器 / WSL 无 systemd：本方案不适用，可改用 hermes 插件或手动启动"
+  exit 1
+fi
+
+# ── 解析 node / python（写入生成单元，规避 PATH 精简导致的坑）──
+NODE_BIN="$(command -v node || true)"
+PYTHON_BIN="$(command -v python || true)"
+PYTHON3_BIN="$(command -v python3 || true)"
+
+echo "[1/4] 仓库目录: $REPO_DIR"
+echo "      node:     ${NODE_BIN:-未找到（ExecStart 保留 /usr/bin/env node，需 systemd 环境 PATH 可解析）}"
+echo "      python:   ${PYTHON_BIN:-未找到} | python3: ${PYTHON3_BIN:-未找到}"
+
+# ── 生成单元文件（模板 → 烘焙真实路径；bash 参数替换为字面替换，无需转义）──
+unit="$(<"$TEMPLATE")"
+unit="${unit//'%h/vrchat-assistant'/$REPO_DIR}"
+if [[ -n "$NODE_BIN" ]]; then
+  unit="${unit//'/usr/bin/env node'/$NODE_BIN}"
+fi
+# PATH 无 python 但存在 python3：解除注释并注入 VRC_MONITOR_PYTHON，
+# 否则 OTP 自动登录失败会陷入重试循环（AGENTS.md 环境变量章节明确要求）
+if [[ -z "$PYTHON_BIN" && -n "$PYTHON3_BIN" ]]; then
+  unit="${unit//'# Environment=VRC_MONITOR_PYTHON=/usr/bin/python3'/"Environment=VRC_MONITOR_PYTHON=$PYTHON3_BIN"}"
+  echo "      → PATH 无 python，已注入 Environment=VRC_MONITOR_PYTHON=$PYTHON3_BIN"
+fi
+
+mkdir -p "$UNIT_DIR"
+printf '%s\n' "$unit" > "$UNIT_FILE"
+echo "[2/4] 已生成用户单元: $UNIT_FILE"
+
+# ── 注册并启动 ──
+systemctl --user daemon-reload
+systemctl --user enable --now "$UNIT_NAME"
+echo "[3/4] 已 enable --now $UNIT_NAME"
+
+# ── linger：登出后继续运行（无头服务器 / 监控常驻必需）──
+if loginctl enable-linger "${USER:-$(id -un)}" 2>/dev/null; then
+  echo "[4/4] 已启用 linger（登出后服务继续运行）"
+else
+  echo "[4/4] [warn] enable-linger 失败（无 logind / 容器环境），登出后服务会停止"
+  echo "      手动执行: loginctl enable-linger ${USER:-$(id -un)}"
+fi
+
+echo
+echo "完成。常用命令："
+echo "  查看状态:   systemctl --user status $UNIT_NAME"
+echo "  实时日志:   journalctl --user -u $UNIT_NAME -f"
+echo "  重启服务:   systemctl --user restart $UNIT_NAME"
+echo "  健康检查:   curl http://127.0.0.1:8799/health"
+echo "  卸载:       bash $SCRIPT_DIR/setup-linux.sh --uninstall"

--- a/service-linux/setup-linux.sh
+++ b/service-linux/setup-linux.sh
@@ -87,10 +87,20 @@ echo "      python:   ${PYTHON_BIN:-未找到} | python3: ${PYTHON3_BIN:-未找�
 
 # ── 生成单元文件（模板 → 烘焙真实路径；bash 参数替换为字面替换，无需转义）──
 unit="$(<"$TEMPLATE")"
-unit="${unit//'%h/vrchat-assistant'/$REPO_DIR}"
+# ExecStart 单独组装：node 与仓库路径含空格时 systemd 按空白拆分参数会截断，
+# 需对含空格 token 加引号（无空格时保持模板原样，便于阅读/排查）
 if [[ -n "$NODE_BIN" ]]; then
-  unit="${unit//'/usr/bin/env node'/$NODE_BIN}"
+  node_arg="$NODE_BIN"
+else
+  node_arg="/usr/bin/env node"
 fi
+main_arg="$REPO_DIR/start-monitor.js"
+if [[ "$NODE_BIN" == *" "* || "$REPO_DIR" == *" "* ]]; then
+  unit="${unit//'ExecStart=/usr/bin/env node %h/vrchat-assistant/start-monitor.js'/"ExecStart=\"$node_arg\" \"$main_arg\""}"
+else
+  unit="${unit//'ExecStart=/usr/bin/env node %h/vrchat-assistant/start-monitor.js'/"ExecStart=$node_arg $main_arg"}"
+fi
+unit="${unit//'%h/vrchat-assistant'/$REPO_DIR}"
 # PATH 无 python 但存在 python3：解除注释并注入 VRC_MONITOR_PYTHON，
 # 否则 OTP 自动登录失败会陷入重试循环（AGENTS.md 环境变量章节明确要求）
 if [[ -z "$PYTHON_BIN" && -n "$PYTHON3_BIN" ]]; then

--- a/service-linux/setup-linux.sh
+++ b/service-linux/setup-linux.sh
@@ -88,18 +88,24 @@ echo "      python:   ${PYTHON_BIN:-未找到} | python3: ${PYTHON3_BIN:-未找�
 # ── 生成单元文件（模板 → 烘焙真实路径；bash 参数替换为字面替换，无需转义）──
 unit="$(<"$TEMPLATE")"
 # ExecStart 单独组装：node 与仓库路径含空格时 systemd 按空白拆分参数会截断，
-# 需对含空格 token 加引号（无空格时保持模板原样，便于阅读/排查）
-if [[ -n "$NODE_BIN" ]]; then
-  node_arg="$NODE_BIN"
-else
-  node_arg="/usr/bin/env node"
-fi
+# 需对含空格 token 加引号（无空格时保持模板原样，便于阅读/排查）。
+# env 模式（node 不在 PATH）下 /usr/bin/env node 是两个独立 token，
+# 只能对路径加引号，绝不能整体加引号（否则被当单个可执行文件路径导致启动失败）
 main_arg="$REPO_DIR/start-monitor.js"
-if [[ "$NODE_BIN" == *" "* || "$REPO_DIR" == *" "* ]]; then
-  unit="${unit//'ExecStart=/usr/bin/env node %h/vrchat-assistant/start-monitor.js'/"ExecStart=\"$node_arg\" \"$main_arg\""}"
+if [[ -n "$NODE_BIN" ]]; then
+  if [[ "$NODE_BIN" == *" "* || "$main_arg" == *" "* ]]; then
+    exec_line="ExecStart=\"$NODE_BIN\" \"$main_arg\""
+  else
+    exec_line="ExecStart=$NODE_BIN $main_arg"
+  fi
 else
-  unit="${unit//'ExecStart=/usr/bin/env node %h/vrchat-assistant/start-monitor.js'/"ExecStart=$node_arg $main_arg"}"
+  if [[ "$main_arg" == *" "* ]]; then
+    exec_line="ExecStart=/usr/bin/env node \"$main_arg\""
+  else
+    exec_line="ExecStart=/usr/bin/env node $main_arg"
+  fi
 fi
+unit="${unit//'ExecStart=/usr/bin/env node %h/vrchat-assistant/start-monitor.js'/$exec_line}"
 unit="${unit//'%h/vrchat-assistant'/$REPO_DIR}"
 # PATH 无 python 但存在 python3：解除注释并注入 VRC_MONITOR_PYTHON，
 # 否则 OTP 自动登录失败会陷入重试循环（AGENTS.md 环境变量章节明确要求）

--- a/service-linux/vrc-monitor.service
+++ b/service-linux/vrc-monitor.service
@@ -1,0 +1,44 @@
+# vrc-monitor 常驻服务（Linux systemd 用户服务）
+#
+# 安装（推荐）：bash service-linux/setup-linux.sh
+#   - 自动把模板中的路径占位符替换为实际仓库路径、解析 node / python 后
+#     生成 ~/.config/systemd/user/vrc-monitor.service，并 enable --now
+#
+# 手动安装（仓库位于 ~/vrchat-assistant 时可直接使用本模板）：
+#   mkdir -p ~/.config/systemd/user
+#   cp service-linux/vrc-monitor.service ~/.config/systemd/user/
+#   systemctl --user daemon-reload
+#   systemctl --user enable --now vrc-monitor
+#   loginctl enable-linger        # 登出后继续运行（无头服务器必需）
+#
+# 日志：journalctl --user -u vrc-monitor -f（服务日志走 stdout → journald）
+
+[Unit]
+Description=VRChat 好友监控服务 (vrc-monitor)
+Documentation=https://github.com/ggg123124/vrchat-assistant
+
+[Service]
+Type=simple
+WorkingDirectory=%h/vrchat-assistant
+ExecStart=/usr/bin/env node %h/vrchat-assistant/start-monitor.js
+# 崩溃自愈：进程异常退出后 5 秒自动重启（等价 Windows 方案的 watchdog）
+Restart=always
+RestartSec=5
+# 日志采集走 journald（符合开发规范「日志走 stdout」约定）
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=vrc-monitor
+# ---- 可选环境变量（按需取消注释；或用 systemctl --user edit vrc-monitor 写 drop-in）----
+# OTP 自动登录需要 python 解释器。systemd 用户服务的 PATH 较精简，
+# 若 PATH 中找不到 python（只有 python3 等），必须指定解释器，
+# 否则 OTP 自动登录失败会陷入重试循环（每次循环 VRChat 都会重发验证码邮件）：
+# Environment=VRC_MONITOR_PYTHON=/usr/bin/python3
+# 网络代理（如需要）：
+# Environment=HTTPS_PROXY=http://127.0.0.1:7892
+# Environment=HTTP_PROXY=http://127.0.0.1:7892
+# 数据目录可迁移到独立数据盘（默认在仓库内）：
+# Environment=VRC_MONITOR_DB_PATH=/data/vrc-monitor.sqlite3
+# Environment=VRC_MONITOR_BACKUP_DIR=/data/vrc-monitor-backups
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
## 需求来源

使用者提出：为仓库添加 systemd 用户服务文件，用于 Linux 进程托管（常驻运行），与现有的 Windows 托管方案（`service-windows/`）形成平台互补，覆盖无头服务器 / VPS / NAS 场景。

## 实现方式

新增 `service-linux/` 目录，提供 Linux systemd **用户服务**（`systemctl --user`）托管方案：

- **`vrc-monitor.service`**（systemd 用户单元模板）
  - `Restart=always` + `RestartSec=5`：进程异常退出后自动重启，崩溃自愈由 systemd 承担（等价 Windows 方案的 watchdog 轮询）
  - `StandardOutput/StandardError=journal`：日志走 journald（`journalctl --user -u vrc-monitor -f`），符合 DEVELOPMENT.md §3.8「日志走 stdout」约定，无需 `VRC_MONITOR_LOG_DIR`
  - `%h` 路径占位 + `WantedBy=default.target`：模板零个人环境硬编码，手动安装时直接可用（仓库位于 `~/vrchat-assistant`）
  - 服务已实现 SIGTERM 优雅关闭（`start-monitor.js`），`Type=simple` 默认信号即可干净收尾
- **`setup-linux.sh`**（一键安装 / 卸载）
  - 解析仓库实际路径 / `node` / `python` 可执行文件，由模板生成 `~/.config/systemd/user/vrc-monitor.service`（路径烘焙进 `ExecStart`）并 `daemon-reload` + `enable --now`
  - PATH 无 `python` 但存在 `python3` 时自动注入 `Environment=VRC_MONITOR_PYTHON=<python3>`，规避 AGENTS.md 明确警告的「systemd 下 PATH 无 python 导致 OTP 自动登录陷入重试循环」陷阱
  - `loginctl enable-linger` 保证登出后服务继续运行（无头服务器必需，失败仅警告不中断）；支持 `--uninstall` 干净卸载
- **`README.md`**：快速开始 / 手动安装 / 环境变量配置（含 drop-in 示例）/ 与 Windows 方案差异对比 / 常用命令 / 卸载 / 故障排查
- **文档同步**：AGENTS.md 常用操作表拆分 Windows / Linux 两行、Hermes 插件平台限制说明补 Linux 托管方式、`VRC_MONITOR_LOG_DIR` 注明 Linux 走 journald；README 文档导航登记 `service-linux/`；docs/history 补演进记录

## 验证过程与结果

1. `bash -n service-linux/setup-linux.sh` 语法检查通过
2. 沙箱模拟安装（伪造 `systemctl` / `loginctl` 垫片 + 隔离 `XDG_CONFIG_HOME`）端到端验证，未触碰真实 systemd 环境：
   - 安装分支：`%h/vrchat-assistant` → 实际仓库路径、`node` 路径烘焙进 `ExecStart`、systemctl 调用顺序（show-environment → daemon-reload → enable --now → loginctl enable-linger）正确
   - PATH 无 `python`（仅 `python3`）分支：自动注入 `Environment=VRC_MONITOR_PYTHON=<python3>`；PATH 有 `python` 分支：保持注释不注入
   - `--uninstall` 分支：disable → 删除单元文件 → daemon-reload，无残留
3. `systemd-analyze verify --user` 对模板（`%h` 占位版）与生成件（烘焙路径版）均通过
4. `python scripts/check-doc-drift.py` 退出码 0，无文档漂移
5. 提交内容自查：无凭据 / 本机路径 / 个人账号信息残留（`credentials.json`、`auth_cookie.txt`、数据库均未入库）

> 说明：未在本机实际执行 `systemctl --user enable --now`（本机已有监控实例占用 8799 端口，避免与现有进程冲突），安装动作以沙箱垫片完成验证；真实机器上按 README 一键安装即可。
