### PR TITLE
fix(auth): 运行期 API 401 自动重登录，TOTP 账号免重启恢复

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -243,7 +243,12 @@ Agent 在配置、使用、维护本软件过程中，若发现原始代码存�
 
 ### TOTP（Authenticator 验证码）登录
 
-若 VRChat 账号启用了 **TOTP 两步验证**（Authenticator 应用），服务启动/重连时会进入 `needsTotp` 状态（`/health` 的 `auth.needsTotp` 为 `true`，或日志提示调用 `submit_totp`），此时：
+若 VRChat 账号启用了 **TOTP 两步验证**（Authenticator 应用），以下情况会进入 `needsTotp` 状态（`/health` 的 `auth.needsTotp` 为 `true`，或日志提示调用 `submit_totp`）：
+
+- **服务启动 / WS 重连**时：cookie 过期、自动重登录发现需要 2FA，且邮箱 OTP 不可用（未启用或抓取失败）；
+- **服务运行中 API 返回 401**（运行期 cookie 过期）时：服务检测到 401 会自动触发重新登录，若需要 TOTP 同样进入 `needsTotp` 状态——**无需重启服务**。
+
+此时：
 1. 服务已保留待验证的临时会话，**只差验证码**；
 2. Agent（或用户）打开 Authenticator 应用查看当前 6 位验证码；
 3. 调用 MCP 工具 `submit_totp { code: "123456" }` 完成登录，WebSocket 会自动重连上线。
@@ -251,7 +256,8 @@ Agent 在配置、使用、维护本软件过程中，若发现原始代码存�
 注意：
 - 账号**同时启用邮箱 OTP 与 TOTP** 时，服务优先走邮箱 OTP 自动抓取，仅在邮箱抓取失败时才兜底转为需要 TOTP 手动提交；
 - 账号**仅启用 TOTP** 时，服务不会尝试邮箱，直接等待 `submit_totp`；
-- 验证码每 30 秒变化，过期需重新获取；提交失败后临时会话保留，可再次提交。
+- 验证码每 30 秒变化，过期需重新获取；提交失败后临时会话保留，可再次提交；
+- 运行期 401 自动重登录失败（非 TOTP 原因，如网络/凭据错误）会冷却 60 秒再重试，不会高频刷认证接口。
 
 ### 代理说明
 

--- a/README.en.md
+++ b/README.en.md
@@ -68,7 +68,7 @@ A: Check that `imap_auth_code` in `credentials.json` is a correct IMAP authoriza
 A: The service supports TOTP: when `/health` returns `auth.needsTotp: true`, an agent can call the `submit_totp` MCP tool with the current 6-digit code to complete login. If both email OTP and TOTP are enabled, email OTP is preferred; TOTP-only accounts wait for manual submission.
 
 **Q: Do I need to handle expired cookies manually?**
-A: No. Service startup and WS reconnects automatically go through OTP login, and the valid cookie is persisted to `auth_cookie.txt`.
+A: No. Service startup and WS reconnects automatically go through OTP login, and the valid cookie is persisted to `auth_cookie.txt`. During runtime, when the API returns 401 (cookie expired), the service also auto-triggers re-login — if TOTP is required it enters `needsTotp` state, call `submit_totp` to complete, no restart needed.
 
 **Q: The database file is too big?**
 A: Normal. ~300K events ≈ 300+ MB. better-sqlite3 (WAL mode) reads on demand and never loads the whole DB into memory.

--- a/README.ja.md
+++ b/README.ja.md
@@ -68,7 +68,7 @@ A: `credentials.json` の `imap_auth_code` が正しい IMAP 認証コードか�
 A: サービスは TOTP に対応しています：`/health` が `auth.needsTotp: true` を返す場合、Agent は MCP ツール `submit_totp` で現在の 6 桁コードを送信してログインを完了できます。メール OTP と TOTP の両方を有効にしている場合はメール OTP が優先され、TOTP のみのアカウントは手動送信を待ちます。
 
 **Q: Cookie の期限切れは手動で対応が必要？**
-A: 不要です。サービス起動時と WS 再接続時に自動で OTP ログインを行い、有効な Cookie は `auth_cookie.txt` に自動保存されます。
+A: 不要です。サービス起動時と WS 再接続時に自動で OTP ログインを行い、有効な Cookie は `auth_cookie.txt` に自動保存されます。**実行中に** API が 401（Cookie 期限切れ）を返した場合も自動で再ログインを試みます。TOTP が必要な場合は `needsTotp` 状態になり、`submit_totp` を呼べば完了します（再起動不要）。
 
 **Q: データベースファイルが大きすぎる？**
 A: 正常です。約 30 万イベント ≈ 300+ MB。better-sqlite3（WAL モード）はオンデマンド読み込みで、DB 全体をメモリに載せません。

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ A: 检查 `credentials.json` 的 `imap_auth_code` 是否为正确的 IMAP 授权
 A: 服务支持 TOTP：健康检查 `/health` 返回 `auth.needsTotp: true` 时，Agent 可调用 MCP 工具 `submit_totp` 提交当前 6 位验证码完成登录。账号同时启用邮箱 OTP 时会优先自动走邮箱；仅启用 TOTP 时等待手动提交。
 
 **Q: cookie 过期了要手动处理吗？**
-A: 不需要。服务启动和 WS 重连都会自动走 OTP 取码登录，有效 cookie 自动落盘 `auth_cookie.txt`。
+A: 不需要。服务启动和 WS 重连都会自动走 OTP 取码登录，有效 cookie 自动落盘 `auth_cookie.txt`。**运行中** API 返回 401（cookie 过期）时服务也会自动触发重新登录——若需要 TOTP 会进入 `needsTotp` 状态，调用 `submit_totp` 即可完成，无需重启服务。
 
 **Q: 数据库文件太大？**
 A: 正常。约 30 万行事件 ≈ 300+ MB。better-sqlite3（WAL 模式）按需读取，不整库载入内存。

--- a/core/handlers/auth.js
+++ b/core/handlers/auth.js
@@ -16,7 +16,7 @@ export async function handleSubmitTotp({ code }) {
     throw new Error('TOTP 验证码应为 6 位数字');
   }
   if (!api.tempAuthCookie) {
-    throw new Error('当前没有待验证的 2FA 会话，请先触发重新登录（如重启服务）');
+    throw new Error('当前没有待验证的 2FA 会话：请先触发一次 API 调用（如 get_online_friends），服务检测到 401 会自动进入重登录等待');
   }
 
   try {

--- a/core/rpc-router.js
+++ b/core/rpc-router.js
@@ -451,6 +451,12 @@ export async function handleRpc(rpc, session, res) {
           result: { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] },
         }]);
       } catch (err) {
+        // 401 自动重认证后若需要 TOTP，_request 抛 needsTotp 错误：
+        // 在此同步 serverState，让 /health 与 submit_totp 流程感知待验证状态
+        if (err.needsTotp) {
+          ctx.serverState.needsTotp = true;
+          log('🔑 检测到需要 TOTP 验证码，请调用 submit_totp 完成登录');
+        }
         log(`❌ ${name} failed: ${err.message}`);
         sendError(res, id, err.message);
       }

--- a/skills/vrc-monitor-agent/SKILL.md
+++ b/skills/vrc-monitor-agent/SKILL.md
@@ -95,7 +95,7 @@ metadata:
 | `x_add_creator` | 添加要追踪的 X 博主（VRChat 世界推荐博主；`screen_name` 不带 @） |
 | `x_remove_creator` | 移除追踪的 X 博主 |
 | `x_worlds` | 查看已收录的推荐世界列表（调试用） |
-| `submit_totp` | **提交 TOTP 验证码**：账号启用 Authenticator 两步验证（`/health` 的 `auth.needsTotp: true`）时，提交当前 6 位验证码完成登录（`code` 必填；登录后 WS 自动重连） |
+| `submit_totp` | **提交 TOTP 验证码**：账号启用 Authenticator 两步验证（`/health` 的 `auth.needsTotp: true`）时，提交当前 6 位验证码完成登录（`code` 必填；登录后 WS 自动重连）。`needsTotp` 出现于：启动/重连需要 2FA 且邮箱 OTP 不可用，或**运行中 API 401 自动重登录需要 TOTP**（无需重启服务） |
 
 调用方式（HTTP SSE JSON-RPC）：
 

--- a/start-monitor.js
+++ b/start-monitor.js
@@ -178,6 +178,7 @@ async function main() {
     process.exit(1);
   }
   ctx.api = new VrchatApiClient(creds.email, creds.password);
+  ctx.api.setOtpFetcher(fetchOtpFromEmail);  // 401 自动重认证时复用邮箱 OTP 抓取
   ctx.api.loadCookieFromFile(COOKIE_FILE);
   try {
     const user = await ctx.api.ensureAuthWithAutoOtp(fetchOtpFromEmail);

--- a/vrchat-api.js
+++ b/vrchat-api.js
@@ -27,6 +27,14 @@ export class VrchatApiClient {
     this.pending2faTypes = [];      // 2FA types required by the pending login (e.g. ['emailOtp','totp'])
     this._cookiePath = '';
     this.#authLock = null;       // single-flight lock for ensureAuth / ensureAuthWithAutoOtp
+    this.otpFetcher = null;        // 注入邮箱 OTP 自动获取函数（用于 401 自动重认证）
+    this._reauthInFlight = false;  // 防止并发 401 重认证
+    this._reauthCooldownUntil = 0; // 非 TOTP 重认证失败后的冷却（防循环）
+  }
+
+  /** 注入邮箱 OTP 获取函数（start-monitor.js 启动时调用） */
+  setOtpFetcher(fn) {
+    this.otpFetcher = fn;
   }
 
   loadCookieFromFile(path) {
@@ -46,9 +54,88 @@ export class VrchatApiClient {
   }
 
   /**
-   * Make an HTTPS request with cookie
+   * Make an HTTPS request with cookie.
+   *
+   * 带 401 自动重认证：业务请求返回 401（cookie 过期）时自动尝试重新登录，
+   * 成功后重放原请求一次；若重新登录需要 TOTP，则抛 { needsTotp: true } 进入
+   * needsTotp 状态（tempAuthCookie 已保留，submit_totp 可直接完成登录）。
+   *
+   * 注意：认证端点自身（/auth/user、/auth、twofactorauth）不走此逻辑，
+   * 避免 ensureAuth / checkAuth 内部形成递归。
    */
-  _request(method, path, body = null, customCookies = null) {
+  async _request(method, path, body = null, customCookies = null) {
+    const res = await this._requestRaw(method, path, body, customCookies);
+    if (res.status === 401 && !customCookies && !this._isAuthEndpoint(path)) {
+      try {
+        const reauthed = await this._tryAutoReauth();
+        if (reauthed) {
+          return await this._requestRaw(method, path, body, customCookies);
+        }
+      } catch (err) {
+        if (err.needsTotp) {
+          // 保留 tempAuthCookie，抛 needsTotp 由 rpc-router 层设置 serverState.needsTotp
+          err.message = `API 登录已失效，需要 TOTP 验证码：请调用 submit_totp 提交当前验证码（${err.message}）`;
+          throw err;
+        }
+        // 其他重认证错误：不吞掉，向上抛
+        throw err;
+      }
+    }
+    return res;
+  }
+
+  /** 认证端点判断——避免 ensureAuth/checkAuth 内部递归触发重认证 */
+  _isAuthEndpoint(path) {
+    return path === '/auth' || path === '/auth/user' || path.startsWith('/auth/twofactorauth');
+  }
+
+  /**
+   * 401 后的自动重认证（single-flight + 冷却）。
+   * 返回 true=已重新登录；false=失败已冷却；抛 { needsTotp } = 需 TOTP 手动提交。
+   */
+  async _tryAutoReauth() {
+    if (this._reauthInFlight) return false;  // 已有重认证进行中，跳过本次
+    if (Date.now() < this._reauthCooldownUntil) return false;
+
+    this._reauthInFlight = true;
+    try {
+      console.log('[VRChat API] ⚠️ 请求返回 401，尝试自动重新登录...');
+      if (this.otpFetcher) {
+        await this.ensureAuthWithAutoOtp(this.otpFetcher);
+      } else {
+        // 无 otpFetcher（如测试/未注入场景）：仍解析 2FA 类型，
+        // 纯 TOTP 账号应进入 needsTotp 而非笼统 needsOtp
+        try {
+          await this.ensureAuth();
+        } catch (err) {
+          if (err.needsOtp) {
+            const types = this.pending2faTypes || [];
+            if (types.includes('totp')) {
+              const totpErr = new Error('账号启用 TOTP 两步验证，请调用 submit_totp 工具提交当前验证码');
+              totpErr.needsTotp = true;
+              throw totpErr;
+            }
+            this.requiresOtp = false;
+            this.tempAuthCookie = '';
+          }
+          throw err;
+        }
+      }
+      console.log('[VRChat API] ✅ 自动重新登录成功');
+      return true;
+    } catch (err) {
+      if (err.needsTotp) throw err;
+      // 非 TOTP 失败（网络/凭据错误等）：冷却 60s，避免高频重试
+      this._reauthCooldownUntil = Date.now() + 60_000;
+      console.error(`[VRChat API] ❌ 自动重新登录失败: ${err.message}`);
+      return false;
+    } finally {
+      this._reauthInFlight = false;
+    }
+  }
+
+  /** 底层原始请求（无 401 自动重认证逻辑） */
+  _requestRaw(method, path, body = null, customCookies = null) {
     return new Promise((resolve, reject) => {
       const url = new URL(API_BASE + path);
       const cookieStr = customCookies || (this.authCookie ? `auth=${this.authCookie}` : '');


### PR DESCRIPTION
## 需求来源

我的使用者报告（issue #51）：服务运行中 VRChat cookie 过期后所有 API 工具 401 失效，无自动重认证机制，必须重启服务才能恢复；TOTP 账号重启后还需重新提交验证码。使用者要求"掉登录后允许 TOTP 登录"。

## 实现方式

在 `VrchatApiClient._request` 层拦截 401，自动触发重新登录：

- **`vrchat-api.js`**：新增 `_requestRaw`（原 `_request` 逻辑）+ 带 401 拦截的新 `_request`。401 时调用 `_tryAutoReauth`：复用现有 `ensureAuthWithAutoOtp`（邮箱 OTP 优先，TOTP 兜底），single-flight 防止并发重认证，非 TOTP 失败冷却 60s 防循环。`_isAuthEndpoint` 排除 `/auth*` 端点避免 `ensureAuth`/`checkAuth` 内部递归。需要 TOTP 时抛 `{ needsTotp: true }` 并**保留 `tempAuthCookie`**，`submit_totp` 可直接完成登录。
- **`core/rpc-router.js`**：catch 层识别 `err.needsTotp` → 同步 `ctx.serverState.needsTotp = true`，让 `/health` 与 `submit_totp` 流程感知待验证状态。
- **`start-monitor.js`**：API client 注入 `setOtpFetcher(fetchOtpFromEmail)`，401 重认证复用邮箱 OTP 抓取。
- **`core/handlers/auth.js`**：`submit_totp` 无会话时的提示从"请重启服务"改为"触发一次 API 调用即可自动进入重登录等待"。
- 文档同步：AGENTS.md / README 中英日 / `skills/vrc-monitor-agent/SKILL.md`。

## 验证过程与结果

1. **语法**：`node --check` 全部通过（4 个改动 JS 文件）。
2. **回归**：`test-apis.mjs` 24 通过（2 失败为测试世界 ID 失效的预期 404，与本次改动无关）；`check-doc-drift.py` 无漂移。
3. **端到端**（独立测试进程，不干扰运行中服务）：
   - 篡改内存 cookie 模拟失效 → `_request` 触发 `[VRChat API] ⚠️ 请求返回 401，尝试自动重新登录...`
   - 账号需要 2FA → 抛 `needsTotp: true`，`tempAuthCookie` 保留（`submit_totp` 可用）
   - `loginWithTotp`（`submit_totp` 同路径）提交验证码 → 登录成功、cookie 刷新
   - 新 cookie 再次请求 → `200`，在线好友正常返回
4. **运行服务**：重启加载新代码后 `/health` 正常（authenticated + ws connected），`get_online_friends` 正常返回 68 人在线。

全程无需重启服务即可从 cookie 失效恢复。
