### PR TITLE
fix(x-worlds): 引入 Playwright 浏览器抓取，修复 Nitter/SearchTimeline 2026 双源失效 (issue #82)

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -87,9 +87,15 @@ PR 由 AI Agent 编写提交（人类只提出需求、不直接编码）。以�
 
 - 端口、绑定地址、数据目录、Node 路径等运行参数应可通过环境变量覆盖。
 - 现状：端口（`start-monitor.js` 中硬编码 8799）与绑定地址（127.0.0.1）是已知限制，改造方向是环境变量可配置；已有 `VRC_MONITOR_DIR` / `VRC_MONITOR_NODE` 支持。**新增参数直接做成环境变量可配置，不要新增硬编码。**
-- X 博主抓取相关（`core/fetch-x-worlds.js`，双数据源降级）：
+- X 博主抓取相关（`core/fetch-x-worlds.js`，三通道降级）：
   - `VRC_MONITOR_X_SEARCH_QUERY_ID`：X SearchTimeline GraphQL 的 queryId（默认 `hyPfJYJ_XAtDYoslQc-Rgg`）。X 会不定期轮换 queryId 导致 SearchTimeline 兜底失效，更新方法：从 x.com 访问页面的 JS bundle，或社区维护文档（如 github.com/fa0311/TwitterInternalAPIDocument 的 `docs/json/API.json`，搜 `SearchTimeline` 的 `queryId`）查询最新值后覆盖，无需改代码。
   - `VRC_MONITOR_X_MIN_TWEETS`：Nitter RSS 返回推文数低于该值时，尝试用 X SearchTimeline 补充并合并去重（默认 0 = 仅当 Nitter 完全失败才降级；设 >0 让高频博主「Nitter 只回 ~20 条覆盖不全」时也触发补充，缓解漏抓）。
+  - `VRC_MONITOR_X_PLAYWRIGHT`：Playwright 浏览器抓取开关。默认开启（`1`/`true`/空），设为 `0` 时禁用浏览器通道，直接走 Nitter RSS → SearchTimeline 链。
+  - `VRC_MONITOR_X_PLAYWRIGHT_INSTANCES`：浏览器抓取入口实例列表，逗号分隔（默认 `https://nitter.tiekoetter.com`）。可配置多个 Nitter 实例作为回退。
+  - `VRC_MONITOR_X_PLAYWRIGHT_CHANNEL`：Playwright 浏览器通道（默认 `msedge`）。可选 `msedge`、`chrome`、`chromium`，需已安装对应浏览器且 Playwright 已 `npx playwright install`。
+  - `VRC_MONITOR_X_PLAYWRIGHT_TIMEOUT_MS`：浏览器 goto / waitForSelector 超时（默认 45000 ms）。
+  - **浏览器抓取现在作为 `x_scan_creators` / `x_world_digest` 的默认主通道**（Nitter RSS / SearchTimeline 2026 已失效，保留作降级）。
+  - **注意**：Anubis 会拦截无头浏览器，浏览器抓取必须有头（`headless:false`，默认离屏+最小化，窗口置于 `-2400,-2400`）；服务跑在无头 Linux 服务器 / 容器时需要 `xvfb-run` 等提供虚拟显示（该路径待验证）。
 
 ### 3.5 网络环境差异
 

--- a/core/fetch-x-worlds.js
+++ b/core/fetch-x-worlds.js
@@ -67,12 +67,24 @@ let _xGuestTokenAt = 0;
 
 // ── Playwright 浏览器抓取（主通道，2026 Nitter RSS / SearchTimeline 均已失效）──
 // Anubis/Cloudflare 反爬拦截裸 HTTP 客户端，必须有头浏览器才能通过（无头被硬拒绝）。
-const X_PLAYWRIGHT_ENABLED = process.env.VRC_MONITOR_X_PLAYWRIGHT !== '0'; // 默认开
-const X_PLAYWRIGHT_INSTANCES = (process.env.VRC_MONITOR_X_PLAYWRIGHT_INSTANCES || 'https://nitter.tiekoetter.com')
-  .split(',').map(s => s.trim()).filter(Boolean);
-const X_PLAYWRIGHT_CHANNEL = process.env.VRC_MONITOR_X_PLAYWRIGHT_CHANNEL || 'msedge'; // msedge | chrome | chromium
-const X_PLAYWRIGHT_TIMEOUT_MS = parseInt(process.env.VRC_MONITOR_X_PLAYWRIGHT_TIMEOUT_MS, 10) || 45000;
 let _pw = null, _pwErr = null; // 懒加载缓存
+
+/**
+ * 懒读取 Playwright 浏览器抓取配置。
+ * 由于 start-monitor.js 在 import 本模块之后才加载 .env，模块顶层 const 会导致
+ * .env 里的变量失效，因此改为运行时每次读取 process.env。
+ */
+function getXPlaywrightConfig() {
+  const env = process.env;
+  return {
+    enabled: env.VRC_MONITOR_X_PLAYWRIGHT !== '0',
+    channel: env.VRC_MONITOR_X_PLAYWRIGHT_CHANNEL || 'auto', // auto|msedge|chrome|chromium
+    instances: (env.VRC_MONITOR_X_PLAYWRIGHT_INSTANCES || 'https://nitter.tiekoetter.com')
+      .split(',').map(s => s.trim()).filter(Boolean),
+    timeoutMs: parseInt(env.VRC_MONITOR_X_PLAYWRIGHT_TIMEOUT_MS, 10) || 45000,
+    stateFile: env.VRC_MONITOR_X_PLAYWRIGHT_STATE_FILE || '', // 可选：storageState 持久化路径
+  };
+}
 
 async function getPlaywright() {
   if (_pw) return _pw;
@@ -93,6 +105,36 @@ function resolveProxy() {
   const env = process.env;
   return env.VRC_MONITOR_HTTP_PROXY || env.HTTPS_PROXY || env.https_proxy
     || env.HTTP_PROXY || env.http_proxy || '';
+}
+
+function sleep(ms) { return new Promise(r => setTimeout(r, ms)); }
+
+let _detectedChannel = null; // 缓存已探测成功的通道，避免每次 launch 探测浪费
+
+/**
+ * 自动探测可用的 Playwright 浏览器通道。
+ * .env 显式指定 channel 时优先用它，失败再按 msedge → chrome → chromium 回退探测。
+ * 探测结果缓存到模块级变量，后续调用直接复用（同一进程内不重复 launch）。
+ */
+async function detectChannel(pw, requestedChannel, launchArgs) {
+  if (_detectedChannel) return _detectedChannel;
+  const preferred = requestedChannel && requestedChannel !== 'auto' ? [requestedChannel] : [];
+  const candidates = [...preferred, 'msedge', 'chrome', 'chromium'];
+  const tried = new Set();
+  for (const channel of candidates) {
+    if (tried.has(channel)) continue;
+    tried.add(channel);
+    try {
+      const browser = await pw.chromium.launch({ channel, headless: false, args: launchArgs });
+      await browser.close();
+      log(`x-world Playwright channel detected: ${channel}`);
+      _detectedChannel = channel;
+      return channel;
+    } catch (e) {
+      log(`x-world Playwright channel ${channel} unavailable: ${e.message.slice(0, 80)}`);
+    }
+  }
+  throw new Error('Playwright 无可用浏览器通道（msedge/chrome/chromium 均不可启动）');
 }
 
 /**
@@ -400,8 +442,11 @@ export function buildTweetFromBrowserItem({ text, url, time, links }) {
 export async function fetchCreatorViaBrowser(screenName) {
   const pw = await getPlaywright();
   const proxy = resolveProxy();
+  const cfg = getXPlaywrightConfig();
+  const timeoutMs = cfg.timeoutMs;
+  const stateFile = cfg.stateFile;
   const errors = [];
-  for (const base of X_PLAYWRIGHT_INSTANCES) {
+  for (const base of cfg.instances) {
     let browser = null;
     const url = `${base}/${encodeURIComponent(screenName)}`;
     try {
@@ -413,14 +458,70 @@ export async function fetchCreatorViaBrowser(screenName) {
         '--window-size=1280,900',
       ];
       if (proxy) args.push(`--proxy-server=${proxy}`);
+
+      const channel = await detectChannel(pw, cfg.channel, args);
       browser = await pw.chromium.launch({
-        channel: X_PLAYWRIGHT_CHANNEL,
+        channel,
         headless: false,
         args,
       });
-      const page = await browser.newPage();
-      await page.goto(url, { waitUntil: 'domcontentloaded', timeout: X_PLAYWRIGHT_TIMEOUT_MS });
-      await page.waitForSelector('.tweet-content', { timeout: X_PLAYWRIGHT_TIMEOUT_MS });
+
+      // 复用已通过 Anubis 验证的 cookie，减少重复挑战
+      const contextOptions = {};
+      if (stateFile) {
+        try {
+          const fs = await import('node:fs/promises');
+          await fs.access(stateFile);
+          contextOptions.storageState = stateFile;
+        } catch { /* 状态文件不存在时忽略，走全新上下文 */ }
+      }
+      const page = await browser.newPage(contextOptions);
+
+      await page.goto(url, { waitUntil: 'domcontentloaded', timeout: timeoutMs });
+
+      // 轮询等待推文内容（Anubis 挑战页会自动跳转，需跨导航等待）
+      const challengeRe = /anubis|不是机器人|not a bot|checkpoint|confirming|just a moment/i;
+      let challengeSeen = 0;
+      let lastChallenge = false;
+      const startAt = Date.now();
+      let contentFound = false;
+      while (Date.now() - startAt < timeoutMs) {
+        let bodyText = '';
+        try { bodyText = await page.locator('body').innerText(); }
+        catch { /* 导航中 context 被销毁，忽略 */ }
+        const isChallenge = challengeRe.test(bodyText);
+        if (isChallenge) {
+          challengeSeen++;
+          lastChallenge = true;
+          if (challengeSeen > 3) {
+            // 触发重新挑战
+            await page.reload({ waitUntil: 'domcontentloaded', timeout: timeoutMs }).catch(() => {});
+            challengeSeen = 0;
+          } else {
+            await sleep(1000);
+          }
+          continue;
+        }
+        lastChallenge = false;
+        let tweetCount = 0;
+        try { tweetCount = await page.locator('.tweet-content').count(); }
+        catch { /* 导航中，下一轮再试 */ }
+        if (tweetCount > 0) {
+          contentFound = true;
+          break;
+        }
+        await sleep(1000);
+      }
+      if (!contentFound) {
+        throw new Error(`轮询等待推文超时（${timeoutMs}ms），最后${lastChallenge ? '检测到挑战页' : '未检测到 .tweet-content'}`);
+      }
+
+      // 成功后持久化 storageState，供下次扫描复用
+      if (stateFile) {
+        try { await page.context().storageState({ path: stateFile }); }
+        catch (e) { log(`x-world storageState 保存失败：${e.message}`); }
+      }
+
       const rawTweets = await page.evaluate(() => {
         const items = [];
         const contentEls = document.querySelectorAll('.tweet-content');
@@ -791,7 +892,8 @@ function mapWorld(w) {
  *  - 三通道均失败/均空时抛 X_FETCH_ALL_FAILED（含诊断、可读错误提示）。
  */
 export async function fetchCreatorTweets(screenName, { minTweets = 0 } = {}) {
-  if (X_PLAYWRIGHT_ENABLED) {
+  const xCfg = getXPlaywrightConfig();
+  if (xCfg.enabled) {
     try {
       const tweets = await fetchCreatorViaBrowser(screenName);
       return { tweets, source: 'browser' };

--- a/core/fetch-x-worlds.js
+++ b/core/fetch-x-worlds.js
@@ -65,6 +65,25 @@ const X_GUEST_TOKEN_TTL_MS = 3 * 3600 * 1000; // guest token 缓存 3 小时
 let _xGuestToken = null;
 let _xGuestTokenAt = 0;
 
+// ── Playwright 浏览器抓取（主通道，2026 Nitter RSS / SearchTimeline 均已失效）──
+// Anubis/Cloudflare 反爬拦截裸 HTTP 客户端，必须有头浏览器才能通过（无头被硬拒绝）。
+const X_PLAYWRIGHT_ENABLED = process.env.VRC_MONITOR_X_PLAYWRIGHT !== '0'; // 默认开
+const X_PLAYWRIGHT_INSTANCES = (process.env.VRC_MONITOR_X_PLAYWRIGHT_INSTANCES || 'https://nitter.tiekoetter.com')
+  .split(',').map(s => s.trim()).filter(Boolean);
+const X_PLAYWRIGHT_CHANNEL = process.env.VRC_MONITOR_X_PLAYWRIGHT_CHANNEL || 'msedge'; // msedge | chrome | chromium
+const X_PLAYWRIGHT_TIMEOUT_MS = parseInt(process.env.VRC_MONITOR_X_PLAYWRIGHT_TIMEOUT_MS, 10) || 45000;
+let _pw = null, _pwErr = null; // 懒加载缓存
+
+async function getPlaywright() {
+  if (_pw) return _pw;
+  if (_pwErr) throw _pwErr;
+  try { _pw = await import('playwright'); return _pw; }
+  catch (e) {
+    _pwErr = new Error(`Playwright 未安装或不可用：${e.message}。请 npm i playwright && npx playwright install chromium`);
+    throw _pwErr;
+  }
+}
+
 /**
  * 代理解析：默认【直连】（不设代理）。
  * 仅当显式设置 VRC_MONITOR_HTTP_PROXY / HTTPS_PROXY / HTTP_PROXY 时才走代理，
@@ -332,6 +351,113 @@ function findBottomCursor(obj) {
     }
   }
   return null;
+}
+
+// ── Playwright 浏览器抓取（有头，绕过 Anubis/Cloudflare）──
+
+/** 从推文容器内的 <a href> 中提取世界链接（innerText 不含 href，需单独抽取） */
+export function extractWorldIdsFromLinks(links) {
+  const ids = new Set();
+  for (const link of links || []) {
+    let m;
+    if ((m = link.match(/vrchat\.com\/home\/world\/(wrld_[0-9a-f-]+)/i))) {
+      const raw = m[1];
+      const hex = raw.slice(5).replace(/-/g, '');
+      if (/^[0-9a-f]{32}$/i.test(hex)) ids.add(raw);
+    } else if ((m = link.match(/vrchat\.com\/home\/launch\?[^]*worldId=(wrld_[0-9a-f-]+)/i))) {
+      const raw = m[1];
+      const hex = raw.slice(5).replace(/-/g, '');
+      if (/^[0-9a-f]{32}$/i.test(hex)) ids.add(raw);
+    }
+  }
+  return [...ids];
+}
+
+export function buildTweetFromBrowserItem({ text, url, time, links }) {
+  const parsed = extractWorldsFromTweetText(text);
+  // 合并文本提取 + 链接 href 提取的世界 ID（.tweet-content innerText 不含 <a> href）
+  const worldIds = [...new Set([...parsed.worldIds, ...extractWorldIdsFromLinks(links)])];
+  // 归一化 URL：去掉 #m 锚点
+  let normalized = url || '';
+  if (normalized.includes('#m')) {
+    normalized = normalized.split('#m')[0];
+  }
+  // 从 /status/{id} 提取 tweet id
+  let id = '';
+  const m = normalized.match(/\/status\/(\d+)/);
+  if (m) id = m[1];
+  return {
+    id,
+    url: normalized,
+    time: time || null,
+    text,
+    worldIds,
+    worldNames: parsed.worldNames,
+    authorName: parsed.authorName,
+  };
+}
+
+export async function fetchCreatorViaBrowser(screenName) {
+  const pw = await getPlaywright();
+  const proxy = resolveProxy();
+  const errors = [];
+  for (const base of X_PLAYWRIGHT_INSTANCES) {
+    let browser = null;
+    const url = `${base}/${encodeURIComponent(screenName)}`;
+    try {
+      const args = [
+        '--no-sandbox',
+        '--mute-audio',
+        '--disable-infobars',
+        '--window-position=-2400,-2400',
+        '--window-size=1280,900',
+      ];
+      if (proxy) args.push(`--proxy-server=${proxy}`);
+      browser = await pw.chromium.launch({
+        channel: X_PLAYWRIGHT_CHANNEL,
+        headless: false,
+        args,
+      });
+      const page = await browser.newPage();
+      await page.goto(url, { waitUntil: 'domcontentloaded', timeout: X_PLAYWRIGHT_TIMEOUT_MS });
+      await page.waitForSelector('.tweet-content', { timeout: X_PLAYWRIGHT_TIMEOUT_MS });
+      const rawTweets = await page.evaluate(() => {
+        const items = [];
+        const contentEls = document.querySelectorAll('.tweet-content');
+        for (const el of contentEls) {
+          const text = el.innerText || '';
+          // 优先 a.tweet-link，其次包含 /status/ 的链接
+          let link = el.closest('.timeline-item')?.querySelector('a.tweet-link')?.href || '';
+          if (!link) {
+            const statusLink = el.closest('.timeline-item')?.querySelector('a[href*="/status/"]')?.href || '';
+            link = statusLink;
+          }
+          let time = null;
+          const dateEl = el.closest('.timeline-item')?.querySelector('.tweet-date a[title]');
+          if (dateEl) time = dateEl.getAttribute('title') || null;
+          // 抽取该推文容器内的 vrchat 链接（世界链接在 <a href>，innerText 不含）
+          const links = Array.from((el.closest('.timeline-item')?.querySelectorAll('a') || []))
+            .map(a => a.href).filter(h => h && /vrchat\.com\//.test(h));
+          items.push({ text, url: link, time, links });
+        }
+        return items;
+      });
+      await browser.close();
+      browser = null;
+      const tweets = rawTweets.map(t => buildTweetFromBrowserItem(t));
+      if (tweets.length > 0) return tweets;
+      errors.push(`${base} → 页面无推文`);
+    } catch (e) {
+      errors.push(`${base} → ${e.message || e.code || '未知错误'}`);
+      if (browser) { await browser.close().catch(() => {}); browser = null; }
+    } finally {
+      if (browser) { await browser.close().catch(() => {}); }
+    }
+  }
+  const err = new Error(`浏览器抓取全部失败（@${screenName}）：${errors.join('；')}`);
+  err.code = 'X_BROWSER_UNREACHABLE';
+  err.details = errors;
+  throw err;
 }
 
 // ── 博主清单 ──────────────────────────────────────────────
@@ -652,18 +778,28 @@ function mapWorld(w) {
 // ── 扫描主流程 ─────────────────────────────────────────────
 
 /**
- * 统一抓取入口：先 Nitter RSS（主源），失败/空/数据不足回退 X SearchTimeline（兜底）。
- * 返回 { tweets, source }，source ∈ 'nitter' | 'search_timeline' | 'nitter+search_timeline'。
+ * 统一抓取入口：先 Playwright 浏览器（主源），失败回退 Nitter RSS → X SearchTimeline（兜底）。
+ * 返回 { tweets, source }，source ∈ 'browser' | 'nitter' | 'search_timeline' | 'nitter+search_timeline'。
  *
  * 降级语义（明确）：
+ *  - fetchCreatorViaBrowser 用有头浏览器绕过 Anubis/Cloudflare，失败时 log 警告并回退 HTTP 通道。
  *  - fetchCreatorRss 内部已把「空 RSS / 0 条推文」视为该实例失败（continue 下一个），
  *    全部实例失败时抛 NITTER_UNREACHABLE → 触发 SearchTimeline 回退（"空数组算失败"已覆盖）。
  *  - 若 Nitter 返回非空但推文数 < minTweets（高频博主 Nitter RSS 仅 ~20 条可能覆盖不全 3 天窗口），
  *    也尝试 SearchTimeline 补充并合并去重（minTweets 默认 0 = 仅失败才回退，保持向后兼容；
  *    可通过 env VRC_MONITOR_X_MIN_TWEETS 配置为 >0，让"数据不足"也触发补充）。
- *  - 双源均失败/均空时抛 X_FETCH_ALL_FAILED（含诊断、可读错误提示）。
+ *  - 三通道均失败/均空时抛 X_FETCH_ALL_FAILED（含诊断、可读错误提示）。
  */
 export async function fetchCreatorTweets(screenName, { minTweets = 0 } = {}) {
+  if (X_PLAYWRIGHT_ENABLED) {
+    try {
+      const tweets = await fetchCreatorViaBrowser(screenName);
+      return { tweets, source: 'browser' };
+    } catch (e) {
+      log(`⚠️ x-world @${screenName} 浏览器抓取失败，回退 HTTP 通道：${e.message}`);
+      // 落到下方原 Nitter RSS → SearchTimeline 链
+    }
+  }
   const minTweetsEffective = parseInt(process.env.VRC_MONITOR_X_MIN_TWEETS, 10) || minTweets || 0;
   let tweets = [];
   let source = '';
@@ -689,13 +825,13 @@ export async function fetchCreatorTweets(screenName, { minTweets = 0 } = {}) {
       tweets = await fetchCreatorViaSearchTimeline(screenName);
       source = 'search_timeline';
     } catch (e2) {
-      const err = new Error(`@${screenName} 双数据源均失败（Nitter + X SearchTimeline）：${e2.message}。建议检查网络或设置 HTTPS_PROXY。`);
+      const err = new Error(`@${screenName} Nitter / X SearchTimeline / 浏览器抓取均不可用（2026 上游反向爬 + 网络受限），该通道当前无法获取新推荐。`);
       err.code = 'X_FETCH_ALL_FAILED';
       throw err;
     }
   }
   if (tweets.length === 0) {
-    const err = new Error(`@${screenName} 双数据源均未返回推文。建议检查网络或设置 HTTPS_PROXY。`);
+    const err = new Error(`@${screenName} Nitter / X SearchTimeline / 浏览器抓取均未返回推文（2026 上游反向爬 + 网络受限），该通道当前无法获取新推荐。`);
     err.code = 'X_FETCH_ALL_FAILED';
     throw err;
   }
@@ -761,9 +897,9 @@ export async function scanCreatorWorlds({ force = false } = {}) {
       results.push({ screen_name: screen, name: creator.name || screen, tweets: tweets.length, worlds: saved });
     } catch (e) {
       log(`❌ x-world scan @${screen}: ${e.message}`);
-      // 结构化错误：双源均失败 → 用户可读的降级提示
+      // 结构化错误：三通道均失败 → 用户可读的降级提示
       const errorInfo = e.code === 'X_FETCH_ALL_FAILED'
-        ? `Nitter 与 X SearchTimeline 双数据源均不可达（网络受限/需代理）。请在服务环境设置 HTTPS_PROXY 或 VRC_MONITOR_HTTP_PROXY 后重试。`
+        ? `Nitter / X SearchTimeline / 浏览器抓取均不可用（2026 上游反向爬 + 网络受限），该通道当前无法获取新推荐。`
         : e.message;
       results.push({ screen_name: screen, name: creator.name || screen, tweets: 0, worlds: 0, error: errorInfo });
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,11 @@
       "dependencies": {
         "better-sqlite3": "^12.2.0",
         "https-proxy-agent": "^9.1.0",
+        "playwright": "^1.62.1",
         "ws": "^8.21.1"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       }
     },
     "node_modules/agent-base": {
@@ -189,6 +190,20 @@
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "license": "MIT"
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/github-from-package": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
@@ -299,6 +314,36 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/prebuild-install": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "better-sqlite3": "^12.2.0",
     "https-proxy-agent": "^9.1.0",
+    "playwright": "^1.62.1",
     "ws": "^8.21.1"
   }
 }

--- a/test-fetch-x-worlds-browser.mjs
+++ b/test-fetch-x-worlds-browser.mjs
@@ -1,0 +1,110 @@
+// 测试 Playwright 浏览器抓取后的 tweet 组装逻辑（纯函数，离线可过）
+import { buildTweetFromBrowserItem, extractWorldsFromTweetText, extractWorldIdsFromLinks } from './core/fetch-x-worlds.js';
+
+let pass = 0, fail = 0;
+function assert(label, cond) {
+  if (cond) { pass++; console.log(`  ✓ ${label}`); }
+  else { fail++; console.log(`  ✗ ${label}`); }
+}
+
+function testBuildTweetFromBrowserItem() {
+  console.log('=== buildTweetFromBrowserItem 单元测试 ===');
+
+  // 1. 标准 fox_yata9 格式：World:XX By:YY + world 链接 + status 链接
+  const t1 = buildTweetFromBrowserItem({
+    text: 'World:Desert Clash By:PatMaz02\nhttps://vrchat.com/home/world/wrld_12345678-1234-1234-1234-123456789abc',
+    url: 'https://nitter.tiekoetter.com/fox_yata9/status/1234567890#m',
+    time: '2026-08-24 12:34:56',
+  });
+  assert('标准格式 worldId 提取', t1.worldIds.includes('wrld_12345678-1234-1234-1234-123456789abc'));
+  assert('标准格式 worldName 提取', t1.worldNames.includes('Desert Clash'));
+  assert('标准格式作者提取', t1.authorName === 'PatMaz02');
+  assert('标准格式 id 提取', t1.id === '1234567890');
+  assert('标准格式 url 去掉 #m', t1.url === 'https://nitter.tiekoetter.com/fox_yata9/status/1234567890');
+  assert('标准格式时间保留', t1.time === '2026-08-24 12:34:56');
+
+  // 2. 没有 #m 的 status 链接
+  const t2 = buildTweetFromBrowserItem({
+    text: 'World:Tiny Space By:foo https://vrchat.com/home/world/wrld_aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+    url: 'https://nitter.tiekoetter.com/fox_yata9/status/9876543210',
+    time: '2026-08-23 08:00:00',
+  });
+  assert('无 #m 时 url 不变', t2.url === 'https://nitter.tiekoetter.com/fox_yata9/status/9876543210');
+  assert('无 #m 时 id 提取', t2.id === '9876543210');
+
+  // 3. 多条 world 链接去重 + launch worldId 格式
+  const t3 = buildTweetFromBrowserItem({
+    text: `A: https://vrchat.com/home/world/wrld_bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb
+B: https://vrchat.com/home/launch?worldId=wrld_cccccccc-cccc-cccc-cccc-cccccccccccc`,
+    url: 'https://nitter.tiekoetter.com/fox_yata9/status/1111111111#m',
+    time: null,
+  });
+  assert('多条 worldId 提取', t3.worldIds.length === 2);
+  assert('launch worldId 归一化', t3.worldIds.includes('wrld_cccccccc-cccc-cccc-cccc-cccccccccccc'));
+  assert('时间为 null 时保留', t3.time === null);
+
+  // 4. 空/无推荐推文
+  const t4 = buildTweetFromBrowserItem({
+    text: '今天天气不错，没有推荐。',
+    url: 'https://nitter.tiekoetter.com/fox_yata9/status/2222222222#m',
+    time: '2026-08-22 00:00:00',
+  });
+  assert('空推荐 worldIds 为空', t4.worldIds.length === 0);
+  assert('空推荐 worldNames 为空', t4.worldNames.length === 0);
+  assert('空推荐 id 仍可提取', t4.id === '2222222222');
+
+  // 5. 无 status id 的非常规链接
+  const t5 = buildTweetFromBrowserItem({
+    text: 'World:Test By:Author https://vrchat.com/home/world/wrld_dddddddd-dddd-dddd-dddd-dddddddddddd',
+    url: 'https://example.com/something',
+    time: '2026-08-21 10:00:00',
+  });
+  assert('非常规链接 id 为空', t5.id === '');
+  assert('非常规链接 url 原样保留', t5.url === 'https://example.com/something');
+
+  // 6. 多行带作者 + Platform 边界
+  const t6 = buildTweetFromBrowserItem({
+    text: 'World name: Tranquility Lane （Fallout 3）\nBy: ControVR\nPlatform: PC & Quest',
+    url: 'https://nitter.tiekoetter.com/Bradlee1011/status/3333333333#m',
+    time: '2026-08-20 20:00:00',
+  });
+  assert('多行世界名', t6.worldNames.some(n => n.includes('Tranquility Lane')));
+  assert('多行作者名', t6.authorName === 'ControVR');
+  assert('多行 id', t6.id === '3333333333');
+
+  // 7. 世界链接只存在于 <a href>（innerText 不含）——从 links 抽取并合并
+  const t7 = buildTweetFromBrowserItem({
+    text: 'World: Desert Linkage\nBy: SomeAuthor\nPlatform: PC',
+    url: 'https://nitter.tiekoetter.com/fox_yata9/status/4444444444#m',
+    time: '2026-08-19 09:00:00',
+    links: ['https://vrchat.com/home/world/wrld_a1b2c3d4-e5f6-7890-abcd-ef1234567890/info', 'https://vrchat.com/home/group/grp_zzzz'],
+  });
+  assert('links 提取 worldId（带 /info 后缀）', t7.worldIds.includes('wrld_a1b2c3d4-e5f6-7890-abcd-ef1234567890'));
+  assert('grp_ 组链接被忽略', !t7.worldIds.some(x => x.startsWith('grp_')));
+}
+
+function testExtractWorldIdsFromLinks() {
+  console.log('\n=== extractWorldIdsFromLinks 边界测试 ===');
+  const ids = extractWorldIdsFromLinks([
+    'https://vrchat.com/home/world/wrld_11111111-2222-3333-4444-555555555555/info',
+    'https://vrchat.com/home/launch?worldId=wrld_66666666-7777-8888-9999-000000000000',
+  ]);
+  assert('world 链接提取', ids.includes('wrld_11111111-2222-3333-4444-555555555555'));
+  assert('launch worldId 提取', ids.includes('wrld_66666666-7777-8888-9999-000000000000'));
+  assert('grp/其它链接被过滤', extractWorldIdsFromLinks(['https://vrchat.com/home/group/grp_x']).length === 0);
+}
+
+function testExtractWorldsFromTweetText() {
+  console.log('\n=== extractWorldsFromTweetText 边界测试 ===');
+
+  // 非法/截断 worldId 应被过滤
+  const r = extractWorldsFromTweetText('bad https://vrchat.com/home/world/wrld_6… truncated');
+  assert('截断 worldId 被过滤', r.worldIds.length === 0);
+}
+
+testBuildTweetFromBrowserItem();
+testExtractWorldsFromTweetText();
+testExtractWorldIdsFromLinks();
+
+console.log(`\n结果: ${pass} 通过, ${fail} 失败`);
+process.exit(fail > 0 ? 1 : 0);


### PR DESCRIPTION
## 需求来源

issue #82：`x_scan_creators` / `x_world_digest` 自 2026 起无法抓取任何新推荐。根因是 Nitter RSS 全线遭遇 Anubis/Cloudflare 反爬、X SearchTimeline 对 guest 匿名访问整体限制（所有 queryId 404），裸 HTTP 客户端无论何种出口均被打回验证页/拒绝。属 2026 上游生态变化，非仓库逻辑 bug。

## 实现方式

引入 **Playwright 浏览器自动化**作为新的主抓取通道（唯一能绕过 Anubis/Cloudflare、保留 X 博主策展语义的路径）：

1. 新增 `fetchCreatorViaBrowser`：**有头浏览器**（`headless:false`，离屏 `--window-position=-2400,-2400`）访问 `https://nitter.tiekoetter.com/{user}`，抽取推文。**必须有头**：Anubis 实测硬拦截无头（错误码 4d1dbaddfcc0f385）。
2. 降级链：**浏览器(主) → Nitter RSS → X SearchTimeline**（后两者 2026 已失效，保留作兜底）。
3. `buildTweetFromBrowserItem` 纯函数合并 `innerText` 文本与 `<a href>` 世界链接（`extractWorldIdsFromLinks`）——`.tweet-content` 的 innerText 不含 `<a>` href，避免浏览器路径漏抓 worldId。
4. `getPlaywright()` 懒加载；默认 `VRC_MONITOR_X_PLAYWRIGHT` 开启。
5. 修正 3 处失真的「建议设置 HTTPS_PROXY」降级提示（2026 反爬与代理无关）。
6. `package.json` 加 `playwright`；新增 `test-fetch-x-worlds-browser.mjs` 离线单测；DEVELOPMENT.md 补 4 个 `VRC_MONITOR_X_PLAYWRIGHT*` 环境变量。

## 验证过程与结果

- `node --check` 通过；`node test-fetch-x-worlds-browser.mjs` **25 通过**；`node test-fetch-x-worlds.mjs` **7 通过**
- **服务端到端**（本机 Windows + msedge + 代理 7892）：`x_scan_creators` 返回 `scanned:4, tweets:81, worlds:26`，`x_world_recommendations` 落库 53 行（含 Desert Clash/Pillars/Nemuarium）
- 修复前（PR #87 后双源均 0 推文 0 世界），功能已恢复

## 审后更新（R2，commit b43253d）

针对 AGENT-REVIEW 审核的 3 个阻断项 + 2 个警告补齐：

- **env 时序**：`X_PLAYWRIGHT_*` 由模块顶层 const 改 `getXPlaywrightConfig()` 懒读取，`.env` 后加载不再失效
- **通道自动探测**：`detectChannel()` 按 `msedge→chrome→chromium` 回退 + 缓存，Linux 无 Edge 不再默认必挂
- **Anubis challenge 处理**：轮询等待 `.tweet-content`、挑战页检测 + PoW 自动跳转、超阈值 reload 重试、`evaluate` 容错跨导航；**storageState 复用**成功会话减少重复挑战
- 复测（本机）：全新会话 9.3s/19 条推文，复用 state 第 2 次 9.0s/19 条，均稳定

> ⚠️ 环境说明：上文 81 推文为**本机 Windows+msedge+代理 7892** 的实测结果；该环境 challenge 自动解。R2 已把 challenge 处理补上，Linux/Wayland + chromium 环境请持 contributor 按 DEVELOPMENT.md（需 `playwright install chromium` + 服务带代理 env 启动、无头服务器 `xvfb-run`）复测确认。

Closes #82
