### PR TITLE
fix(storage): refactor 后无 data/ 目录时启动崩溃 + 旧数据不迁移

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ name: CI
 #   - test/test-registry.mjs  （注册表完整性：工具数、顺序+定义+handler，无凭据可跑）
 #   - scripts/dump-tools.mjs     （权威工具清单，行数须与 core/tool-order.json 一致——动态推导，不写死）
 #   - test/test-storage-snapshot.mjs（storage 行为等价基线：公共方法「输入→返回」快照，--check 对比 golden）
+#   - test/test-migrate-data.mjs（issue #103 回归：无 data/ 目录启动不崩 + 迁移引导行为/warn 提示）
 #   - scripts/check-doc-drift.py （文档漂移：skill 工具清单/数字残留/版本同步/死引用，has_drift=false）
 #
 # 刻意不接入任何真实凭据：本仓库所有自动化测试只能覆盖「无凭据也能验证」的部分，
@@ -60,6 +61,9 @@ jobs:
 
       - name: Storage behavior-equivalence snapshot (no credentials)
         run: node test/test-storage-snapshot.mjs
+
+      - name: Migrate legacy data regression (issue #103, no credentials)
+        run: node test/test-migrate-data.mjs
 
       - name: Doc drift check (has_drift must be false)
         shell: bash

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -161,7 +161,7 @@ PR 由 AI Agent 编写提交（人类只提出需求、不直接编码）。以�
 
 ## 6. 测试与 CI
 
-- **现状（含 PR-3 起）**：已接入 GitHub Actions（`.github/workflows/ci.yml`），对 Node 22 × Ubuntu/Windows 跑**无凭据冒烟**：`node test/test-registry.mjs`（注册表完整性，工具数、顺序+定义+handler）、`node scripts/dump-tools.mjs`（权威工具清单，行数与 core/tool-order.json 动态对齐）、`python scripts/check-doc-drift.py --json`（文档漂移，`has_drift` 必须为 false）。**CI 里一份真实 VRChat 凭据都没有**，自动化只覆盖「无凭据也能验证」的部分（模块加载、插件加载、DB 初始化、注册表完整、文档一致），涉及真实登录的验证仍需作者人工完成（可用 secrets 里的测试账号，但绝不能泄露到日志）。手动验证脚本：`test/test-apis.mjs`（REST API）、`test/test-websocket.mjs` / `test/test-ws-direct.mjs`（WebSocket）、`scripts/analyze-db.mjs`（数据库分析）。合并以作者实际运行为准，并参考 CI 冒烟结果。
+- **现状（含 PR-3 起）**：已接入 GitHub Actions（`.github/workflows/ci.yml`），对 Node 22 × Ubuntu/Windows 跑**无凭据冒烟**：`node test/test-registry.mjs`（注册表完整性，工具数、顺序+定义+handler）、`node scripts/dump-tools.mjs`（权威工具清单，行数与 core/tool-order.json 动态对齐）、`node test/test-migrate-data.mjs`（issue #103 回归：无 data/ 目录启动不崩 + 迁移引导行为/warn 提示）、`python scripts/check-doc-drift.py --json`（文档漂移，`has_drift` 必须为 false）。**CI 里一份真实 VRChat 凭据都没有**，自动化只覆盖「无凭据也能验证」的部分（模块加载、插件加载、DB 初始化、注册表完整、文档一致），涉及真实登录的验证仍需作者人工完成（可用 secrets 里的测试账号，但绝不能泄露到日志）。手动验证脚本：`test/test-apis.mjs`（REST API）、`test/test-websocket.mjs` / `test/test-ws-direct.mjs`（WebSocket）、`scripts/analyze-db.mjs`（数据库分析）。合并以作者实际运行为准，并参考 CI 冒烟结果。
 - **Agent 义务**：涉及 API / WebSocket / 数据库的功能改动，Agent 必须在 PR 描述写明验证方式；能跑现有脚本就跑一遍（尤其 `test/test-registry.mjs` / `scripts/check-doc-drift.py`），不能跑要说明原因。Agent 提交前必须实际运行验证，不能只做静态分析就声称完成。
 - **CI 里的凭据红线**：workflow 文件及其他自动化路径**严禁**出现任何真实凭据、Cookie、token、密码、IMAP 授权码（`credentials.json` 已被 gitignore 排除）。自动化测试账号如需纳入 CI，一律走 GitHub repo secrets 且绝不回显到日志。
 - 新增测试脚本命名沿用 `test-*.mjs` 风格，方便 CI 统一发现。

--- a/core/migrate-legacy-data.js
+++ b/core/migrate-legacy-data.js
@@ -1,0 +1,76 @@
+/**
+ * migrate-legacy-data.js — 旧数据迁移（issue #103）引导
+ *
+ * 背景：refactor(structure) 提交把三个运行时文件默认路径从仓库根目录挪到 data/ 子目录
+ * （DB_PATH / COOKIE_FILE / BACKUP_DIR），但未建目录、未迁移旧数据。已有部署升级后
+ * 启动即崩溃（无 data/ 目录），且根目录几十万条历史数据被晾在一边（「假丢失」）。
+ *
+ * 本模块提供一次性迁移引导：检测仓库根目录旧运行时文件（vrc-monitor.sqlite3[-wal|-shm]
+ * / auth_cookie.txt / backups/），仅当 data/ 下对应目标尚不存在时才搬移，避免覆盖；幂等。
+ *
+ * 只依赖 node:fs / node:path，可被 start-monitor.js 与回归测试（test-migrate-data.mjs）复用。
+ */
+import { existsSync, mkdirSync, renameSync } from 'node:fs';
+import path from 'node:path';
+
+/**
+ * 把根目录旧运行时文件迁移到 data/ 目录（尽量覆盖同名则跳过，避免覆盖 data/ 新数据）。
+ * @param {string} rootDir 仓库根目录
+ * @param {string} dataDir 目标 data/ 子目录
+ * @returns {number} 实际搬移的文件/目录个数
+ */
+export function migrateLegacyData(rootDir, dataDir) {
+  const legacyDb = path.join(rootDir, 'vrc-monitor.sqlite3');
+  const dataDb = path.join(dataDir, 'vrc-monitor.sqlite3');
+  const legacyCookie = path.join(rootDir, 'auth_cookie.txt');
+  const dataCookie = path.join(dataDir, 'auth_cookie.txt');
+  const legacyBackups = path.join(rootDir, 'backups');
+  const dataBackups = path.join(dataDir, 'backups');
+
+  const needsMove = [];
+
+  // 主库 + WAL/SHM
+  const dataDbExists = existsSync(dataDb) || existsSync(dataDb + '-wal') || existsSync(dataDb + '-shm');
+  for (const ext of ['', '-wal', '-shm']) {
+    const from = legacyDb + ext;
+    const to = dataDb + ext;
+    if (existsSync(from) && !dataDbExists) {
+      needsMove.push({ from, to, label: path.relative(rootDir, from) });
+    }
+  }
+
+  // Cookie
+  if (existsSync(legacyCookie) && !existsSync(dataCookie)) {
+    needsMove.push({ from: legacyCookie, to: dataCookie, label: 'auth_cookie.txt' });
+  }
+
+  // 备份目录
+  if (existsSync(legacyBackups) && !existsSync(dataBackups)) {
+    needsMove.push({ from: legacyBackups, to: dataBackups, label: 'backups/' });
+  }
+
+  // ⚠️ 静默跳过提示（issue #103）：根目录存在旧库主文件、但 data/ 已存在同名库时，
+  // 旧库不会被搬移（可能是用户按临时 workaround 手动 mkdir -p data 启动过一次）。
+  // 若无提示，用户会误以为历史数据仍在（假丢失），此处输出 warn 提醒可手动处理。
+  if (existsSync(legacyDb) && dataDbExists) {
+    console.warn(
+      `[migrate] 检测到根目录旧库 ${path.relative(rootDir, legacyDb)}，但 data/ 已存在同名库，跳过迁移；` +
+      '若需恢复旧数据请手动处理'
+    );
+  }
+
+  if (needsMove.length === 0) return 0;
+
+  mkdirSync(dataDir, { recursive: true });
+  let moved = 0;
+  for (const { from, to, label } of needsMove) {
+    try {
+      renameSync(from, to);
+      console.log(`[migrate] ${label} -> ${path.relative(rootDir, to)}`);
+      moved += 1;
+    } catch (e) {
+      console.warn(`[migrate] 移动失败 ${label}: ${e.message}`);
+    }
+  }
+  return moved;
+}

--- a/core/storage.js
+++ b/core/storage.js
@@ -7,7 +7,7 @@
  * 是原生绑定 + WAL 模式：每次写即时落盘、崩溃安全、支持并发读。
  */
 import Database from 'better-sqlite3';
-import { readFileSync } from 'node:fs';
+import { readFileSync, mkdirSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 import { backupDatabase } from './backup.js';
@@ -36,6 +36,7 @@ export class Storage {
 
   async init(dbPath) {
     this.dbPath = dbPath;
+    mkdirSync(path.dirname(dbPath), { recursive: true });
     this.db = new Database(dbPath);
     this.db.pragma('journal_mode = WAL');
     this.db.pragma('busy_timeout = 5000');

--- a/start-monitor.js
+++ b/start-monitor.js
@@ -6,7 +6,7 @@
  * 
  * 启动: node start-monitor.js
  */
-import { readFileSync, existsSync, mkdirSync, renameSync } from 'node:fs';
+import { readFileSync, existsSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 import net from 'node:net';
@@ -22,6 +22,7 @@ import { EventPipeline } from './core/event-pipeline.js';
 import { FriendStateManager } from './core/friend-state.js';
 import { createServer } from './core/http-server.js';
 import { PluginLoader } from './core/plugin-loader.js';
+import { migrateLegacyData } from './core/migrate-legacy-data.js';
 import { fetchOtpFromEmail } from './core/otp-fetcher.js';
 import {
   getCreators, addCreator, removeCreator,
@@ -240,51 +241,6 @@ function registerCoreServices(loader, ctx) {
     port: parseInt(process.env.VRC_MONITOR_PORT || '8799', 10),
   }));
   loader.serviceOwners.set('core.authConfig', 'core');
-}
-
-// ── 旧数据迁移（issue #103）：refactor 后根目录数据 → data/ 目录 ──
-// 仅当仓库根存在旧文件、且 data/ 下对应目标不存在时才搬移，避免覆盖；幂等。
-function migrateLegacyData(rootDir, dataDir) {
-  const legacyDb = path.join(rootDir, 'vrc-monitor.sqlite3');
-  const dataDb = path.join(dataDir, 'vrc-monitor.sqlite3');
-  const legacyCookie = path.join(rootDir, 'auth_cookie.txt');
-  const dataCookie = path.join(dataDir, 'auth_cookie.txt');
-  const legacyBackups = path.join(rootDir, 'backups');
-  const dataBackups = path.join(dataDir, 'backups');
-
-  const needsMove = [];
-
-  // 主库 + WAL/SHM
-  const dataDbExists = existsSync(dataDb) || existsSync(dataDb + '-wal') || existsSync(dataDb + '-shm');
-  for (const ext of ['', '-wal', '-shm']) {
-    const from = legacyDb + ext;
-    const to = dataDb + ext;
-    if (existsSync(from) && !dataDbExists) {
-      needsMove.push({ from, to, label: path.relative(rootDir, from) });
-    }
-  }
-
-  // Cookie
-  if (existsSync(legacyCookie) && !existsSync(dataCookie)) {
-    needsMove.push({ from: legacyCookie, to: dataCookie, label: 'auth_cookie.txt' });
-  }
-
-  // 备份目录
-  if (existsSync(legacyBackups) && !existsSync(dataBackups)) {
-    needsMove.push({ from: legacyBackups, to: dataBackups, label: 'backups/' });
-  }
-
-  if (needsMove.length === 0) return;
-
-  mkdirSync(dataDir, { recursive: true });
-  for (const { from, to, label } of needsMove) {
-    try {
-      renameSync(from, to);
-      console.log(`[migrate] ${label} -> ${path.relative(rootDir, to)}`);
-    } catch (e) {
-      console.warn(`[migrate] 移动失败 ${label}: ${e.message}`);
-    }
-  }
 }
 
 // ── 启动 ──

--- a/start-monitor.js
+++ b/start-monitor.js
@@ -6,7 +6,7 @@
  * 
  * 启动: node start-monitor.js
  */
-import { readFileSync, existsSync } from 'node:fs';
+import { readFileSync, existsSync, mkdirSync, renameSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 import net from 'node:net';
@@ -242,6 +242,51 @@ function registerCoreServices(loader, ctx) {
   loader.serviceOwners.set('core.authConfig', 'core');
 }
 
+// ── 旧数据迁移（issue #103）：refactor 后根目录数据 → data/ 目录 ──
+// 仅当仓库根存在旧文件、且 data/ 下对应目标不存在时才搬移，避免覆盖；幂等。
+function migrateLegacyData(rootDir, dataDir) {
+  const legacyDb = path.join(rootDir, 'vrc-monitor.sqlite3');
+  const dataDb = path.join(dataDir, 'vrc-monitor.sqlite3');
+  const legacyCookie = path.join(rootDir, 'auth_cookie.txt');
+  const dataCookie = path.join(dataDir, 'auth_cookie.txt');
+  const legacyBackups = path.join(rootDir, 'backups');
+  const dataBackups = path.join(dataDir, 'backups');
+
+  const needsMove = [];
+
+  // 主库 + WAL/SHM
+  const dataDbExists = existsSync(dataDb) || existsSync(dataDb + '-wal') || existsSync(dataDb + '-shm');
+  for (const ext of ['', '-wal', '-shm']) {
+    const from = legacyDb + ext;
+    const to = dataDb + ext;
+    if (existsSync(from) && !dataDbExists) {
+      needsMove.push({ from, to, label: path.relative(rootDir, from) });
+    }
+  }
+
+  // Cookie
+  if (existsSync(legacyCookie) && !existsSync(dataCookie)) {
+    needsMove.push({ from: legacyCookie, to: dataCookie, label: 'auth_cookie.txt' });
+  }
+
+  // 备份目录
+  if (existsSync(legacyBackups) && !existsSync(dataBackups)) {
+    needsMove.push({ from: legacyBackups, to: dataBackups, label: 'backups/' });
+  }
+
+  if (needsMove.length === 0) return;
+
+  mkdirSync(dataDir, { recursive: true });
+  for (const { from, to, label } of needsMove) {
+    try {
+      renameSync(from, to);
+      console.log(`[migrate] ${label} -> ${path.relative(rootDir, to)}`);
+    } catch (e) {
+      console.warn(`[migrate] 移动失败 ${label}: ${e.message}`);
+    }
+  }
+}
+
 // ── 启动 ──
 
 async function main() {
@@ -277,6 +322,9 @@ async function main() {
   } else {
     log('\n🔓 安全模式未启用（VRC_MONITOR_SAFE_MODE 未设置或非 true）');
   }
+
+  // 0c. 旧数据迁移（issue #103）：根目录旧文件 → data/
+  migrateLegacyData(__dirname, path.join(__dirname, 'data'));
 
   // 1. 初始化数据库
   log('📦 初始化数据库...');

--- a/test/test-migrate-data.mjs
+++ b/test/test-migrate-data.mjs
@@ -1,0 +1,167 @@
+#!/usr/bin/env node
+/**
+ * test-migrate-data.mjs — issue #103 回归测试（无凭据、离线可跑）
+ *
+ * 覆盖：
+ *   1. issue #103 核心回归：无 data/ 目录（父目录/多级父目录不存在）时 Storage.init 不再崩
+ *      ——mkdirSync(dirname(dbPath), {recursive:true}) 在 new Database 前建目录。
+ *   2. migrateLegacyData（core/migrate-legacy-data.js）行为：
+ *      - 干净裸机：根无旧文件 → 不建 data/、返回 0
+ *      - 全量搬移：根旧库+wal+shm+cookie+backups、data/ 空 → 全部搬入、根移走
+ *      - 防覆盖：data/ 已存在同名库 → 不覆盖（保留 data/ 新数据）
+ *      - 静默跳过 warn：根旧库在但 data/ 已有同名库 → 不迁移但输出 warn 提示（防「假丢失」）
+ *      - 幂等：重复执行第二次不重复搬、根无残留
+ *      - 仅 wal 异常态（无主库文件）：仍搬 wal
+ *      - 失败兜底：目标为目录（rename 报错）→ warn 不抛、不阻断
+ *
+ * 用法：node test-migrate-data.mjs   （退出码 0 = 全部通过）
+ */
+import { rmSync, existsSync, mkdirSync, writeFileSync, readFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const { migrateLegacyData } = await import(
+  pathToFileURL(path.join(__dirname, '..', 'core', 'migrate-legacy-data.js')).href
+);
+const { Storage } = await import(
+  pathToFileURL(path.join(__dirname, '..', 'core', 'storage.js')).href
+);
+
+let passed = 0;
+let failed = 0;
+function ok(name, cond) {
+  if (cond) { passed += 1; console.log(`  ✅ ${name}`); }
+  else { failed += 1; console.log(`  ❌ FAIL: ${name}`); }
+}
+
+function sandbox() {
+  const root = path.join(os.tmpdir(), `vrmon-migrate-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(root, { recursive: true });
+  return { root, data: path.join(root, 'data') };
+}
+function w(p, s = '') { writeFileSync(p, s); }
+function mkdb(root, ext) { w(path.join(root, 'vrc-monitor.sqlite3' + ext)); }
+
+// ── 1. issue #103 核心：无 data/ 目录时 Storage.init 不崩 ──
+console.log('── 1. Storage.init：父目录不存在时不崩 ──');
+{
+  // 多级父目录都不存在，验证 mkdirSync recursive 全建
+  const dbPath = path.join(os.tmpdir(), `vrmon-no-data-${Math.random().toString(36).slice(2)}`, 'data', 'vrc-monitor.sqlite3');
+  for (const f of [dbPath, dbPath + '-wal', dbPath + '-shm']) { try { rmSync(f, { force: true }); } catch {} }
+  let threw = false, db;
+  try {
+    const s = new Storage();
+    await s.init(dbPath);
+    db = s.db;
+  } catch (e) { threw = true; console.log('  init 抛错:', e.message); }
+  ok('无 data/ 目录 init 不抛错', !threw);
+  ok('创建了父目录 data/', existsSync(path.dirname(dbPath)));
+  ok('数据库文件已创建且可打开', !!db && existsSync(dbPath));
+  // 打开后能查（说明库就绪）
+  let qOk = false;
+  try { if (db) { db.prepare('SELECT 1 AS x').get(); qOk = true; } } catch {}
+  ok('init 后库可查询', qOk);
+  // 清理（含 WAL/SHM）
+  for (const f of [dbPath, dbPath + '-wal', dbPath + '-shm']) { try { rmSync(f, { force: true }); } catch {} }
+  try { rmSync(path.dirname(path.dirname(dbPath)), { recursive: true, force: true }); } catch {}
+}
+
+// ── 2. migrateLegacyData ──
+console.log('── 2. migrateLegacyData ──');
+
+// 2.1 干净裸机：根无旧文件 → 不建 data/、返回 0
+{
+  const { root, data } = sandbox();
+  const n = migrateLegacyData(root, data);
+  ok('2.1 无旧文件不建 data/', !existsSync(data));
+  ok('2.1 返回 0', n === 0);
+  rmSync(root, { recursive: true, force: true });
+}
+
+// 2.2 全量搬移：根旧库+wal+shm+cookie+backups、data/ 空 → 全搬入、根移走
+{
+  const { root, data } = sandbox();
+  mkdb(root, ''); mkdb(root, '-wal'); mkdb(root, '-shm');
+  w(path.join(root, 'auth_cookie.txt'), 'cookie');
+  mkdirSync(path.join(root, 'backups')); w(path.join(root, 'backups', 'b.sqlite3'), 'x');
+  const n = migrateLegacyData(root, data);
+  ok('2.2 主库搬入', existsSync(path.join(data, 'vrc-monitor.sqlite3')));
+  ok('2.2 wal 搬入', existsSync(path.join(data, 'vrc-monitor.sqlite3-wal')));
+  ok('2.2 shm 搬入', existsSync(path.join(data, 'vrc-monitor.sqlite3-shm')));
+  ok('2.2 cookie 搬入', existsSync(path.join(data, 'auth_cookie.txt')));
+  ok('2.2 backups 搬入', existsSync(path.join(data, 'backups')));
+  ok('2.2 根主库移走', !existsSync(path.join(root, 'vrc-monitor.sqlite3')));
+  ok('2.2 根 cookie 移走', !existsSync(path.join(root, 'auth_cookie.txt')));
+  ok('2.2 根 backups 移走', !existsSync(path.join(root, 'backups')));
+  ok('2.2 返回 5（5 项：库+wal+shm+cookie+backups）', n === 5);
+  rmSync(root, { recursive: true, force: true });
+}
+
+// 2.3 防覆盖：data/ 已存在同名库 → 保留 data/ 新数据
+{
+  const { root, data } = sandbox();
+  mkdirSync(data, { recursive: true });
+  w(path.join(data, 'vrc-monitor.sqlite3'), 'NEWDB');
+  mkdb(root, ''); // 根也有旧库
+  migrateLegacyData(root, data);
+  ok('2.3 不覆盖 data/ 库', readFileSync(path.join(data, 'vrc-monitor.sqlite3'), 'utf8') === 'NEWDB');
+  ok('2.3 根旧库未搬（防止覆盖）', existsSync(path.join(root, 'vrc-monitor.sqlite3')));
+  rmSync(root, { recursive: true, force: true });
+}
+
+// 2.4 静默跳过 warn：根旧库在但 data/ 已有同名库（用户手动 workaround 过）→ warn 提示
+{
+  const { root, data } = sandbox();
+  mkdirSync(data, { recursive: true });
+  w(path.join(data, 'vrc-monitor.sqlite3'), 'EMPTY_NEW');
+  mkdb(root, '');
+  const logs = [];
+  const origWarn = console.warn;
+  console.warn = (...a) => logs.push(a.join(' '));
+  try { migrateLegacyData(root, data); } finally { console.warn = origWarn; }
+  const warnHit = logs.some(l => l.includes('[migrate]') && l.includes('跳过迁移'));
+  ok('2.4 根旧库未被迁移', existsSync(path.join(root, 'vrc-monitor.sqlite3')));
+  ok('2.4 data/ 新库未被覆盖', readFileSync(path.join(data, 'vrc-monitor.sqlite3'), 'utf8') === 'EMPTY_NEW');
+  ok('2.4 输出 warn（防「假丢失」不可察觉）', warnHit);
+  if (!warnHit) console.log('   logs=', JSON.stringify(logs));
+  rmSync(root, { recursive: true, force: true });
+}
+
+// 2.5 幂等：重复执行第二次不重复搬、根无残留
+{
+  const { root, data } = sandbox();
+  mkdb(root, '');
+  migrateLegacyData(root, data);
+  migrateLegacyData(root, data); // 第二次
+  ok('2.5 二次迁移根无残留', !existsSync(path.join(root, 'vrc-monitor.sqlite3')));
+  ok('2.5 data 库仍在', existsSync(path.join(data, 'vrc-monitor.sqlite3')));
+  rmSync(root, { recursive: true, force: true });
+}
+
+// 2.6 仅 wal 异常态（无主库文件）→ 仍搬 wal
+{
+  const { root, data } = sandbox();
+  mkdb(root, '-wal');
+  migrateLegacyData(root, data);
+  ok('2.6 仅 wal 搬入', existsSync(path.join(data, 'vrc-monitor.sqlite3-wal')));
+  ok('2.6 根 wal 移走', !existsSync(path.join(root, 'vrc-monitor.sqlite3-wal')));
+  rmSync(root, { recursive: true, force: true });
+}
+
+// 2.7 失败兜底：目标为目录（rename 报错）→ warn、不抛、不阻断
+{
+  const { root, data } = sandbox();
+  mkdirSync(data, { recursive: true });
+  mkdirSync(path.join(data, 'vrc-monitor.sqlite3')); // 目标同名目录
+  mkdb(root, '');
+  let threw = false;
+  try { migrateLegacyData(root, data); } catch (e) { threw = true; }
+  ok('2.7 搬移失败不抛异常', !threw);
+  rmSync(root, { recursive: true, force: true });
+}
+
+console.log(`\nRESULT: ${passed} PASS / ${failed} FAIL`);
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## 背景

issue #103（回归）：refactor commit eb487a3 把三个运行时默认路径（`DB_PATH`/`COOKIE_FILE`/`BACKUP_DIR`）从仓库根挪到 `data/` 子目录，但代码中**没有任何创建 `data/` 目录的逻辑，也无旧数据迁移**。已有部署升级到该版本后，服务启动即崩溃：

```
Fatal: TypeError: Cannot open database because the directory does not exist
    at new Database (node_modules/better-sqlite3/lib/database.js:65:9)
    at Storage.init (core/storage.js:39:15)
    at main (start-monitor.js:284:21)
```

且根目录旧库（几十万条历史的 `vrc-monitor.sqlite3`）被晾在一边，表现为「数据全丢」。

## 改动

### 1. `core/storage.js` — 启动前确保 data/ 父目录存在
`Storage.init()` 在 `new Database(dbPath)` 之前新增 `mkdirSync(path.dirname(dbPath), { recursive: true })`，better-sqlite3 打开库时父目录必然存在（幂等、无副作用）。

### 2. `start-monitor.js` — 旧数据一次性迁移引导
新增 `migrateLegacyData()`，在 `storage.init` 之前调用：检测仓库根目录的旧运行时文件（`vrc-monitor.sqlite3[-wal|-shm]` / `auth_cookie.txt` / `backups/`），**仅当 `data/` 下对应目标尚不存在时**才 `renameSync` 搬移，避免覆盖；搬移失败 `warn` 兜底不影响启动。

## 验证（实测）

1. **无 `data/` 目录时启动不再崩**：模拟根目录无 `data/`，`new Database(data/vrc-monitor.sqlite3)` 前已建父目录 → 不再抛 `Cannot open database because the directory does not exist`。
2. **迁移幂等防覆盖**：
   - 根目录有旧库 + data/ 空 → 旧库/cookie/backups 全部搬入 data/，根目录旧文件移走；
   - data/ 已存在同名库 → 不覆盖（保留 data/ 新库）；
   - 根目录无旧库 → 无操作（干净裸机不误建）。
3. `node --check core/storage.js start-monitor.js` 均通过。

_Fixes #103_
