### PR TITLE
fix(migrate): 迁移 VRCX gamelog_location 补全自己的位置历史，修复 get_companions 查不到迁移前同屏

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,7 @@
 | 好友备注 | `memos` | 好友昵称/备注文本 |
 | 世界缓存 | `cache_world` | 世界 ID、名称、作者、缩略图等 |
 | 位置变更 | `feed_gps` | 好友何时在哪个世界 |
+| 自己的位置历史 | `gamelog_location` | 本账号自己的位置历史（VRCX 游戏日志解析），迁移为 `user-location` 事件，供 `get_companions` 交叉匹配好友位置查同屏 |
 | 上下线记录 | `feed_online_offline` | 好友上线/下线时间及位置 |
 | Avatar 变更 | `feed_avatar` | 好友更换 Avatar 记录 |
 | 状态变更 | `feed_status` | 好友状态文本变更 |

--- a/migrate-vrcx0.mjs
+++ b/migrate-vrcx0.mjs
@@ -128,6 +128,7 @@ const stats = {
   feed_avatar: 0,
   feed_status: 0,
   feed_bio: 0,
+  gamelog_location: 0,
   memos: 0,
   friend_log_current: 0,
   cache_world: 0,
@@ -147,6 +148,14 @@ function worldIdFromLocation(location) {
   return idx > 0 ? location.slice(0, idx) : '';
 }
 
+// ── 用户前缀转标准 userId（补横线）──
+// VRCX 表名前缀是去掉横线的 userId（如 usr3a6252c9... → usr_3a6252c9-88e9-...）
+function userIdFromPrefix(prefix) {
+  const m = String(prefix).match(/^usr([0-9a-fA-F]{8})([0-9a-fA-F]{4})([0-9a-fA-F]{4})([0-9a-fA-F]{4})([0-9a-fA-F]{12})$/);
+  if (!m) return '';
+  return `usr_${m[1]}-${m[2]}-${m[3]}-${m[4]}-${m[5]}`;
+}
+
 // ── 幂等防重（Issue #13）──
 // events 表无主键/唯一约束，纯 INSERT 追加；重复执行迁移会全量重插历史。
 // 方案：迁移时把源记录 id 写入 content_json.vrcxId（带表前缀避免跨表 id 冲突），
@@ -157,6 +166,7 @@ const VRCX_ID_PREFIX = {
   feed_avatar: 'avatar',
   feed_status: 'status',
   feed_bio: 'bio',
+  gamelog_location: 'selfloc',
 };
 
 // 唯一索引：仅约束带 vrcxId 的迁移记录（实时采集数据无 vrcxId，不受影响）
@@ -443,6 +453,59 @@ async function main() {
   log(`   ✅ 迁移 ${count} 条位置变更`);
 
   // ═══════════════════════════════════════════
+  // 5.5 gamelog_location → events（用户自己的位置历史）
+  // ═══════════════════════════════════════════
+  // VRCX 的 gamelog_location 表记录的是本账号自己的位置历史（游戏日志解析），
+  // 事件类型 user-location，供 findCompanions 交叉匹配好友位置（查同屏）。
+  // 缺了这段迁移，get_companions 查自己只能看到迁移后实时采集的少量记录。
+  log('\n🐾 迁移自己的位置历史 (gamelog_location)...');
+  count = 0;
+  try {
+    const selfUserId = userIdFromPrefix(USER_PREFIX);
+    const rows = vrcx0.prepare(
+      `SELECT id, created_at, location, world_id, world_name, time, group_name
+       FROM gamelog_location ORDER BY created_at ASC`
+    ).all();
+    if (rows.length > 0 && selfUserId) {
+      const stmt = monitorDb.prepare(
+        `INSERT OR IGNORE INTO events (type, user_id, display_name, content_json, world_id, world_name, created_at, source)
+         VALUES ($type, $userId, $displayName, $contentJson, $worldId, $worldName, $createdAt, $source)`
+      );
+      const insertFn = (row) => {
+        const location = row.location || '';
+        const worldName = row.world_name || '';
+        const worldId = row.world_id || worldIdFromLocation(location);
+        stmt.run({
+          type: 'user-location',
+          userId: selfUserId,
+          displayName: '',
+          contentJson: JSON.stringify({
+            userId: selfUserId,
+            displayName: '',
+            location,
+            worldName,
+            time: row.time || 0,
+            groupName: row.group_name || '',
+            vrcxId: `${VRCX_ID_PREFIX.gamelog_location}:${row.id}`,
+          }),
+          worldId,
+          worldName,
+          createdAt: row.created_at || '',
+          source: 'migrate',
+        });
+      };
+      count = insertInBatches(monitorDb, rows, BATCH_SIZE, insertFn);
+      stats.gamelog_location = count;
+    } else if (!selfUserId) {
+      log(`   ⚠️ 无法从表前缀解析自己的 userId，跳过 gamelog_location 迁移`);
+    }
+  } catch (err) {
+    log(`   ⚠️ gamelog_location: ${err.message}`);
+  }
+  log(`   ✅ 迁移 ${count} 条自己的位置历史`);
+
+
+  // ═══════════════════════════════════════════
   // 6. feed_online_offline → events
   // ═══════════════════════════════════════════
   log('\n🔄 迁移上下线记录 (feed_online_offline)...');
@@ -665,6 +728,7 @@ async function main() {
   log('\n  备注迁移:');
   log(`  memos（好友昵称）            : ${stats.memos} 条`);
   log(`  cache_world（世界缓存）       : ${stats.cache_world} 个`);
+  log(`  gamelog_location（自己的位置） : ${stats.gamelog_location} 条`);
 
   log('\n✅ 数据迁移完成！');
   log(`   新数据库: ${MONITOR_DB}`);


### PR DESCRIPTION
## 需求来源

我的使用者在迁移 VRCX 历史数据后发现：`get_companions` 查询自己的历史同屏全为 0。经排查，`migrate-vrcx0.mjs` 只迁移了好友侧数据（`feed_*` 系列），漏掉了 VRCX 记录本账号自己位置的 `gamelog_location` 表，导致 `core/storage.js:findCompanions` 依赖的 `user-location` 事件在迁移前窗口没有数据。修复方案已在本地验证后，按 DEVELOPMENT.md §1 缺陷上报义务回馈上游（issue #46）。

## 实现方式

`migrate-vrcx0.mjs` 新增 gamelog_location 迁移段（位于 feed_gps 之后，编号 5.5）：

- `stats` 新增 `gamelog_location` 计数；`VRCX_ID_PREFIX` 新增 `gamelog_location: 'selfloc'`
- 新增工具函数 `userIdFromPrefix()`：VRCX 表名前缀（usr + 32 位 hex，无横线）转标准 `usr_xxx-xxx-...` 格式
- 读取 `gamelog_location`（id/created_at/location/world_id/world_name/time/group_name）→ 批量 INSERT OR IGNORE 为 `type='user-location'`、`user_id=自己`、`world_id=row.world_id`、content_json 含 location/worldName/time/groupName + vrcxId(`selfloc:<id>`)
- 沿用 `insertInBatches` 分批事务 + vrcxId 唯一索引，**幂等**（重复执行自动跳过）

文档同步：AGENTS.md 迁移表新增「自己的位置历史 | gamelog_location」一行。无 DB schema 变更。

## 验证过程与结果

- 在真实环境复跑迁移（服务运行中，`node migrate-vrcx0.mjs --force`）：`gamelog_location` 迁移 **1844 条**；复跑后 `user-location` 总数保持 1844（迁移）+ 3（实时）不变，`selfloc:*` vrcxId 1844 条全 distinct——幂等确认，无重复插入
- `PRAGMA integrity_check : ok`
- 迁移后实时调用 `get_companions`（近 7 天窗口）：返回 `userInstanceCount: 104`，同屏好友数据恢复，不再为空
- 文档漂移检查：`python scripts/check-doc-drift.py` 退出码 0，无漂移

Fixes #46
