### PR TITLE
fix(monitor): 在线口径与 MCP 一致 + 非好友追踪导入上限（issue #114 复测遗留）

### DIFF
--- a/docs/history/2026-08.md
+++ b/docs/history/2026-08.md
@@ -809,7 +809,7 @@
 
 ## 2026-08-30 · 汇总 PR #112 + 评审 R1/R2/R3 阻断项修复 + identical-changes 合并静默丢修复陷阱
 
-- `#112` (OPEN, 2026-08-30) feat(dashboard): 核心数据服务下沉 + 非好友追踪 + Web Dashboard 全家桶（汇总 #108/#109/#110/#111，@nixi-agent，head=dashboard-series → main）
+- `#112` (MERGED, 2026-08-31, #108/#109/#110/#111 汇总) feat(dashboard): 核心数据服务下沉 + 非好友追踪 + Web Dashboard 全家桶（@nixi-agent，head=dashboard-series → main）
 - 汇总 PR 定位：把四个已各自 APPROVE 的子 PR 组装到暂存分支后**一次性合入 main**，团队在汇总 PR 上做 final review；合并顺序约束已验证（#108→#109→#110→#111）
 - 评审阻断项修复（合入前清零）：
   - **R1 个人环境信息出清**：移除私有部署交接文档 HANDOFF/PR-MATERIALS（个人环境信息）、移除含路由器路径硬编码的本地环境脚本（deploy/backup/verify）、移除误提交的 .agents 工作区（本地 agent 状态/技能/图片，522f356）

--- a/start-monitor.js
+++ b/start-monitor.js
@@ -128,7 +128,9 @@ async function _refreshOnlineState() {
       displayName: f.displayName,
       location: f.location || '',
       worldId: f.worldId || (f.location || '').split(':')[0],
-      isOnline: true,
+      // 在线口径与 MCP get_online_friends 一致：仅「有有效 location」计在线（offline=false 返回含
+      // active/菜单中用户，location 为空者不算在线——issue #114 ⚠️2 复测遗留修复）
+      isOnline: !!(f.location && f.location !== 'offline'),
     })));
 
     // 断线窗口对账：WS 断开期间的好友下线事件会错过（下线不再广播），本地状态会卡在「在线」。
@@ -251,10 +253,14 @@ async function _seedTrackedNonFriends() {
       const del = ctx.storage.run(`DELETE FROM tracked_non_friends WHERE user_id = $u`, { $u: selfId });
       if (del.changes > 0) log(`🧹 追踪列表移除误导入的自己（${selfId.slice(0, 12)}…）`);
     }
+    // 自动导入上限（issue #114 ⚠️3 复测遗留修复）：仅导入近 30 天出现过的非好友，最多 100 人——
+    // 长历史全量导入会数百上千行，每小时逐人拉资料触发 VRChat 限流；手动添加不受此限
     const rows = ctx.storage.query(
       `SELECT user_id, MAX(display_name) AS dn FROM events
        WHERE user_id LIKE 'usr_%' AND user_id != ''
-       GROUP BY user_id`
+         AND created_at >= datetime('now', '-30 days')
+       GROUP BY user_id
+       LIMIT 100`
     );
     let added = 0;
     for (const r of rows) {


### PR DESCRIPTION
修复 issue #114 复测遗留的两项设计级 ⚠️：

### ⚠️2: 在线口径变更未声明
`_refreshOnlineState()` 用 `offline=false` 拉好友后把全体返回用户标 `isOnline:true`（含 active / 菜单中 / location 为空者），导致 `/health` 的 `friendState.online` 被放大。
**修复**：恢复与 MCP `get_online_friends` 一致的口径——仅「有有效 location」计在线（`!!(f.location && f.location !== 'offline')`）。生产验证：health 与 MCP online 一致。

### ⚠️3: 非好友追踪规模无上限
`_seedTrackedNonFriends()` 把历史 events 中**所有**非好友全量导入，长历史（10 个月）可能数百上千行 → 每小时逐人拉资料触发 VRChat 限流。
**修复**：自动导入加 **30 天窗口 + 100 人上限**（仅导入近 30 天出现过的非好友；手动添加不受此限）。

### 附带：doc-drift 修复
#112 合入后 `docs/history/2026-08.md` 仍标 OPEN——更新为 MERGED（`check-doc-drift.py` 恢复 False）。

**验证**：`node test/test-registry.mjs` PASS · `node test/test-storage-snapshot.mjs` PASS · `check-doc-drift.py` False · 生产容器已验证（health/MCP 口径一致）