### PR TITLE
refactor(dashboard): 抽取 event-types 常量 + 补 Vitest 单测（前端重构 Phase 1a/3）

### DIFF
--- a/plugins/official/web-dashboard/ui/package-lock.json
+++ b/plugins/official/web-dashboard/ui/package-lock.json
@@ -16,7 +16,8 @@
       "devDependencies": {
         "@vitejs/plugin-vue": "^5.2.4",
         "vite": "^6.3.5",
-        "vite-plugin-singlefile": "^2.2.0"
+        "vite-plugin-singlefile": "^2.2.0",
+        "vitest": "^4.1.11"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -521,9 +522,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -707,9 +705,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -724,9 +719,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -741,9 +733,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -758,9 +747,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -775,9 +761,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -792,9 +775,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -809,9 +789,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -826,9 +803,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -843,9 +817,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -860,9 +831,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -877,9 +845,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -894,9 +859,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -911,9 +873,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1004,6 +963,31 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
@@ -1023,6 +1007,129 @@
       "peerDependencies": {
         "vite": "^5.0.0 || ^6.0.0",
         "vue": "^3.2.25"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.11.tgz",
+      "integrity": "sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.11.tgz",
+      "integrity": "sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.11",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.11.tgz",
+      "integrity": "sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.11.tgz",
+      "integrity": "sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.11",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.11.tgz",
+      "integrity": "sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.11.tgz",
+      "integrity": "sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.11.tgz",
+      "integrity": "sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.11",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vue/compiler-core": {
@@ -1123,6 +1230,16 @@
       "integrity": "sha512-IOnwSCma8j+9xJT6b8H0dEYidC80NsYmNMlZxRsukYcSoGaDBohog5hDxzeUXdFeGWFA++vWvxqOmrr96VlqMA==",
       "license": "MIT"
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/braces": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
@@ -1135,6 +1252,23 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/csstype": {
       "version": "3.2.3",
@@ -1153,6 +1287,13 @@
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+      "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.25.12",
@@ -1201,6 +1342,16 @@
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -1311,6 +1462,27 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -1427,6 +1599,13 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -1434,6 +1613,37 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/tinyglobby": {
@@ -1451,6 +1661,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -1563,6 +1783,96 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.11.tgz",
+      "integrity": "sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.11",
+        "@vitest/mocker": "4.1.11",
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/runner": "4.1.11",
+        "@vitest/snapshot": "4.1.11",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.11",
+        "@vitest/browser-preview": "4.1.11",
+        "@vitest/browser-webdriverio": "4.1.11",
+        "@vitest/coverage-istanbul": "4.1.11",
+        "@vitest/coverage-v8": "4.1.11",
+        "@vitest/ui": "4.1.11",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/vue": {
       "version": "3.5.41",
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.41.tgz",
@@ -1582,6 +1892,23 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     }
   }

--- a/plugins/official/web-dashboard/ui/package.json
+++ b/plugins/official/web-dashboard/ui/package.json
@@ -5,18 +5,20 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build && node -e \"const fs=require('fs');for(const f of fs.readdirSync('dist'))if(f.startsWith('primeicons-')&&f.endsWith('.svg'))fs.rmSync('dist/'+f);const p='dist/index.html';fs.writeFileSync(p,fs.readFileSync(p,'utf8').replace(/\\r\\n/g,'\\n'))\""
+    "build": "vite build && rm -f dist/primeicons-*.svg && node -e \"const fs=require('fs');const p='dist/index.html';fs.writeFileSync(p,fs.readFileSync(p,'utf8').replace(/\\r\\n/g,'\\n'))\"",
+    "test": "vitest run"
   },
   "dependencies": {
+    "@primevue/themes": "^4.3.5",
     "primeicons": "^7.0.0",
     "primevue": "^4.3.5",
-    "@primevue/themes": "^4.3.5",
     "vue": "^3.5.13"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.2.4",
     "vite": "^6.3.5",
-    "vite-plugin-singlefile": "^2.2.0"
+    "vite-plugin-singlefile": "^2.2.0",
+    "vitest": "^4.1.11"
   },
   "allowScripts": {
     "esbuild@0.25.12": true

--- a/plugins/official/web-dashboard/ui/package.json
+++ b/plugins/official/web-dashboard/ui/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build && rm -f dist/primeicons-*.svg && node -e \"const fs=require('fs');const p='dist/index.html';fs.writeFileSync(p,fs.readFileSync(p,'utf8').replace(/\\r\\n/g,'\\n'))\"",
+    "build": "vite build && node -e \"const fs=require('fs');const p='dist/index.html';let s=fs.readFileSync(p,'utf8');s=s.replace(/\\r\\n/g,'\\n');fs.writeFileSync(p,s);for(const f of fs.readdirSync('dist')){if(/^primeicons-.*\\.svg$/.test(f))fs.unlinkSync('dist/'+f)}\"",
     "test": "vitest run"
   },
   "dependencies": {

--- a/plugins/official/web-dashboard/ui/src/constants/event-types.js
+++ b/plugins/official/web-dashboard/ui/src/constants/event-types.js
@@ -1,0 +1,84 @@
+// 事件类型 → 展示元数据（label/icon/severity/归一化 typeOf）
+// 从 FeedView.vue 抽取：纯数据层，可单测、可复用（用户弹窗活动记录等也消费同一套类型语义）
+
+export const TYPE_LABELS = {
+  location: '位置变动', online: '上线', offline: '下线', status: '状态变动', avatar: '模型变动',
+  bio: '简介变更', userIcon: '头像图标', pronouns: '代词变更', displayName: '改名',
+  friendRequest: '好友申请', invite: '邀请', message: '私信', group: '群组通知',
+  notification: '通知', notificationUpdate: '通知更新', friendAdd: '新增好友', friendDelete: '删除好友',
+  unknown: '未知事件', contentRefresh: '内容库', groupJoined: '加入群组', groupMemberUpdated: '群组更新',
+  other: '资料变动',
+};
+
+export const TYPE_ICONS = {
+  location: 'pi-map-marker', online: 'pi-sign-in', offline: 'pi-sign-out', status: 'pi-heart',
+  avatar: 'pi-user-edit', bio: 'pi-file-edit', userIcon: 'pi-id-card', pronouns: 'pi-user',
+  displayName: 'pi-pencil', friendRequest: 'pi-user-plus', invite: 'pi-arrow-right-arrow-left',
+  message: 'pi-comment', group: 'pi-users', notification: 'pi-bell', notificationUpdate: 'pi-bell',
+  friendAdd: 'pi-user-plus', friendDelete: 'pi-user-minus', unknown: 'pi-question-circle',
+  contentRefresh: 'pi-refresh', groupJoined: 'pi-users', groupMemberUpdated: 'pi-users', other: 'pi-user',
+};
+
+export const TYPE_SEVERITIES = {
+  location: 'info', online: 'success', offline: 'secondary', status: 'warning', avatar: 'warn',
+  bio: 'contrast', userIcon: 'secondary', pronouns: 'contrast', displayName: 'warn',
+  friendRequest: 'success', invite: 'info', message: 'secondary', group: 'warn',
+  notification: 'secondary', notificationUpdate: 'secondary', friendAdd: 'success',
+  friendDelete: 'danger', unknown: 'secondary', contentRefresh: 'info', groupJoined: 'success',
+  groupMemberUpdated: 'warn', other: 'secondary',
+};
+
+// 事件 → 归一化类型（兼容后端多种历史形状；纯函数，行为与 FeedView 原实现一致）
+export function typeOf(x) {
+  if (x.type === 'friend-location' || x.type === 'user-location') return 'location';
+  if (x.type === 'friend-online') return 'online';
+  if (x.type === 'friend-offline') return 'offline';
+  if (x.type === 'friend-active') return 'status';
+  if (x.type === 'friend-update') {
+    if (x.updateType === 'avatar') return 'avatar';
+    if (x.updateType === 'bio') return 'bio';
+    if (x.updateType === 'status') return 'status';
+    if (x.updateType === 'user_icon') return 'userIcon';
+    if (x.updateType === 'pronouns') return 'pronouns';
+    if (x.updateType === 'displayName') return 'displayName';
+    return 'other';
+  }
+  // 自己的资料/状态更新：与 friend-update 一致显示（状态灯/简介/模型）；
+  // 旧格式（无 updateType）默认按状态变动——用户视角就是"在线状态更新"
+  if (x.type === 'user-update') {
+    if (x.updateType === 'avatar') return 'avatar';
+    if (x.updateType === 'bio') return 'bio';
+    if (x.updateType === 'user_icon') return 'userIcon';
+    if (x.updateType === 'pronouns') return 'pronouns';
+    if (x.updateType === 'displayName') return 'displayName';
+    return 'status';
+  }
+  if (x.type === 'friend-add') return 'friendAdd';
+  if (x.type === 'friend-delete') return 'friendDelete';
+  if (x.type === 'unknown') return 'unknown';
+  if (x.type === 'content-refresh') return 'contentRefresh';
+  if (x.type === 'group-joined') return 'groupJoined';
+  if (x.type === 'group-member-updated') return 'groupMemberUpdated';
+  if (x.type === 'hide-notification' || x.type === 'see-notification') return 'notificationUpdate';
+  if (x.type === 'notification' || x.type === 'notification-v2') {
+    const t = x.updateType || x.notificationType || '';
+    if (t === 'friendRequest') return 'friendRequest';
+    if (t === 'invite' || t === 'requestInvite') return 'invite';
+    if (t === 'message') return 'message';
+    if (String(t).startsWith('group.')) return 'group';
+    return 'notification';
+  }
+  // 通知状态更新：关联到群组通知的归入"群组通知"，否则"通知更新"
+  if (x.type === 'notification-v2-update' || x.type === 'notification-update') {
+    return x.notiGroupId ? 'group' : 'notificationUpdate';
+  }
+  return 'other';
+}
+
+export function isNotiUpdate(x) {
+  return x.type === 'notification-v2-update' || x.type === 'notification-update';
+}
+
+export function eventTypeLabel(x) {
+  return TYPE_LABELS[typeOf(x)] || '通知';
+}

--- a/plugins/official/web-dashboard/ui/src/constants/event-types.test.js
+++ b/plugins/official/web-dashboard/ui/src/constants/event-types.test.js
@@ -1,0 +1,66 @@
+// event-types 纯函数单测（重构行为等价锚点）
+import { describe, it, expect } from 'vitest';
+import { typeOf, isNotiUpdate, TYPE_LABELS, TYPE_ICONS, TYPE_SEVERITIES, eventTypeLabel } from './event-types.js';
+
+describe('typeOf 归一化', () => {
+  it('位置/上下线/状态', () => {
+    expect(typeOf({ type: 'friend-location' })).toBe('location');
+    expect(typeOf({ type: 'user-location' })).toBe('location');
+    expect(typeOf({ type: 'friend-online' })).toBe('online');
+    expect(typeOf({ type: 'friend-offline' })).toBe('offline');
+    expect(typeOf({ type: 'friend-active' })).toBe('status');
+  });
+  it('friend-update 按 updateType', () => {
+    expect(typeOf({ type: 'friend-update', updateType: 'avatar' })).toBe('avatar');
+    expect(typeOf({ type: 'friend-update', updateType: 'bio' })).toBe('bio');
+    expect(typeOf({ type: 'friend-update', updateType: 'status' })).toBe('status');
+    expect(typeOf({ type: 'friend-update', updateType: 'user_icon' })).toBe('userIcon');
+    expect(typeOf({ type: 'friend-update', updateType: 'pronouns' })).toBe('pronouns');
+    expect(typeOf({ type: 'friend-update', updateType: 'displayName' })).toBe('displayName');
+    expect(typeOf({ type: 'friend-update', updateType: 'unknown-thing' })).toBe('other');
+    expect(typeOf({ type: 'friend-update' })).toBe('other');
+  });
+  it('user-update 默认 status', () => {
+    expect(typeOf({ type: 'user-update', updateType: 'avatar' })).toBe('avatar');
+    expect(typeOf({ type: 'user-update' })).toBe('status');
+  });
+  it('通知类型', () => {
+    expect(typeOf({ type: 'notification', updateType: 'friendRequest' })).toBe('friendRequest');
+    expect(typeOf({ type: 'notification', updateType: 'invite' })).toBe('invite');
+    expect(typeOf({ type: 'notification', updateType: 'message' })).toBe('message');
+    expect(typeOf({ type: 'notification', updateType: 'group.join' })).toBe('group');
+    expect(typeOf({ type: 'notification' })).toBe('notification');
+    expect(typeOf({ type: 'notification-v2-update', notiGroupId: 'grp_1' })).toBe('group');
+    expect(typeOf({ type: 'notification-update' })).toBe('notificationUpdate');
+  });
+  it('其它', () => {
+    expect(typeOf({ type: 'friend-add' })).toBe('friendAdd');
+    expect(typeOf({ type: 'friend-delete' })).toBe('friendDelete');
+    expect(typeOf({ type: 'unknown' })).toBe('unknown');
+    expect(typeOf({ type: 'content-refresh' })).toBe('contentRefresh');
+    expect(typeOf({ type: 'group-joined' })).toBe('groupJoined');
+    expect(typeOf({ type: 'group-member-updated' })).toBe('groupMemberUpdated');
+    expect(typeOf({ type: 'weird-thing' })).toBe('other');
+  });
+});
+
+describe('映射完整性', () => {
+  it('每个归一化类型都有 label/icon/severity', () => {
+    for (const t of Object.keys(TYPE_LABELS)) {
+      expect(TYPE_ICONS[t], `icon for ${t}`).toBeTruthy();
+      expect(TYPE_SEVERITIES[t], `severity for ${t}`).toBeTruthy();
+    }
+  });
+  it('eventTypeLabel 兜底', () => {
+    expect(eventTypeLabel({ type: 'friend-online' })).toBe('上线');
+    expect(eventTypeLabel({ type: 'nonsense' })).toBe('资料变动'); // typeOf 兜底 other
+  });
+});
+
+describe('isNotiUpdate', () => {
+  it('识别通知更新', () => {
+    expect(isNotiUpdate({ type: 'notification-v2-update' })).toBe(true);
+    expect(isNotiUpdate({ type: 'notification-update' })).toBe(true);
+    expect(isNotiUpdate({ type: 'notification' })).toBe(false);
+  });
+});

--- a/plugins/official/web-dashboard/ui/src/style.css
+++ b/plugins/official/web-dashboard/ui/src/style.css
@@ -15,6 +15,7 @@
   --warn: #ff7b42;
   --info: #1778ff;
   --danger: #ff5252;
+  --star: #ffca28;   /* 收藏星标金（VRChat 惯例）——FeedView 星标筛选使用（评审阻断②修复） */
   --radius: 10px;
   --font-mono: ui-monospace, 'JetBrains Mono', SFMono-Regular, Menlo, Consolas, monospace;
   --header-h: 48px;

--- a/plugins/official/web-dashboard/ui/src/utils.test.js
+++ b/plugins/official/web-dashboard/ui/src/utils.test.js
@@ -1,0 +1,70 @@
+// utils 纯函数单测（重构行为等价锚点）
+import { describe, it, expect } from 'vitest';
+import { time, date, reltime, parseLoc, avatarLabel, isWebOnline, platformLabel, platformIcon, dateTime } from './utils.js';
+
+describe('时间格式', () => {
+  it('time/date 空值兜底', () => {
+    expect(time('')).toBe('--:--');
+    expect(date('')).toBe('--/--');
+  });
+  it('reltime 分级', () => {
+    expect(reltime('')).toBe('');
+    expect(reltime('not-a-date')).toBe('');
+    expect(reltime(Date.now())).toBe('刚刚');
+    expect(reltime(Date.now() - 5 * 60_000)).toBe('5 分钟前');
+    expect(reltime(Date.now() - 3 * 3_600_000)).toBe('3 小时前');
+    expect(reltime(Date.now() - 2 * 86_400_000)).toBe('2 天前');
+  });
+  it('dateTime 完整', () => {
+    const r = dateTime('2026-08-31T06:00:00Z');
+    expect(typeof r).toBe('string');
+    expect(r.length).toBeGreaterThan(0);
+  });
+});
+
+describe('位置解析', () => {
+  it('特殊值不误解析', () => {
+    for (const v of ['offline', 'offline:offline', 'traveling']) {
+      const r = parseLoc(v);
+      expect(r.worldId).toBe(v);
+      expect(r.instanceId).toBeNull();
+      expect(r.type).toBeNull();
+    }
+  });
+  it('标准实例格式（type 来自 ~ 标记）', () => {
+    const r = parseLoc('wrld_123:abc~private(usr_abc)~region(us)');
+    expect(r.worldId).toBe('wrld_123');
+    expect(r.instanceId).toBe('abc');
+    expect(r.type).toBe('private');
+    expect(r.ownerId).toBe('usr_abc');
+    expect(r.region).toBe('us');
+  });
+  it('无 ~ 标记时 type 默认 public', () => {
+    const r = parseLoc('wrld_123:abc');
+    expect(r.type).toBe('public');
+  });
+  it('空值', () => {
+    expect(parseLoc('')).toBeNull();
+    expect(parseLoc(null)).toBeNull();
+  });
+});
+
+describe('头像/平台', () => {
+  it('avatarLabel 无图时显示首字母', () => {
+    expect(avatarLabel('', 'Alice')).toBe('A');
+    expect(avatarLabel('', '')).toBe('?');
+    expect(avatarLabel('http://img')).toBeUndefined();
+  });
+  it('isWebOnline 识别网页在线（对象）', () => {
+    expect(isWebOnline({ isOnline: true, platform: 'web' })).toBe(true);
+    expect(isWebOnline({ isOnline: true, platform: 'standalone' })).toBe(false);
+    expect(isWebOnline({ isOnline: false, platform: 'web' })).toBe(false);
+    expect(isWebOnline({ isOnline: true, location: 'offline:offline' })).toBe(true);
+  });
+  it('platformLabel/Icon 映射', () => {
+    expect(platformLabel('standalone')).toBeTruthy();
+    expect(platformIcon('web')).toBe('pi-globe');
+    expect(platformIcon('standalone')).toBeTruthy();
+    expect(platformIcon('')).toBe('');
+  });
+});

--- a/plugins/official/web-dashboard/ui/src/views/FeedView.vue
+++ b/plugins/official/web-dashboard/ui/src/views/FeedView.vue
@@ -339,6 +339,7 @@ onMounted(() => {
   }
 });
 onUnmounted(() => {
+  if (filterTimer) clearTimeout(filterTimer); // 筛选防抖定时器卸载清理（评审建议）
   if (observer) observer.disconnect();
   const rootEl = document.querySelector('.main-viewport');
   if (rootEl && onScroll) rootEl.removeEventListener('scroll', onScroll);

--- a/plugins/official/web-dashboard/ui/src/views/FeedView.vue
+++ b/plugins/official/web-dashboard/ui/src/views/FeedView.vue
@@ -1,7 +1,11 @@
 <script setup>
 import { ref, computed, watch, onMounted, onUnmounted } from 'vue';
-import { store, openUser, openWorld, openPreview, loadMoreFeed, copyText, openGroup, resetFeed } from '../store.js';
+import { store, setView, openUser, openWorld, openPreview, loadMoreFeed, copyText, openGroup, resetFeed } from '../store.js';
 import { time, date, locLabel, statusLabels, trustColor, instanceLabel, avatarLabel } from '../utils.js';
+import { post } from '../api.js';
+import { toast } from '../toast.js';
+import { statusColor } from '../composables/useFriendGroups.js';
+import { typeOf, isNotiUpdate, TYPE_LABELS, TYPE_ICONS, TYPE_SEVERITIES } from '../constants/event-types.js';
 
 const datePop = ref(null);
 
@@ -43,6 +47,22 @@ const dateLabel = computed(() => {
   return store.feedDateFrom ? `${fmt(store.feedDateFrom)} 起` : `至 ${fmt(store.feedDateTo)}`;
 });
 const hasDateFilter = computed(() => !!(store.feedDateFrom || store.feedDateTo));
+// 任一筛选激活（类型/日期/星标/关注/我的/此世界/此人/追踪）
+const hasAnyFilter = computed(() => store.feedFilter.length > 0 || hasDateFilter.value || store.feedOnlyFav || store.feedOnlyWatch || store.feedOnlyMe || store.feedOnlyWorld || store.feedOnlyUser || store.feedOnlyTracked);
+function clearAllFilters() {
+  store.feedFilter = [];
+  store.feedDateFrom = '';
+  store.feedDateTo = '';
+  store.feedOnlyFav = false;
+  store.feedOnlyWatch = false;
+  store.feedOnlyMe = false;
+  store.feedOnlyWorld = '';
+  store.feedOnlyUser = '';
+  store.feedOnlyTracked = false;
+  dateRange.value = [];
+  setView(store.view);   // 同步 URL hash（清除 filter/fav 参数，刷新不再恢复旧筛选）
+  // 筛选字段变化由下方 watch 自动触发 resetFeed（避免双重加载）
+}
 // 日历范围选满两个端点才可应用
 const canApplyRange = computed(() => Array.isArray(dateRange.value) && dateRange.value.length === 2 && !!dateRange.value[0] && !!dateRange.value[1]);
 
@@ -73,63 +93,8 @@ function clearDateRange() {
 }
 
 /* ── 类型判定 ── */
-function typeOf(x) {
-  if (x.type === 'friend-location' || x.type === 'user-location') return 'location';
-  if (x.type === 'friend-online') return 'online';
-  if (x.type === 'friend-offline') return 'offline';
-  if (x.type === 'friend-active') return 'status';
-  if (x.type === 'friend-update') {
-    if (x.updateType === 'avatar') return 'avatar';
-    if (x.updateType === 'bio') return 'bio';
-    if (x.updateType === 'status') return 'status';
-    if (x.updateType === 'user_icon') return 'userIcon';
-    if (x.updateType === 'pronouns') return 'pronouns';
-    if (x.updateType === 'displayName') return 'displayName';
-    return 'other';
-  }
-  // 自己的资料/状态更新：与 friend-update 一致显示（状态灯/简介/模型）；
-  // 旧格式（无 updateType）默认按状态变动——用户视角就是"在线状态更新"
-  if (x.type === 'user-update') {
-    if (x.updateType === 'avatar') return 'avatar';
-    if (x.updateType === 'bio') return 'bio';
-    if (x.updateType === 'user_icon') return 'userIcon';
-    if (x.updateType === 'pronouns') return 'pronouns';
-    if (x.updateType === 'displayName') return 'displayName';
-    return 'status';
-  }
-  if (x.type === 'friend-add') return 'friendAdd';
-  if (x.type === 'friend-delete') return 'friendDelete';
-  if (x.type === 'unknown') return 'unknown';
-  if (x.type === 'content-refresh') return 'contentRefresh';
-  if (x.type === 'group-joined') return 'groupJoined';
-  if (x.type === 'group-member-updated') return 'groupMemberUpdated';
-  if (x.type === 'hide-notification' || x.type === 'see-notification') return 'notificationUpdate';
-  if (x.type === 'notification' || x.type === 'notification-v2') {
-    const t = x.updateType || x.notificationType || '';
-    if (t === 'friendRequest') return 'friendRequest';
-    if (t === 'invite' || t === 'requestInvite') return 'invite';
-    if (t === 'message') return 'message';
-    if (String(t).startsWith('group.')) return 'group';
-    return 'notification';
-  }
-  // 通知状态更新：关联到群组通知的归入"群组通知"，否则"通知更新"
-  if (x.type === 'notification-v2-update' || x.type === 'notification-update') {
-    return x.notiGroupId ? 'group' : 'notificationUpdate';
-  }
-  return 'other';
-}
-const typeLabels = { location: '位置变动', online: '上线', offline: '下线', status: '状态变动', avatar: '模型变动', bio: '简介变更', userIcon: '头像图标', pronouns: '代词变更', displayName: '改名', friendRequest: '好友申请', invite: '邀请', message: '私信', group: '群组通知', notification: '通知', notificationUpdate: '通知更新', friendAdd: '新增好友', friendDelete: '删除好友', unknown: '未知事件', contentRefresh: '内容库', groupJoined: '加入群组', groupMemberUpdated: '群组更新', other: '资料变动' };
-const typeIcons = { location: 'pi-map-marker', online: 'pi-sign-in', offline: 'pi-sign-out', status: 'pi-heart', avatar: 'pi-user-edit', bio: 'pi-file-edit', userIcon: 'pi-id-card', pronouns: 'pi-user', displayName: 'pi-pencil', friendRequest: 'pi-user-plus', invite: 'pi-arrow-right-arrow-left', message: 'pi-comment', group: 'pi-users', notification: 'pi-bell', notificationUpdate: 'pi-bell', friendAdd: 'pi-user-plus', friendDelete: 'pi-user-minus', unknown: 'pi-question-circle', contentRefresh: 'pi-refresh', groupJoined: 'pi-users', groupMemberUpdated: 'pi-users', other: 'pi-user' };
-const typeSeverities = { location: 'info', online: 'success', offline: 'secondary', status: 'warning', avatar: 'warn', bio: 'contrast', userIcon: 'secondary', pronouns: 'contrast', displayName: 'warn', friendRequest: 'success', invite: 'info', message: 'secondary', group: 'warn', notification: 'secondary', notificationUpdate: 'secondary', friendAdd: 'success', friendDelete: 'danger', unknown: 'secondary', contentRefresh: 'info', groupJoined: 'success', groupMemberUpdated: 'warn', other: 'secondary' };
-function isNotiUpdate(x) {
-  return x.type === 'notification-v2-update' || x.type === 'notification-update';
-}
 
-/* ── 状态灯颜色（VRChat 官方状态色）── */
-const STATUS_COLORS = { active: '#52c41a', 'join me': '#4287f5', 'ask me': '#fa8c16', busy: '#f5222d', offline: '#596778' };
-function statusColor(s) {
-  return STATUS_COLORS[s] || '#596778';
-}
+/* ── 状态灯颜色（VRChat 官方状态色，共享自 useFriendGroups）── */
 function statusText(s) {
   return statusLabels[s] || s || '';
 }
@@ -342,9 +307,14 @@ function fillFeed() {
 // 有筛选时列表匹配不足自动补齐（无筛选靠触底/按钮手动加载，避免死循环）
 watch(rows, () => { if (hasFilter()) fillFeed(); });
 // 筛选条件变化 → 重置列表（只留当前筛选下的最新数据，不堆积为凑数加载的无关事件）再补齐
+// 筛选/搜索变化：搜索输入防抖 300ms（避免每键请求），其它筛选即时
+let filterTimer = null;
 watch(() => [store.feedFilter, store.feedSearch, store.feedDateFrom, store.feedDateTo, store.feedOnlyFav, store.feedOnlyWatch, store.feedOnlyMe, store.feedOnlyUser, store.feedOnlyTracked, store.feedOnlyWorld], () => {
-  if (store.feedLoading) return;
-  resetFeed().then(() => fillFeed());
+  clearTimeout(filterTimer);
+  filterTimer = setTimeout(() => {
+    if (store.feedLoading) return;
+    resetFeed().then(() => fillFeed());
+  }, 300);
 });
 let observer = null;
 let onScroll = null;
@@ -388,8 +358,9 @@ onUnmounted(() => {
       </div>
     </Popover>
 
-    <div class="view-title">
-      动态
+    <div class="feed-head">
+      <h2><i class="pi pi-bolt"></i> 动态</h2>
+      <span class="feed-sub">{{ store.feedTotal ? '数据库共 ' + store.feedTotal + ' 条' : '好友活动实时记录' }}</span>
       <Tag v-if="store.feedLoading" value="同步中…" severity="secondary" rounded />
       <!-- 日期+星标在标题行（双端统一）；弹层锚定到点击的按钮 -->
       <span class="vt-actions">
@@ -407,6 +378,7 @@ onUnmounted(() => {
           <i :class="store.feedOnlyMe ? 'pi pi-user-check' : 'pi pi-user'"></i>
         </button>
         <button class="chip star-btn" title="导出当前筛选结果（JSON）" aria-label="导出当前筛选结果" @click="exportRows"><i class="pi pi-download"></i></button>
+        <button v-if="hasAnyFilter" class="chip star-btn" title="清除全部筛选" aria-label="清除全部筛选" @click="clearAllFilters"><i class="pi pi-filter-slash"></i> 清除全部</button>
         <button v-if="store.feedOnlyWorld" class="chip star-btn star-on" @click="clearWorldFilter" :title="'清除「只看此世界」筛选'" aria-label="清除只看此世界筛选">
           <i class="pi pi-globe"></i> 只看此世界{{ worldNameOf() ? '：' + worldNameOf().slice(0, 16) : '' }}
         </button>
@@ -423,7 +395,7 @@ onUnmounted(() => {
     <!-- 类型筛选横条 + 搜索（所有元素弹性收缩换行） -->
     <div class="feed-toolbar">
       <div class="ft-row">
-        <div class="ft-chips">
+        <div class="ft-chips" role="group" aria-label="事件类型筛选">
           <button v-for="o in filterOptions" :key="o.value" class="chip" :class="{ active: isFilterActive(o.value) }" @click="toggleFilter(o.value)">{{ o.label }}</button>
         </div>
         <div class="ft-search">
@@ -459,7 +431,7 @@ onUnmounted(() => {
       <div v-else class="ev-row" :class="{ open: expanded === rowId(x) }" role="button" tabindex="0" @click="toggleRow(x)" @keydown.enter="toggleRow(x)">
         <div v-if="!store.isMobile" class="c-time mono">{{ time(x.createdAt) }}<small>{{ date(x.createdAt) }}</small></div>
         <div v-else class="c-time mono">{{ date(x.createdAt) }}</div>
-        <div class="c-type"><Tag :value="typeLabels[typeOf(x)]" :severity="typeSeverities[typeOf(x)]" rounded><i class="pi ctype-ico" :class="typeIcons[typeOf(x)] || 'pi-circle'"></i></Tag></div>
+        <div class="c-type"><Tag :value="TYPE_LABELS[typeOf(x)]" :severity="TYPE_SEVERITIES[typeOf(x)]" rounded><i class="pi ctype-ico" :class="TYPE_ICONS[typeOf(x)] || 'pi-circle'"></i></Tag></div>
         <div class="c-player" @click.stop="playerOpen(x)" role="button" tabindex="0" @keydown.enter="playerOpen(x)">
           <Avatar :image="playerAvatarOf(x)" shape="circle" size="small" :label="avatarLabel(playerAvatarOf(x), playerNameOf(x))" />
           <span class="pl-name" :style="{ color: trustColor(x.trustLevel) }">{{ playerNameOf(x) }}</span>
@@ -541,7 +513,7 @@ onUnmounted(() => {
 
           <!-- 邀请 / 私信 -->
           <template v-else-if="typeOf(x) === 'invite' || typeOf(x) === 'message'">
-            <span class="dim">{{ x.notiMessage || x.notiTitle || x.summary || (x.senderUsername + ' 发来一条' + typeLabels[typeOf(x)]) }}</span>
+            <span class="dim">{{ x.notiMessage || x.notiTitle || x.summary || (x.senderUsername + ' 发来一条' + TYPE_LABELS[typeOf(x)]) }}</span>
           </template>
 
           <!-- 群组通知：显示群组名+内容；更新类显示"通知已读：内容"，点击打开群组 -->
@@ -689,6 +661,7 @@ onUnmounted(() => {
 
       <div class="feed-more">
         <Button v-if="store.feedHasMore && store.feedEvents.length < feedHardCap" :label="store.feedLoadingMore ? '加载中…' : '加载更多'" text size="small" icon="pi pi-angle-down" @click="loadMoreFeed()" />
+        <span v-else-if="store.feedEvents.length" class="feed-end">— 已加载全部动态 —</span>
         <!-- 哨兵始终渲染（条件渲染会导致 onMounted 拿不到元素、observer 失效） -->
         <div id="feed-sentinel" class="feed-sentinel"></div>
       </div>
@@ -697,6 +670,7 @@ onUnmounted(() => {
 </template>
 
 <style scoped>
+.feed-view { padding: 4px; }
 .feed-toolbar { margin-bottom: 12px; }
 .ft-row { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
 .ft-chips { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; flex: 1 1 320px; min-width: 0; }
@@ -721,6 +695,7 @@ onUnmounted(() => {
 .ft-search > .pi-search { font-size: 11px; color: var(--text-dim); flex: none; }
 .search-clear { font-size: 10px; color: var(--text-dim); cursor: pointer; padding: 2px; flex: none; }
 .search-clear:hover { color: var(--text); }
+.feed-sub { font-size: 11px; color: var(--text-dim); flex: 1; min-width: 80px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .feed-count { margin-left: auto; color: var(--text-dim); font-size: 11px; font-variant-numeric: tabular-nums; min-width: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 /* C4 窄窗口：计数保持行内、贴最右（不换行独占） */
 @media (min-width: 900px) and (max-width: 1280px) {
@@ -729,49 +704,23 @@ onUnmounted(() => {
 
 /* C4 桌面窄窗口：标题行与工具栏所有元素一起弹性收缩换行，不再只有 chips 独自动 */
 @media (min-width: 900px) and (max-width: 1280px) {
-  .view-title { flex-wrap: wrap; row-gap: 4px; }
+  .feed-head { flex-wrap: wrap; row-gap: 4px; }
   .vt-actions .chip { padding: 4px 8px; }
   .ft-row { row-gap: 6px; }
   .ft-chips { flex-basis: auto; }
   .ft-search { max-width: none; min-width: 140px; flex: 1 1 150px; }
 }
 
-/* 筛选 chip（多选 + 日期/星标统一为同一视觉语言） */
-.chip {
-  border: 1px solid var(--border);
-  background: var(--surface-2);
-  color: var(--text-dim);
-  border-radius: 999px;
-  padding: 4px 13px;
-  font-size: 12px;
-  height: 28px;
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  cursor: pointer;
-  transition: all 0.12s;
-  white-space: nowrap;
-  font-family: inherit;
-  line-height: 1;
-}
-
-.chip.active {
-  background: var(--accent);
-  border-color: var(--accent);
-  color: #fff;
-}
-
+/* 筛选 chip：视觉语言统一走全局 .chip（style.css），此处仅保留本页私有覆盖 */
 .date-btn i { font-size: 11px; }
 .date-btn.active { background: color-mix(in srgb, var(--accent) 14%, transparent); color: var(--accent); }
 .star-btn { width: 30px; padding: 0; justify-content: center; }
 .star-btn i { font-size: 12px; }
-.star-btn.star-on { color: #ffca28; border-color: color-mix(in srgb, #ffca28 40%, var(--border)); }
-.date-opts { display: flex; flex-direction: column; gap: 2px; padding: 4px; }
-.date-opts .chip { text-align: left; border-radius: 6px; }
+.star-btn.star-on { color: var(--star); border-color: color-mix(in srgb, var(--star) 40%, var(--border)); }
 .date-cal { padding: 6px; }
 .dc-actions { display: flex; justify-content: flex-end; align-items: center; gap: 8px; padding: 8px 6px 2px 0; }
-.star-on { color: #ffca28 !important; }
-.star-on .pi { color: #ffca28 !important; }
+.star-on { color: var(--star) !important; }
+.star-on .pi { color: var(--star) !important; }
 
 .feed-loading { display: flex; flex-direction: column; align-items: center; gap: 10px; padding: 60px 0; }
 
@@ -825,7 +774,7 @@ onUnmounted(() => {
 }
 .c-player:hover { background: var(--surface-3); }
 .pl-name { font-weight: 600; font-size: 12.5px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.pl-star { font-size: 9px; color: #ffca28; flex: none; }
+.pl-star { font-size: 9px; color: var(--star); flex: none; }
 .pl-watch { font-size: 9px; color: var(--text-dim); flex: none; margin-left: 3px; }
 
 /* 详细信息列：桌面禁止换行（单行省略）；移动端卡片流仍允许换行 */
@@ -961,7 +910,7 @@ onUnmounted(() => {
 .noti-read-wrap.noti-msg-link .noti-msg-inline { color: var(--accent-2); }
 
 .feed-more { display: flex; flex-direction: column; align-items: center; gap: 4px; padding: 12px 0; }
-.feed-cap-hint { font-size: 11px; }
+.feed-end { font-size: 11px; color: var(--text-dim); opacity: 0.7; }
 
 /* B3 展开详情 */
 .ev-chev { display: none; }
@@ -987,10 +936,10 @@ onUnmounted(() => {
 
 /* 移动端：卡片化 */
 @media (max-width: 899px) {
+  .feed-head { flex-wrap: wrap; row-gap: 4px; }
   .ft-head { display: none; }
   .ft-row { gap: 8px; }
-  /* 筛选 chips 与标题行日期/星标按钮同大小（用户要求统一） */
-  .chip { height: 26px; padding: 4px 10px; font-size: 11px; }
+  /* 筛选 chips 移动端尺寸走全局（style.css @media .chip） */
   .search-input { font-size: 12.5px; }
   /* 右上角计数三段在手机上收窄（完整值在 title 提示） */
   .feed-count { font-size: 10px; max-width: 56%; }


### PR DESCRIPTION
按前端重构调研报告执行 Phase 1a + Phase 3（低风险先行，行为等价）。

### Phase 1a：抽取事件类型常量
- 新增 `src/constants/event-types.js`：`typeOf`/`TYPE_LABELS`/`TYPE_ICONS`/`TYPE_SEVERITIES`/`isNotiUpdate` 从 FeedView 剥离
- `FeedView.vue` 1032 → 981 行，模板改用常量导入

### Phase 3：补前端单测（此前前端零测试）
- `event-types.test.js`（8 用例）+ `utils.test.js`（10 用例）
- `npm test` 接入 vitest

### 评审修复（已合入本 PR）
- ① build 脚本 `rm -f` → `node -e` 删除（跨平台安全，DEVELOPMENT.md §3.2）
- ② style.css 补 `--star` 定义（星标色在 upstream 环境生效）
- ③ FeedView 筛选防抖定时器 onUnmounted 清理

### 附带说明（范围漂移——PR 基于 fork 开发线，含此前已合入上游的 UI 变更：清除全部筛选按钮、feed-sub 总数显示、已加载全部提示、筛选 300ms 防抖、.chip 样式全局化。这些均已通过 #112/#115 合入上游 main，本 PR 分支基于上游重建时自然携带）

### 验证
- `npx vitest run` 18 passed · `npm run build` 通过
- PR 不含 dist 构建产物