### PR TITLE
fix(auth): needsTotp 状态下 /health 与 get_server_status 仍报 authenticated:true，掩盖待验证状态 (#59)

### DIFF
--- a/core/handlers/misc.js
+++ b/core/handlers/misc.js
@@ -22,7 +22,9 @@ export function handleGetServerStatus() {
   return {
     status: 'running',
     startedAt: serverState.started,
-    authenticated: !!serverState.authUser,
+    // needsTotp 状态（运行期 401 需 TOTP）时账号并未真正登录，需报 authenticated:false（issue #59）
+    authenticated: !!serverState.authUser && !serverState.needsTotp,
+    needsTotp: serverState.needsTotp,
     user: serverState.authUser,
     dbEvents: storage.getStats().events,
     dbFriends: storage.getStats().friends,

--- a/core/http-server.js
+++ b/core/http-server.js
@@ -62,7 +62,9 @@ async function handleRequest(req, res) {
     const uptime = serverState.started ? Math.floor((Date.now() - serverState.started) / 1000) : 0;
     const status = {
       ok: true,
-      auth: serverState.authUser
+      // needsTotp 状态下账号并未真正登录（运行期 401 需 TOTP），即使 authUser 仍保留上次缓存，
+      // 也必须报 authenticated:false 并暴露 needsTotp，避免 /health 误报已认证（issue #59）
+      auth: serverState.authUser && !serverState.needsTotp
         ? { authenticated: true, user: serverState.authUser }
         : { authenticated: false, needsOtp: serverState.needsOtp, needsTotp: serverState.needsTotp },
       db: storage.getStats(),


### PR DESCRIPTION
## 需求来源

Issue #59：账号启用 TOTP 时，**运行期** API 返回 401、自动重认证需要 TOTP 验证码后，服务进入 `needsTotp` 待验证状态，但 `/health` 与 `get_server_status` 仍报 `authenticated: true`，且 `/health` 不暴露 `needsTotp` 字段。Agent 若只查这两处判断登录态会误以为一切正常，实际 API 调用才抛「需要 TOTP 验证码」。与文档承诺（`/health` 的 `auth.needsTotp: true` 时调用 submit_totp）不符。

## 实现方式

采用 issue「期望行为」中的备选方案：**让 `authenticated` 的计算考虑 `needsTotp`**（而非清空 `authUser`，避免破坏 `get_weekly_report` 等依赖 `authUser?.id` 的本地库查询）：

- `core/http-server.js` `/health`：`auth` 改为 `authUser && !needsTotp` 才报 `authenticated: true`；否则进入 `authenticated: false` 分支，暴露 `needsOtp`/`needsTotp`
- `core/handlers/misc.js` `get_server_status`：`authenticated` 改为 `!!authUser && !needsTotp`，并新增 `needsTotp` 字段

## 验证过程与结果

- `systemctl --user restart vrc-monitor.service` 重启服务加载新代码
- 正常认证态实测：`/health` 报 `authenticated: true`，`get_server_status` 报 `authenticated: true` + `needsTotp: false` ✓（未回归）
- `node --check core/http-server.js core/handlers/misc.js` 语法通过 ✓
- `python3 scripts/check-doc-drift.py` 退出码 0、无漂移 ✓（文档本就是正确预期，无改动）

进入 `needsTotp` 时两处将正确报 `authenticated: false` + `needsTotp: true`。