### PR TITLE
feat(mcp): 安全模式——VRC_MONITOR_SAFE_MODE=true 时自动移除破坏性工具

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# VRChat-Assistant 个人配置样板（复制为 .env 后按需修改；.env 已被 .gitignore 排除，不会入库）
+# 仅 VRC_MONITOR_* 前缀的变量会被 start-monitor.js 加载。
+
+# 安全模式：true 时自动移除全部破坏性 MCP 工具（删除好友/删照片/退群/拒好友请求等），
+# tools/list 不暴露 + tools/call 直接拦截，防止 Agent 误删数据。默认关闭（不设置或非 true）。
+# 被移除的工具清单见 core/safe-mode.js 的 DESTRUCTIVE_TOOLS。
+VRC_MONITOR_SAFE_MODE=true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,7 @@
 - `VRC_MONITOR_BACKUP_DIR`：自动备份目录（默认 `<仓库>/backups`）。
 - `VRC_MONITOR_LOG_DIR`：常驻服务脚本的日志 / 修复记录目录（默认 `<仓库>/service-logs`，仅 `service-windows/` 脚本使用；Linux systemd 方案日志走 journald，无需设置）。
 - `VRC_MONITOR_PYTHON`：执行 fetch-otp.py 的 Python 解释器路径（默认 PATH 中的 `python`）。以计划任务 / systemd / 容器等方式运行且 PATH 中无 python 时必须设置，否则 OTP 自动登录失败会陷入重试循环（每次循环 VRChat 都会重新发送验证码邮件）。**路径含空格无需自带引号**（如 `C:\Program Files\Python311\python.exe`），脚本执行时会自动加引号。
+- `VRC_MONITOR_SAFE_MODE`：**安全模式开关**（默认关闭）。设为 `true` 时，服务启动后自动移除全部破坏性 MCP 工具（删除好友 `remove_friend`、删除相册照片 `remove_print`、删除画廊图片 `remove_gallery_image`、移除好友收藏 `unfavorite_friend`、退出群组 `leave_group`、拒绝好友请求 `decline_friend_request`、隐藏通知 `hide_notification`、移出待逛列表 `remove_from_backlog`、移出关注名单 `remove_from_watchlist`、移除 X 博主 `x_remove_creator` 等）：`tools/list` 不再暴露这些工具，`tools/call` 直接拦截报错，防止 Agent 误删数据。可在仓库根 `.env` 中配置（推荐，已被 .gitignore 排除）。
 
 ### 3. 启动服务
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -55,6 +55,7 @@ VRChat WebSocket (wss://pipeline.vrchat.cloud)
 | `theme-config.js` | 51 | 主题关键词配置（sleep/chat/onsen/game/default 等）+ 正则编译 | `DEFAULT_THEME_CONFIG` / `getThemeRegex` |
 | `backup.js` | 73 | 数据库在线备份。better-sqlite3 `db.backup()` API，WAL 模式无需停机。保留最近 2 份，旧备份自动清理 | `backupDatabase()` 函数 |
 | `mcp-definitions.js` | 1056 | MCP 工具定义。name + description + inputSchema 纯数据，无运行时依赖 | `CUSTOM_TOOLS` 数组 |
+| `safe-mode.js` | 52 | 安全模式。`VRC_MONITOR_SAFE_MODE=true` 时从 `tools/list` 剔除并拦截 `tools/call` 破坏性工具（删除/移除/退出/清除类），防御误删 | `DESTRUCTIVE_TOOLS` / `isSafeModeEnabled` / `filterTools` / `assertToolAllowed` |
 | `server-context.js` | 66 | 共享上下文。可变 `ctx` 对象持有所有运行时状态（storage/api/rateLimiter/wsManager 等），`log()`、`parseLocation()`、watchlist 内存缓存管理 | `ctx` / `log` / `parseLocation` / `refreshWatchlistCache` / `invalidateWatchlistCache` |
 | `http-server.js` | 152 | HTTP 服务器 + SSE 端点。McpSession 管理、`sendSSE`/`sendError` 响应辅助、`/health` + `/mcp` 请求路由 | `createServer` / `sendSSE` / `sendError` |
 | `rpc-router.js` | 538 | RPC 分发。`handleRpc` 将 `tools/call` 映射到对应 handler，3 个内联 case（send_boop/send_invite/request_invite）直接访问 ctx.api | `handleRpc` |
@@ -110,6 +111,7 @@ start-monitor.js
   ├── core/mcp-definitions.js  (CUSTOM_TOOLS 纯数据)
   ├── core/http-server.js      (createServer, SSE 辅助)
   │     └── core/rpc-router.js (handleRpc)
+  │           ├── core/safe-mode.js（安全模式：tools/list 过滤 + tools/call 拦截）─┐
   │           ├── core/handlers/*（16 个文件，按功能域分拆）─┐
   │           └── core/notifier.js                          ├── server-context.js
   ├── core/otp-fetcher.js      （fetch-otp.py 调用）

--- a/core/rpc-router.js
+++ b/core/rpc-router.js
@@ -8,6 +8,7 @@
 import { ctx, log } from './server-context.js';
 import { notifier } from './notifier.js';
 import { CUSTOM_TOOLS } from './mcp-definitions.js';
+import { filterTools, assertToolAllowed } from './safe-mode.js';
 import { sendSSE, sendError } from './http-server.js';
 
 // Handler imports
@@ -174,7 +175,8 @@ export async function handleRpc(rpc, session, res) {
     case 'tools/list': {
       sendSSE(res, [{
         jsonrpc: '2.0', id,
-        result: { tools: CUSTOM_TOOLS },
+        // 安全模式开启时过滤掉破坏性工具（客户端拿不到 = 调用不了）
+        result: { tools: filterTools(CUSTOM_TOOLS) },
       }], session.id);
       break;
     }
@@ -182,6 +184,8 @@ export async function handleRpc(rpc, session, res) {
     case 'tools/call': {
       const { name, arguments: args } = params;
       try {
+        // 安全模式：破坏性工具直接拦截（纵深防御，即使客户端持有旧工具清单也执行不了）
+        assertToolAllowed(name);
         let result;
 
         switch (name) {

--- a/core/safe-mode.js
+++ b/core/safe-mode.js
@@ -1,0 +1,52 @@
+/**
+ * 安全模式 — 自动移除破坏性 MCP 工具
+ *
+ * 当配置开启（VRC_MONITOR_SAFE_MODE=true，.env 或环境变量）时：
+ *   - tools/list 不再对外暴露「删除/移除/退出/拒绝」类破坏性工具（客户端拿不到 = 调用不了）；
+ *   - tools/call 对破坏性工具直接拦截报错（纵深防御：即使客户端持有旧工具清单也执行不了）。
+ *
+ * 破坏性工具判定口径：工具的主作用是**不可逆地删除 / 移除 / 退出 / 清除**数据或关系
+ * （删除好友、删除相册照片、退出群组、拒绝好友请求等）。新增写工具时若符合该口径，
+ * 请同步加入 DESTRUCTIVE_TOOLS，否则安全模式会漏拦。
+ *
+ * 配置读取走 process.env（start-monitor.js 启动时已把 .env 的 VRC_MONITOR_* 加载进来），
+ * 每次调用实时求值，无状态、无缓存，开关只在进程启动时生效。
+ */
+
+// ── 破坏性工具清单（安全模式下被移除/拦截）──
+export const DESTRUCTIVE_TOOLS = [
+  'remove_friend',            // 删除好友（不可逆）
+  'remove_print',             // 删除相册照片（不可逆）
+  'remove_gallery_image',     // 删除画廊图片（不可逆）
+  'unfavorite_friend',        // 从收藏分组移除好友
+  'leave_group',              // 退出群组（移除成员身份）
+  'decline_friend_request',   // 拒绝好友请求（清除通知，不可逆）
+  'hide_notification',        // 隐藏/清除通知（旧 v1 hide 即删除）
+  'remove_from_backlog',      // 移出待逛列表（本地）
+  'remove_from_watchlist',    // 移出关注名单（本地）
+  'x_remove_creator',         // 移除追踪的 X 博主（本地配置）
+];
+
+// ── 开关判定：true / 1 / yes / on（大小写不敏感）→ 启用 ──
+export function isSafeModeEnabled() {
+  const v = String(process.env.VRC_MONITOR_SAFE_MODE || '').trim().toLowerCase();
+  return v === 'true' || v === '1' || v === 'yes' || v === 'on';
+}
+
+// ── 工具列表过滤（tools/list 用）：开启时剔除破坏性工具，关闭时原样返回 ──
+export function filterTools(tools) {
+  if (!isSafeModeEnabled()) return tools;
+  return tools.filter(t => !DESTRUCTIVE_TOOLS.includes(t.name));
+}
+
+// ── 调用拦截（tools/call 用）：开启时对破坏性工具抛错，关闭时放行 ──
+export function assertToolAllowed(name) {
+  if (isSafeModeEnabled() && DESTRUCTIVE_TOOLS.includes(name)) {
+    const err = new Error(
+      `🔒 安全模式已启用：${name} 属于破坏性工具（删除/移除类），已被禁用。` +
+      `如需使用，请在 .env 设置 VRC_MONITOR_SAFE_MODE=false 后重启服务。`
+    );
+    err.safeModeBlocked = true;
+    throw err;
+  }
+}

--- a/skills/vrc-monitor-agent/SKILL.md
+++ b/skills/vrc-monitor-agent/SKILL.md
@@ -120,6 +120,16 @@ curl -s http://127.0.0.1:8799/mcp -X POST \
 
 响应是 SSE 格式，取 `data:` 行，解析 `result.content[0].text` 为 JSON。
 
+## 安全模式（VRC_MONITOR_SAFE_MODE，2026-08-22 新增）
+
+> 在仓库根 `.env` 或环境变量设置 `VRC_MONITOR_SAFE_MODE=true` 并重启服务后，**全部破坏性工具会被自动移除**（`tools/list` 不再暴露 + `tools/call` 直接拦截），防止 Agent 误执行删除/移除类操作。默认关闭。
+
+被移除的破坏性工具（删除/移除/退出/清除类，完整清单见 `core/safe-mode.js` 的 `DESTRUCTIVE_TOOLS`）：
+
+`remove_friend`（删好友）、`remove_print`（删相册照片）、`remove_gallery_image`（删画廊图片）、`unfavorite_friend`（移除好友收藏）、`leave_group`（退群）、`decline_friend_request`（拒好友请求）、`hide_notification`（清除通知）、`remove_from_backlog`（移出待逛）、`remove_from_watchlist`（移出关注）、`x_remove_creator`（移除 X 博主）。
+
+安全模式下这些工具**在 tools/list 中根本不存在**——Agent 不要尝试调用（会收到拦截报错）。查询/推荐/加好友/加收藏/开房等非破坏性写工具不受影响。关闭安全模式：`.env` 中改回 `VRC_MONITOR_SAFE_MODE=false`（或删掉该行）并重启服务。
+
 ## 核心查询工作流 → 已按对象域拆分
 
 > **2026-08-16 起查询工作流按域拆分**（本总纲保留工具表唯一权威 + 通用陷阱）：

--- a/start-monitor.js
+++ b/start-monitor.js
@@ -13,6 +13,7 @@ import net from 'node:net';
 
 import { ctx, log, refreshWatchlistCache } from './core/server-context.js';
 import { CUSTOM_TOOLS } from './core/mcp-definitions.js';
+import { isSafeModeEnabled, filterTools, DESTRUCTIVE_TOOLS } from './core/safe-mode.js';
 import { Storage } from './core/storage.js';
 import { RateLimiter } from './core/rate-limiter.js';
 import { VrchatApiClient } from './vrchat-api.js';
@@ -146,6 +147,14 @@ async function main() {
   }
 
   ctx.serverState.started = new Date().toISOString();
+
+  // 0b. 安全模式（VRC_MONITOR_SAFE_MODE=true）：启动即剔除破坏性工具，tools/list 不暴露、tools/call 拦截
+  if (isSafeModeEnabled()) {
+    log('\n🔒 安全模式已启用（VRC_MONITOR_SAFE_MODE=true）');
+    log(`   已移除 ${DESTRUCTIVE_TOOLS.length} 个破坏性工具: ${DESTRUCTIVE_TOOLS.join(', ')}`);
+  } else {
+    log('\n🔓 安全模式未启用（VRC_MONITOR_SAFE_MODE 未设置或非 true）');
+  }
 
   // 1. 初始化数据库
   log('📦 初始化数据库...');
@@ -312,7 +321,7 @@ async function main() {
   server.listen(PORT, '127.0.0.1', () => {
     log(`\n🚀 MCP 服务运行在 http://127.0.0.1:${PORT}/mcp\n`);
     log('可用工具:');
-    for (const t of CUSTOM_TOOLS) {
+    for (const t of filterTools(CUSTOM_TOOLS)) {
       log(`  ${t.name} — ${t.description}`);
     }
     log(`\n健康检查: http://127.0.0.1:${PORT}/health`);

--- a/test-safe-mode.mjs
+++ b/test-safe-mode.mjs
@@ -1,0 +1,122 @@
+/**
+ * test-safe-mode.mjs — 安全模式（VRC_MONITOR_SAFE_MODE）功能验证
+ *
+ * 覆盖：
+ *   1. 单元：开关判定（true/1/yes/on 及大小写/缺省）
+ *   2. 单元：filterTools 过滤 / assertToolAllowed 拦截
+ *   3. 单元：DESTRUCTIVE_TOOLS 清单与 CUSTOM_TOOLS 无漂移（每个名字都存在）
+ *   4. 端到端（开启）：真实 HTTP 服务器 tools/list 不含破坏性工具、tools/call 拦截并报错、普通工具正常
+ *   5. 端到端（关闭）：tools/list 恢复全部工具
+ *
+ * 用法：node test-safe-mode.mjs
+ * 无需 VRChat 凭据 / 网络，可离线运行。退出码 0=全部通过。
+ */
+import assert from 'node:assert/strict';
+import { CUSTOM_TOOLS } from './core/mcp-definitions.js';
+import { DESTRUCTIVE_TOOLS, isSafeModeEnabled, filterTools, assertToolAllowed } from './core/safe-mode.js';
+import { createServer } from './core/http-server.js';
+import { ctx } from './core/server-context.js';
+import { RateLimiter } from './core/rate-limiter.js';
+
+let passed = 0;
+function ok(name) { passed++; console.log(`  ✅ ${name}`); }
+
+console.log('── 1. 开关判定 ──');
+{
+  const cases = [
+    ['true', true], ['TRUE', true], ['True', true],
+    ['1', true], ['yes', true], ['YES', true], ['on', true], [' ON ', true],
+    [undefined, false], ['', false], ['false', false], ['0', false], ['no', false], ['off', false], ['anything', false],
+  ];
+  for (const [v, expect] of cases) {
+    if (v === undefined) delete process.env.VRC_MONITOR_SAFE_MODE;
+    else process.env.VRC_MONITOR_SAFE_MODE = v;
+    assert.equal(isSafeModeEnabled(), expect, `VRC_MONITOR_SAFE_MODE=${JSON.stringify(v)}`);
+  }
+  ok(`${cases.length} 个取值组合判定正确`);
+}
+
+console.log('── 2. 单元：过滤与拦截 ──');
+{
+  // 关闭态：不过滤、不拦截
+  delete process.env.VRC_MONITOR_SAFE_MODE;
+  assert.equal(filterTools(CUSTOM_TOOLS), CUSTOM_TOOLS, '关闭态 filterTools 应原样返回');
+  assert.doesNotThrow(() => assertToolAllowed('remove_friend'), '关闭态不应拦截');
+  ok('关闭态：filterTools 原样返回、assertToolAllowed 放行');
+
+  // 开启态：过滤 + 拦截
+  process.env.VRC_MONITOR_SAFE_MODE = 'true';
+  const filtered = filterTools(CUSTOM_TOOLS);
+  const names = new Set(filtered.map(t => t.name));
+  assert.equal(filtered.length, CUSTOM_TOOLS.length - DESTRUCTIVE_TOOLS.length, '过滤数量不对');
+  for (const t of DESTRUCTIVE_TOOLS) {
+    assert.ok(!names.has(t), `破坏性工具 ${t} 不应出现在过滤后列表`);
+  }
+  assert.ok(names.has('get_online_friends') && names.has('favorite_world') && names.has('submit_totp'), '普通工具应保留');
+  assert.throws(() => assertToolAllowed('remove_friend'), (e) => e.safeModeBlocked === true, 'remove_friend 应被拦截');
+  assert.throws(() => assertToolAllowed('unfavorite_friend'), (e) => e.safeModeBlocked === true, 'unfavorite_friend 应被拦截');
+  assert.doesNotThrow(() => assertToolAllowed('get_online_friends'), '普通工具不应被拦截');
+  ok(`开启态：剔除 ${DESTRUCTIVE_TOOLS.length} 个破坏性工具（剩 ${filtered.length} 个），拦截生效`);
+}
+
+console.log('── 3. 单元：破坏性工具清单无漂移 ──');
+{
+  const allNames = new Set(CUSTOM_TOOLS.map(t => t.name));
+  const missing = DESTRUCTIVE_TOOLS.filter(t => !allNames.has(t));
+  assert.deepEqual(missing, [], `DESTRUCTIVE_TOOLS 含不存在的工具: ${missing.join(', ')}`);
+  ok(`DESTRUCTIVE_TOOLS 全部 ${DESTRUCTIVE_TOOLS.length} 个名字均存在于 CUSTOM_TOOLS`);
+}
+
+// ── 端到端：真实 HTTP 服务器（独立端口 8899，不碰运行中的 8799）──
+async function e2e(envValue, label, expectRemoved, port) {
+  console.log(`── 4/5. 端到端（${label}）──`);
+  if (envValue === undefined) delete process.env.VRC_MONITOR_SAFE_MODE;
+  else process.env.VRC_MONITOR_SAFE_MODE = envValue;
+
+  ctx.paths.PORT = port;
+  ctx.rateLimiter = new RateLimiter({ minInterval: 1 });
+  const server = createServer();
+  await new Promise((resolve) => server.listen(port, '127.0.0.1', resolve));
+
+  async function mcp(body) {
+    const res = await fetch(`http://127.0.0.1:${port}/mcp`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Connection: 'close' },
+      body: JSON.stringify(body),
+    });
+    const text = await res.text();
+    const dataLine = text.split('\n').find((l) => l.startsWith('data: '));
+    return JSON.parse(dataLine.slice(6));
+  }
+
+  try {
+    // tools/list
+    const listResp = await mcp({ jsonrpc: '2.0', id: 1, method: 'tools/list' });
+    const toolNames = new Set(listResp.result.tools.map(t => t.name));
+    for (const t of DESTRUCTIVE_TOOLS) {
+      assert.equal(toolNames.has(t), !expectRemoved, `${label}: tools/list 中 ${t} 可见性错误`);
+    }
+    assert.equal(toolNames.has('get_online_friends'), true, `${label}: 普通工具应始终可见`);
+    ok(`${label}: tools/list ${expectRemoved ? '已剔除' : '包含'}全部破坏性工具（共 ${listResp.result.tools.length} 个）`);
+
+    if (expectRemoved) {
+      // tools/call 拦截：破坏性工具 → JSON-RPC 错误
+      const blockedResp = await mcp({ jsonrpc: '2.0', id: 2, method: 'tools/call', params: { name: 'remove_friend', arguments: { displayName: 'x', confirm: true } } });
+      assert.ok(blockedResp.error, `${label}: remove_friend 应返回错误`);
+      assert.match(blockedResp.error.message, /安全模式/, `${label}: 错误信息应说明安全模式，实际: ${blockedResp.error.message}`);
+      ok(`${label}: tools/call remove_friend 被拦截（error.message 含「安全模式」）`);
+
+      // tools/call 正常工具仍可用
+      const okResp = await mcp({ jsonrpc: '2.0', id: 3, method: 'tools/call', params: { name: 'get_boop_emojis', arguments: {} } });
+      assert.ok(okResp.result?.content?.[0]?.text, `${label}: get_boop_emojis 应成功`);
+      ok(`${label}: tools/call get_boop_emojis 正常返回`);
+    }
+  } finally {
+    await new Promise((r) => server.close(r));
+  }
+}
+
+await e2e('true', '安全模式开启', true, 8899);
+await e2e(undefined, '安全模式关闭', false, 8898);
+
+console.log(`\n🎉 全部 ${passed} 项断言通过`);


### PR DESCRIPTION
## 需求来源

我的使用者提出：给 vrchat-assistant 添加「安全模式」——当配置开启时，自动移除删除好友、删除世界等破坏性 MCP 工具，防止 Agent 误删数据。这是使用者在日常使用中反复出现「担心 Agent 执行删除类操作」的诉求固化为功能。

## 实现方式

新增 `core/safe-mode.js`（纯数据 + 判定逻辑，无运行时依赖）：

- **`DESTRUCTIVE_TOOLS`**：破坏性工具清单，共 10 个（判定口径：主作用是**不可逆地删除 / 移除 / 退出 / 清除**数据或关系）：
  `remove_friend`（删好友）、`remove_print`（删相册照片）、`remove_gallery_image`（删画廊图片）、`unfavorite_friend`（移除好友收藏）、`leave_group`（退群）、`decline_friend_request`（拒好友请求）、`hide_notification`（清除通知）、`remove_from_backlog`（移出待逛列表）、`remove_from_watchlist`（移出关注名单）、`x_remove_creator`（移除 X 博主）。
  注：VRChat API 无「删除世界」端点，项目内最接近的世界删除语义是 `remove_from_backlog`，已包含。清单集中在模块内，新增删除类工具时同步登记即可，避免漏拦。
- **`isSafeModeEnabled()`**：读取 `VRC_MONITOR_SAFE_MODE`（`.env` 或环境变量），`true/1/yes/on`（大小写不敏感）视为启用，默认关闭。`.env` 由 `start-monitor.js` 启动时加载，与既有 `VRC_MONITOR_*` 配置体系一致。
- **`filterTools(tools)`**：`tools/list` 返回过滤后清单——安全模式下破坏性工具**根本不出现在工具列表**（客户端拿不到 = 调用不了）。
- **`assertToolAllowed(name)`**：`tools/call` 入口先拦截——即使客户端持有旧工具清单，调用破坏性工具也会收到明确报错（纵深防御）。

接入点：

- `core/rpc-router.js`：`tools/list` 走 `filterTools`；`tools/call` 的 try 块首行 `assertToolAllowed(name)`。
- `start-monitor.js`：启动日志明示安全模式状态与已移除的工具；启动时打印的「可用工具」清单同步用过滤后列表。
- 文档：AGENTS.md 环境变量登记、`skills/vrc-monitor-agent/SKILL.md` 新增「安全模式」章节、ARCHITECTURE.md 模块表与依赖图、新增 `.env.example` 样板。

## 验证过程与结果

- 新增 `test-safe-mode.mjs`，`node test-safe-mode.mjs` 8 项断言全过：
  1. 开关判定 15 个取值组合（true/TRUE/1/yes/on/缺省/false/0/任意值）正确；
  2. 关闭态 `filterTools` 原样返回、`assertToolAllowed` 放行；开启态剔除全部 10 个破坏性工具（91→81 个），普通工具（get_online_friends/favorite_world/submit_totp）保留；
  3. `DESTRUCTIVE_TOOLS` 与 `CUSTOM_TOOLS` 无漂移（清单里每个名字都存在）；
  4. 端到端（真实 HTTP 服务器，独立端口 8899/8898，不碰运行中的 8799）：开启时 `tools/list` 无破坏性工具、`tools/call remove_friend` 返回含「安全模式」的 JSON-RPC 错误、`tools/call get_boop_emojis` 正常；关闭时 `tools/list` 恢复全量。
- `node --check` 语法检查通过；`python3 scripts/check-doc-drift.py` 本 PR 相关检查项（工具清单完整/无数字残留/plugin.yaml 同步）全部通过。
- 注：`docs/history/2026-08.md` 的既有状态漂移（PR #74/#75/#77 标注 OPEN 但实际已 MERGED）为本 PR 无关的上游既有问题，不在本 PR 处理范围。
- 测试无需 VRChat 凭据 / 网络，可离线运行。
