### PR TITLE
fix: favorite_world 的 favoriteId 传对象 ID 而非分组名/分组 ID

### DIFF
--- a/core/handlers/favorites.js
+++ b/core/handlers/favorites.js
@@ -3,6 +3,11 @@
  *
  * POST /favorites 把世界加入用户云端收藏夹分组。
  * 成功后写本地 world_cache.favorited = 1（供 recommend_worlds 反馈加权，免每次调 API 查收藏）。
+ *
+ * ⚠️ VRChat API 契约（官方文档 Add Favorite，2026-08 实测验证）：
+ *   - favoriteId 必须是被收藏对象本身的 ID（world 类型为 wrld_...），不是收藏分组 ID；
+ *     传分组名（worldsN）会被 400 拒绝（"favoriteId must be an ID"），传 fvgrp_ 分组 ID 会按对象 ID 校验失败。
+ *   - 分组通过 tags 数组指定（tags: ["worlds1"]），无 worldId 字段。
  */
 
 import { ctx, log } from '../server-context.js';
@@ -20,7 +25,7 @@ export async function handleFavoriteWorld({ worldId, tag }) {
     throw new Error(`tag must be one of ${FAVORITE_TAGS.join('/')} (got "${tag}")`);
   }
 
-  const body = { type: 'world', favoriteId: tag, tags: [tag], worldId };
+  const body = { type: 'world', favoriteId: worldId, tags: [tag] };
   const r = await api._request('POST', '/favorites', body);
   if (r.status >= 400) {
     // 透传 API 错误（如重复收藏同分组被拒），不崩溃

--- a/docs/history/2026-08.md
+++ b/docs/history/2026-08.md
@@ -423,3 +423,12 @@
   - 备注：本地工作区可见未跟踪 service-linux/ 目录（开发中）；合并后需同步演进记录状态标注
 
 **演进意义**：平台托管矩阵补齐 Linux 侧——Windows 常驻服务（#30）确立 watchdog 模式后，Linux 用 systemd 用户服务实现等价能力（崩溃自愈/静默运行/日志可查），且天然规避 systemd 环境无 python 的 OTP 循环坑（自动注入 VRC_MONITOR_PYTHON，与 #38 的配置化约定衔接）；「Windows watchdog + Linux systemd」双方案让不同部署场景各取所需。
+
+## 2026-08-19 · fix: favorite_world 请求体契约修正（favoriteId 传对象 ID，PR #55）
+
+- `c75c785` fix: favorite_world 的 favoriteId 传对象 ID 而非分组名/分组 ID（issue #54 实测报告驱动，PR #55）
+  - 修复前请求体 `{ type: 'world', favoriteId: tag, tags: [tag], worldId }` —— `favoriteId` 传分组名（worldsN）被 400 拒绝（`favoriteId must be an ID`），传 fvgrp_ 分组 ID 会按对象 ID 校验失败（`world fvgrp_... not found`）
+  - 修复后 `{ type: 'world', favoriteId: worldId, tags: [tag] }`——按官方 Add Favorite 文档：`favoriteId` 必须是被收藏对象本身的 ID（world 类型为 wrld_...），分组由 `tags` 数组指定，删除无效 `worldId` 字段
+  - 实测：`favorite_world {worldId: wrld_80a0ffdc-..., tag: 'worlds1'}` → 修复前 `favorited: false` + 400；修复后 `favorited: true`，本地 world_cache.favorited 标记写入
+
+**演进意义**：favorite_world 云端收藏工具上线后首次暴露的 API 契约错误——请求体把「收藏分组」（tags 语义）误当成 favoriteId，与官方 Add Favorite 文档不符；本次修正确立请求体契约边界：**favoriteId 恒为对象 ID、分组恒走 tags**，并在 favorites.js 头注释固化该契约（供后续维护者参考），收藏链路（推荐 → 收藏 → 反馈加权）从此可用。


### PR DESCRIPTION
## 需求来源

使用者提出「把推荐的拍照世界加入收藏」，调用 MCP `favorite_world` 时发现必定失败（`favorited: false`）。定位到上游代码 `core/handlers/favorites.js` 的请求体契约错误（见 issue #54），按仓库规范上报 issue + 修复 PR。

## 实现方式

`core/handlers/favorites.js` 请求体从

```js
{ type: 'world', favoriteId: tag, tags: [tag], worldId }
```

改为符合官方 Add Favorite 文档的

```js
{ type: 'world', favoriteId: worldId, tags: [tag] }
```

- `favoriteId` = 被收藏对象 ID（wrld_...）
- 分组由 `tags` 数组指定，删除无效的 `worldId` 字段
- 其余行为不变（失败透传 error、成功写本地 favorited 标记、日志）

## 验证过程与结果

在本地 fork 实际运行验证：

1. 修复前：`favorite_world {worldId: wrld_80a0ffdc-..., tag: 'worlds1'}` → `favorited: false` + `favoriteId must be an ID: 'worlds1'`（400）
2. 中间版本（fvgrp_ 解析）→ `world fvgrp_... not found`（404），确认 favoriteId 语义应为对象 ID
3. 修复后：同一调用 → `favorited: true`，displayName 正确返回；`node --check` 通过；服务 `/health` authenticated: true

Fixes #54