### PR TITLE
feat(weekly-report): daily 每日足迹带当天同屏伙伴（去哪+和谁一起）

### DIFF
--- a/core/analytics/social.js
+++ b/core/analytics/social.js
@@ -499,11 +499,13 @@ export class SocialAnalytics {
       const dayLabel = new Date(dayStart + BJ_OFFSET).toISOString().slice(5, 10); // MM-DD 北京
       for (const c of (r.companions || [])) {
         if (!merged.has(c.userId)) {
-          merged.set(c.userId, { displayName: c.displayName, matchCount: 0, days: new Set(), worlds: new Set() });
+          merged.set(c.userId, { displayName: c.displayName, matchCount: 0, days: new Set(), dayCounts: {}, worlds: new Set() });
         }
         const m = merged.get(c.userId);
         m.matchCount += c.matchCount || 0;
         m.days.add(dayLabel);
+        // 按北京日累计同屏次数（供周报每日足迹展示）
+        m.dayCounts[dayLabel] = (m.dayCounts[dayLabel] || 0) + (c.matchCount || 0);
         for (const w of (c.worlds || [])) m.worlds.add(w);
       }
       dayStart += 86400000;

--- a/core/tools/events.js
+++ b/core/tools/events.js
@@ -347,7 +347,15 @@ export async function handleGetWeeklyReport({ days = 7 }) {
       companionUsers: companions.size,
       topCompanion: topCompanions[0] ? { userId: topCompanions[0].userId, displayName: topCompanions[0].displayName, nickname: topCompanions[0].nickname, days: topCompanions[0].days, matchCount: topCompanions[0].matchCount } : null,
     },
-    daily: [...dayWorlds.entries()].sort().map(([day, worlds]) => ({ day, worlds: [...worlds].map(w => ({ worldId: w, name: worldNameMap[w] || w })) })),
+    daily: [...dayWorlds.entries()].sort().map(([day, worlds]) => ({
+      day,
+      worlds: [...worlds].map(w => ({ worldId: w, name: worldNameMap[w] || w })),
+      // 每日同屏伙伴（昵称 + 当天次数），次数降序
+      companions: [...companions.entries()]
+        .filter(([uid, v]) => v.days.has(day))
+        .map(([uid, v]) => ({ userId: uid, displayName: v.displayName, nickname: nickMap[uid] || null, matchCount: v.dayCounts[day] || 0 }))
+        .sort((a, b) => b.matchCount - a.matchCount),
+    })),
     topWorlds,
     ownPattern: {
       activeDays30: pattern.activeDates?.length || 0,

--- a/skills/vrc-monitor-agent/SKILL.md
+++ b/skills/vrc-monitor-agent/SKILL.md
@@ -45,7 +45,7 @@ metadata:
 | `get_worlds_by_author` | **按作者列出全部世界**：authorId 或 authorName（内部经 /users 解析）→ GET /worlds?userId= 分页拉全该作者发布的全部图（worldId/名称/收藏/浏览/容量/标签/发布时间），顺带写 world_cache（含 author_id）。配合 get_world_name 返回的 authorId 使用（如「当前所在图作者的全部图加权重」） |
 | `set_world_note` | 世界用户备注写入/更新（本地存储，API 刷新不覆盖；空串清除） |
 | `get_world_history` | 世界信息变更历史（name/description/author/image_url/release_status/capacity/tags 字段级记录） |
-| `get_weekly_report` | 一周游戏周报（活跃天数/时长/世界 Top/同屏伙伴带昵称/自己的上线规律/群组活动/圈内活动日历；days 默认 7） |
+| `get_weekly_report` | 一周游戏周报（活跃天数/时长/世界 Top/同屏伙伴带昵称/自己的上线规律/群组活动/圈内活动日历；days 默认 7）。**渲染含两个固化板块**：①每日足迹（每天去了哪些房间+和谁一起，daily 每项带当天 companions[{nickname,matchCount}]）②本周总结（末尾一段连贯叙事评述）。模板见 vrchat-social-queries §9 |
 | `scan_new_worlds` | 扫描最近 N 天新世界（1-30，默认 7），过滤测试/垃圾图后写入 world_kb 表（原 new_worlds），按热度推荐 TOP10；dryRun 只看不写 |
 | `get_new_worlds` | 只读查询已跟踪新世界：onlyUnvisited 只看未逛过、sortBy（favorites/occupants/popularity/created_at）、excludeTheme 排除主题（按 author_tag_* 逗号分隔，SQL 层排除）、limit（默认 10 最大 50） |
 | `rate_world` | **用户反馈**：给世界打好评/烂图标记（rating: 1=好图加权 / -1=烂图降权 / 0=清除），写入 world_kb.user_rating，影响 worldScore 推荐排序 |

--- a/test/storage-snapshot.json
+++ b/test/storage-snapshot.json
@@ -698,6 +698,9 @@
       "days": [
         "08-01"
       ],
+      "dayCounts": {
+        "08-01": 2
+      },
       "worlds": [
         "World One"
       ]
@@ -708,6 +711,9 @@
       "days": [
         "08-01"
       ],
+      "dayCounts": {
+        "08-01": 1
+      },
       "worlds": [
         "World Two"
       ]


### PR DESCRIPTION
## 需求来源
用户 2026-08-31 提出周报需要记录「每天去了什么房间、和谁一起」并固化。现状 get_weekly_report 的 daily 每日足迹只有到访世界，缺当天的同屏伙伴。

## 实现方式
- `core/analytics/social.js` `getWeeklyCompanions`：每项新增 `dayCounts`（按北京自然日累计当天同屏次数），纯增字段，向后兼容，get_recent_cooplay 同款复用不受影响。
- `core/tools/events.js` `handleGetWeeklyReport`：`daily` 每项新增 `companions[{userId, displayName, nickname, matchCount}]`，按当天次数降序；昵称复用已有 nickMap。

## 验证过程与结果
- `node --check core/analytics/social.js core/tools/events.js` 通过。
- 重启本地服务后 MCP 实测 `get_weekly_report {days:7}`：daily[0..6] 均带 companions，昵称正确（如 董董 x16、EMeowSystem x10），次数与 topCompanions 口径一致。
- 无新增工具（工具数不变），复用周报既有同屏合并引擎，输出仅加字段。