### PR TITLE
fix(service-windows): 优先探测并使用 pythonw.exe 解决计划任务每分钟控制台窗口闪烁

### DIFF
--- a/service-windows/setup-windows.cmd
+++ b/service-windows/setup-windows.cmd
@@ -1,4 +1,5 @@
 @echo off
+chcp 65001 >nul 2>&1
 rem ============================================================
 rem  vrc-monitor 常驻服务一键设置（Windows）
 rem  用法: setup-windows.cmd [python解释器路径]

--- a/service-windows/setup-windows.cmd
+++ b/service-windows/setup-windows.cmd
@@ -24,24 +24,38 @@ if "%PYTHON%"=="" (
   exit /b 1
 )
 
-echo [1/3] 创建 VrcMonWatchdog 计划任务（每 1 分钟崩溃自愈）...
-schtasks /create /tn "VrcMonWatchdog" /tr "\"%PYTHON%\" \"%CD%\vrcmon_watchdog.py\"" /sc minute /mo 1 /f
+set "PYTHONW="
+for %%f in ("%PYTHON%") do (
+  if exist "%%~dpfpythonw.exe" set "PYTHONW=%%~dpfpythonw.exe"
+)
+if "%PYTHONW%"=="" (
+  for /f "delims=" %%i in ('where pythonw 2^>nul') do (
+    if not defined PYTHONW set "PYTHONW=%%i"
+  )
+)
+if "%PYTHONW%"=="" set "PYTHONW=%PYTHON%"
+
+echo [1/3] 创建 VrcMonWatchdog 计划任务（每 1 分钟崩溃自愈，无窗口静默执行）...
+schtasks /create /tn "VrcMonWatchdog" /tr "\"%PYTHONW%\" \"%CD%\vrcmon_watchdog.py\"" /sc minute /mo 1 /f
+
+set "STARTUP=%APPDATA%\Microsoft\Windows\Start Menu\Programs\Startup"
 
 echo [2/3] 创建 VrcMonLauncher 登录自启动（onlogon）...
-schtasks /create /tn "VrcMonLauncher" /tr "\"%PYTHON%\" \"%CD%\vrcmon_service_launcher.py\"" /sc onlogon /f
+schtasks /create /tn "VrcMonLauncher" /tr "\"%PYTHONW%\" \"%CD%\vrcmon_service_launcher.py\"" /sc onlogon /f
 if errorlevel 1 (
   echo       onlogon 权限不足，回退到当前用户 Startup 文件夹...
-  set "STARTUP=%APPDATA%\Microsoft\Windows\Start Menu\Programs\Startup"
-  > "%STARTUP%\VrcMon_Launcher.vbs" echo Set sh = CreateObject("WScript.Shell")
-  >> "%STARTUP%\VrcMon_Launcher.vbs" echo sh.Run """%PYTHON%"" ""%CD%\vrcmon_service_launcher.py""", 0, False
+  (
+    echo Set sh = CreateObject^("WScript.Shell"^)
+    echo sh.Run """%PYTHONW%"" ""%CD%\vrcmon_service_launcher.py""", 0, False
+  ) > "%STARTUP%\VrcMon_Launcher.vbs"
   echo       已写入 "%STARTUP%\VrcMon_Launcher.vbs"
 )
 
 echo [3/3] 启动服务（若未运行）...
-"%PYTHON%" "%CD%\vrcmon_service_launcher.py"
+"%PYTHONW%" "%CD%\vrcmon_service_launcher.py"
 
 echo.
 echo 完成。可选：每日修复报告（每天 09:00，昨天有修复才输出）可接入任意调度器：
 echo   Hermes: cron no_agent 任务指向 vrcmon_daily_report.py（空输出 = 静默）
-echo   Windows: schtasks /create /tn VrcMonDailyReport /tr "\"%PYTHON%\" \"%CD%\vrcmon_daily_report.py\"" /sc daily /st 09:00 /f
+echo   Windows: schtasks /create /tn VrcMonDailyReport /tr "\"%PYTHONW%\" \"%CD%\vrcmon_daily_report.py\"" /sc daily /st 09:00 /f
 endlocal


### PR DESCRIPTION
### 1. 需求来源
使用者在 Windows 环境下运行 service-windows/setup-windows.cmd 部署常驻守护服务后，反馈系统每隔 1 分钟会瞬时弹出一个黑色 CMD 控制台窗口并关闭，严重干扰日常操作。

### 2. 根因分析与实现方式
- **根因**：setup-windows.cmd 注册 VrcMonWatchdog 计划任务时使用的是控制台解释器 python.exe。Windows 任务计划程序在交互桌面会话中拉起控制台程序时，每次执行都会闪现一个控制台窗口。此外，批处理中在 if errorlevel 1 括号块内直接扩展 %STARTUP% 变量存在延迟扩展问题，且未声明 chcp 65001 导致部分非 ASCII 字符解析报语法错误。
- **实现方式**：
  1. 在 setup-windows.cmd 中动态探测同一目录或 PATH 下的 pythonw.exe（GUI 无窗口子系统解释器），存在则优先使用，找不到时静默回退至 python.exe；
  2. VrcMonWatchdog 计划任务、VrcMonLauncher 登录自启及 VrcMonDailyReport 统一使用 pythonw.exe 静默调用；
  3. 调整 STARTUP 变量初始化顺序并对 VBS 生成块加固；
  4. 脚本开头增加 chcp 65001 >nul 2>&1，避免在多语言终端环境下批处理解析报错。

### 3. 验证过程与结果
- **端到端实测**：在 Windows 11 环境下重新执行 service-windows/setup-windows.cmd，计划任务 VrcMonWatchdog 成功创建并指向 pythonw.exe；
- **静默性验证**：观察多个周期（每分钟触发），后台守护与健康巡检正常运行，桌面端 100% 零窗口闪烁；
- **回退验证**：当目标环境无 pythonw.exe 时能正常回退到 python.exe，不破坏现有行为。
