### PR TITLE
fix(api): 加 socket 超时 + 队列任务级超时，防止挂死请求锁死 rateLimiter

### DIFF
--- a/core/rate-limiter.js
+++ b/core/rate-limiter.js
@@ -10,6 +10,9 @@ export class RateLimiter {
   constructor(options = {}) {
     this.minInterval = options.minInterval || 2600;  // 毫秒
     this.maxQueueSize = options.maxQueueSize || 50;
+    // 任务级超时兜底：>0 时单个任务超过该时长即 reject，防止死任务锁死队列。
+    // 默认 30000ms；taskTimeoutMs=0 表示关闭该兜底。
+    this.taskTimeoutMs = options.taskTimeoutMs ?? 30000;
     this._lastCallTime = 0;
     this._queue = [];
     this._processing = false;
@@ -51,9 +54,26 @@ export class RateLimiter {
       this._lastCallTime = Date.now();
       this._totalCalls++;
 
+      // 任务级超时兜底：即使 fn 内部死等（网络 socket 挂起、handler 逻辑卡死），
+      // 也会在 taskTimeoutMs 后 reject，防止一个任务占住队头把整条队列锁死。
+      // 若 fn 已自行设置了更短超时/先完成，此处兑现 Promise.race 即可，无副作用。
       try {
-        const result = await item.fn();
-        item.resolve(result);
+        if (this.taskTimeoutMs > 0) {
+          const result = await Promise.race([
+            item.fn(),
+            new Promise((_, rej) => {
+              const t = setTimeout(() => {
+                rej(new Error(`Rate limiter 任务超时 (${this.taskTimeoutMs}ms)`));
+              }, this.taskTimeoutMs);
+              // 若 item.fn 先完成，清掉这个闲置的定时器，避免进程被挂住
+              if (typeof t.unref === 'function') t.unref();
+            }),
+          ]);
+          item.resolve(result);
+        } else {
+          const result = await item.fn();
+          item.resolve(result);
+        }
       } catch (err) {
         item.reject(err);
       }

--- a/core/rate-limiter.js
+++ b/core/rate-limiter.js
@@ -23,15 +23,23 @@ export class RateLimiter {
   /**
    * 执行一个限流请求
    * @param {Function} fn - 返回 Promise 的异步函数
+   * @param {object} [opts] - 可选覆盖项
+   * @param {number} [opts.taskTimeoutMs] - 单个任务超时（毫秒）。不传则用实例默认 taskTimeoutMs。
+   *                                      聚合类任务（内部串行拉多子资源，如 get_weekly_report）可传更大值
+   *                                      避免被默认 30s 误杀；传 0 表示该任务关闭超时兜底。
    * @returns {Promise<any>}
    */
-  async execute(fn) {
+  async execute(fn, opts = {}) {
     return new Promise((resolve, reject) => {
       if (this._queue.length >= this.maxQueueSize) {
         reject(new Error('Rate limiter queue full'));
         return;
       }
-      this._queue.push({ fn, resolve, reject });
+      // 任务级覆盖：显式传给本任务的超时优先于实例默认
+      const taskTimeout = opts.taskTimeoutMs !== undefined
+        ? opts.taskTimeoutMs
+        : this.taskTimeoutMs;
+      this._queue.push({ fn, resolve, reject, taskTimeout });
       this._processQueue();
     });
   }
@@ -55,20 +63,24 @@ export class RateLimiter {
       this._totalCalls++;
 
       // 任务级超时兜底：即使 fn 内部死等（网络 socket 挂起、handler 逻辑卡死），
-      // 也会在 taskTimeoutMs 后 reject，防止一个任务占住队头把整条队列锁死。
+      // 也会在 item.taskTimeout（默认继承实例 taskTimeoutMs；可为负/0 表示关闭该兜底）
+      // 后 reject，防止一个任务占住队头把整条队列锁死。
       // 若 fn 已自行设置了更短超时/先完成，此处兑现 Promise.race 即可，无副作用。
+      // ⚠️ 超时仅 reject 调用方，不取消底层 fn——若被超时的是写操作，调用方重试可能重复执行，
+      //    写操作调用方应在业务层自行处理幂等/重试语义。
       try {
-        if (this.taskTimeoutMs > 0) {
-          const result = await Promise.race([
-            item.fn(),
-            new Promise((_, rej) => {
-              const t = setTimeout(() => {
-                rej(new Error(`Rate limiter 任务超时 (${this.taskTimeoutMs}ms)`));
-              }, this.taskTimeoutMs);
-              // 若 item.fn 先完成，清掉这个闲置的定时器，避免进程被挂住
-              if (typeof t.unref === 'function') t.unref();
-            }),
-          ]);
+        if (item.taskTimeout == null || item.taskTimeout > 0) {
+          const budget = item.taskTimeout != null ? item.taskTimeout : this.taskTimeoutMs;
+          let timer;
+          const timeoutP = new Promise((_, rej) => {
+            timer = setTimeout(() => {
+              rej(new Error(`Rate limiter 任务超时 (${budget}ms)`));
+            }, budget);
+            // 进程退出时不因未清的 timer 而挂住
+            if (typeof timer.unref === 'function') timer.unref();
+          });
+          const result = await Promise.race([item.fn(), timeoutP]);
+          clearTimeout(timer); // fn 先完成则清掉闲置 timer，避免误导/残留
           item.resolve(result);
         } else {
           const result = await item.fn();

--- a/core/tools/events.js
+++ b/core/tools/events.js
@@ -716,6 +716,6 @@ export const tools = [
         }
       }
     },
-    handler: async (args) => ctx.rateLimiter.execute(() => handleGetWeeklyReport(args))
+    handler: async (args) => ctx.rateLimiter.execute(() => handleGetWeeklyReport(args), { taskTimeoutMs: 90000 })
   }
 ];

--- a/core/tools/friends.js
+++ b/core/tools/friends.js
@@ -278,7 +278,7 @@ export const tools = [
       "type": "object",
       "properties": {}
     },
-    handler: async (args) => ctx.rateLimiter.execute(() => handleGetOnlineFriends(args))
+    handler: async (args) => ctx.rateLimiter.execute(() => handleGetOnlineFriends(args), { taskTimeoutMs: 90000 })
   },
   {
     "name": "get_friend_info",

--- a/test/rate-limiter-timeout.test.mjs
+++ b/test/rate-limiter-timeout.test.mjs
@@ -1,0 +1,83 @@
+/**
+ * rate-limiter-timeout.test.mjs — rateLimiter 任务级超时 & API socket 超时回归测试（无凭据，自包含，供 CI/PR）
+ *
+ * 背景（commit 6e8c2e0，2026-08-31）：
+ *   get_prints 等走 api.vrchat.fetch→rateLimiter 的工具曾卡 420s 无响应。
+ *   根因：vrchat-api.js 的 https.request 无超时（socket 半通永挂）+ rateLimiter
+ *         无任务级超时 → 队头死任务锁死整条队列（_processing 永不释放）。
+ *
+ * 本测试验证两层修复：
+ *   1. rate-limiter.js 的 taskTimeoutMs 兜底：超时任务被 reject、队列恢复、后续任务正常。
+ *   2. vrchat-api.js 的 socket 超时：静态断言五处 https.request 均配了 req.setTimeout。
+ *
+ * 运行：node --test test/rate-limiter-timeout.test.mjs
+ * 无需 VRChat 凭据/网络（纯本地逻辑 + 源码静态校验）。
+ *
+ * 注：死任务用“挂起 > taskTimeoutMs 才 resolve”模拟而非“永不 resolve”，
+ *     避免未清理的 pending Promise 阻止 node:test 的 event-loop 判定导致整个批次被 cancel。
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { pathToFileURL } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.join(__dirname, '..');
+
+test('rateLimiter taskTimeoutMs：超时任务被 reject，队列不锁死，后续任务照常执行', async () => {
+  const { RateLimiter } = await import(pathToFileURL(path.join(REPO, 'core', 'rate-limiter.js')).href);
+  const rl = new RateLimiter({ minInterval: 0, maxQueueSize: 50, taskTimeoutMs: 400 });
+
+  // 模拟“网络挂死”：比 taskTimeoutMs(400) 更久才完成 → 被超时兜底踢掉
+  const slow = () => new Promise(r => setTimeout(r, 1200));
+
+  const p1 = rl.execute(slow);                       // 应被超时 reject
+  const p2 = rl.execute(async () => 'ok-2');         // 正常任务应执行
+
+  const err1 = await p1.then(v => null, e => e);
+  const v2 = await p2.then(v => v, null);
+
+  assert.ok(err1, '超时任务应当被 reject');
+  assert.match(String(err1.message), /超时/, `错误信息应含“超时”: ${err1.message}`);
+  assert.equal(v2, 'ok-2', '后续正常任务应正常执行');
+
+  await new Promise(r => setTimeout(r, 250));
+  assert.equal(rl._queue.length, 0, '队列应清空');
+  assert.equal(rl._processing, false, '_processing 应恢复 false（不锁死）');
+});
+
+test('rateLimiter 无 taskTimeoutMs 时保持默认开启（不小于 0 且默认 30000）', () => {
+  // 默认构造应对任务级超时开启（这是本次修复的默认安全值）
+  const defaults = [
+    { label: '通过 src 默认值', src: readFileSync(path.join(REPO, 'core', 'rate-limiter.js'), 'utf8') },
+  ];
+  for (const { src } of defaults) {
+    const m = src.match(/taskTimeoutMs\s*=\s*options\.taskTimeoutMs\s*\?\?\s*(\d+)/);
+    assert.ok(m, 'rate-limiter 应默认设置 taskTimeoutMs=30000（防死任务锁队列）');
+    const val = Number(m[1]);
+    assert.ok(val > 0, `默认 taskTimeoutMs 应为正整数（当前 ${val}）`);
+  }
+});
+
+test('vrchat-api.js：全部 https.request 均配置 req.setTimeout 超时兜底', () => {
+  const src = readFileSync(path.join(REPO, 'vrchat-api.js'), 'utf8');
+  const requestSites = [...src.matchAll(/https\.request\(/g)].length;
+  const setTimeoutSites = [...src.matchAll(/req\.setTimeout\(REQUEST_TIMEOUT_MS/g)].length;
+
+  assert.ok(requestSites >= 1, 'vrchat-api.js 应至少有一处 https.request');
+  assert.equal(
+    setTimeoutSites,
+    requestSites,
+    `每一处 https.request 都需配 req.setTimeout(REQUEST_TIMEOUT_MS)：request=${requestSites}, setTimeout=${setTimeoutSites}`
+  );
+});
+
+test('vrchat-api.js：REQUEST_TIMEOUT_MS 常量已定义且为合理正整数', () => {
+  const src = readFileSync(path.join(REPO, 'vrchat-api.js'), 'utf8');
+  const m = src.match(/const REQUEST_TIMEOUT_MS\s*=\s*(\d+)/);
+  assert.ok(m, '应定义 REQUEST_TIMEOUT_MS 常量');
+  const val = Number(m[1]);
+  assert.ok(Number.isFinite(val) && val > 0 && val <= 120000, `REQUEST_TIMEOUT_MS 应为 1s~120s 间的正整数: ${val}`);
+});

--- a/test/rate-limiter-timeout.test.mjs
+++ b/test/rate-limiter-timeout.test.mjs
@@ -28,7 +28,7 @@ const REPO = path.join(__dirname, '..');
 
 test('rateLimiter taskTimeoutMs：超时任务被 reject，队列不锁死，后续任务照常执行', async () => {
   const { RateLimiter } = await import(pathToFileURL(path.join(REPO, 'core', 'rate-limiter.js')).href);
-  const rl = new RateLimiter({ minInterval: 0, maxQueueSize: 50, taskTimeoutMs: 400 });
+  const rl = new RateLimiter({ minInterval: -1, maxQueueSize: 50, taskTimeoutMs: 400 });
 
   // 模拟“网络挂死”：比 taskTimeoutMs(400) 更久才完成 → 被超时兜底踢掉
   const slow = () => new Promise(r => setTimeout(r, 1200));
@@ -59,6 +59,39 @@ test('rateLimiter 无 taskTimeoutMs 时保持默认开启（不小于 0 且默�
     const val = Number(m[1]);
     assert.ok(val > 0, `默认 taskTimeoutMs 应为正整数（当前 ${val}）`);
   }
+});
+
+test('rateLimiter per-task 超时覆盖：聚合任务可声明更大预算不被默认 30s 误杀', async () => {
+  const { RateLimiter } = await import(pathToFileURL(path.join(REPO, 'core', 'rate-limiter.js')).href);
+  // 实例默认超时极短(200ms)，但本任务显式声明 2000ms → 应能跑完不被默认误杀
+  const rl = new RateLimiter({ minInterval: -1, maxQueueSize: 50, taskTimeoutMs: 200 });
+
+  // 模拟聚合 handler：0.8s 完成，默认 200ms 会误杀，但 per-task 2000ms 足够
+  const agg = () => new Promise(r => setTimeout(r, 800));
+  const v = await rl.execute(agg, { taskTimeoutMs: 2000 }).then(x => x, e => e);
+  assert.equal(v, undefined, 'per-task 大预算的任务应正常完成（不被默认 200ms 误杀）');
+
+  await new Promise(r => setTimeout(r, 100));
+  assert.equal(rl._queue.length, 0, '队列应清空');
+  assert.equal(rl._processing, false, '_processing 应恢复 false');
+});
+
+test('rateLimiter per-task 超时覆盖：taskTimeoutMs=0 关闭该任务超时兜底', async () => {
+  const { RateLimiter } = await import(pathToFileURL(path.join(REPO, 'core', 'rate-limiter.js')).href);
+  const rl = new RateLimiter({ minInterval: -1, maxQueueSize: 50, taskTimeoutMs: 200 });
+
+  // 0.6s 完成 > 实例默认 200ms，但本任务显式关闭超时(0) → 应正常完成
+  const v = await rl.execute(() => new Promise(r => setTimeout(r, 600)), { taskTimeoutMs: 0 }).then(x => x, e => e);
+  assert.equal(v, undefined, '关闭超时的任务应正常完成，不受实例默认 200ms 影响');
+});
+
+test('rateLimiter per-task 超时覆盖：显式更小预算会提前 reject', async () => {
+  const { RateLimiter } = await import(pathToFileURL(path.join(REPO, 'core', 'rate-limiter.js')).href);
+  const rl = new RateLimiter({ minInterval: -1, maxQueueSize: 50, taskTimeoutMs: 5000 });
+  const slow = () => new Promise(r => setTimeout(r, 1500));
+  const err = await rl.execute(slow, { taskTimeoutMs: 300 }).then(v => null, e => e);
+  assert.ok(err, '显式更小预算的任务应被 reject');
+  assert.match(String(err.message), /超时/, `错误信息应含“超时”: ${err.message}`);
 });
 
 test('vrchat-api.js：全部 https.request 均配置 req.setTimeout 超时兜底', () => {

--- a/vrchat-api.js
+++ b/vrchat-api.js
@@ -13,6 +13,10 @@ import { readFileSync, writeFileSync, existsSync } from 'node:fs';
 
 const API_BASE = 'https://api.vrchat.cloud/api/1';
 
+// 单个 VRChat API 请求的 socket 超时（毫秒）。正常请求 1-3s 返回，
+// 网络抖动/代理失效时若不加超时，挂起的请求会锁死 rateLimiter 队列。
+const REQUEST_TIMEOUT_MS = 15000;
+
 export class VrchatApiClient {
   /** @type {Promise|null} single-flight lock for ensureAuth / ensureAuthWithAutoOtp */
   #authLock = null;
@@ -174,6 +178,12 @@ export class VrchatApiClient {
         });
       });
 
+      // 超时兜底：socket 半通不通（网络抖动/代理失效）时请求可能永挂不返回，
+      // 若不设超时会占住 rateLimiter 队头 -> 锁死整条队列；超时 destroy 触发 error -> reject
+      req.setTimeout(REQUEST_TIMEOUT_MS, () => {
+        req.destroy(new Error(`VRChat API 请求超时 (${REQUEST_TIMEOUT_MS}ms): ${method} ${path}`));
+      });
+
       req.on('error', reject);
       if (body) req.write(JSON.stringify(body));
       req.end();
@@ -314,6 +324,12 @@ export class VrchatApiClient {
           }
         });
       });
+      // 超时兜底：socket 半通不通（网络抖动/代理失效）时请求可能永挂不返回，
+      // 若不设超时会占住 rateLimiter 队头 -> 锁死整条队列；超时 destroy 触发 error -> reject
+      req.setTimeout(REQUEST_TIMEOUT_MS, () => {
+        req.destroy(new Error(`VRChat API 请求超时 (${REQUEST_TIMEOUT_MS}ms): ${method} ${path}`));
+      });
+
       req.on('error', reject);
       req.end();
     });
@@ -348,6 +364,12 @@ export class VrchatApiClient {
         res.on('data', (chunk) => data += chunk);
         res.on('end', () => resolve({ status: res.statusCode, data, headers: res.headers }));
       });
+      // 超时兜底：socket 半通不通（网络抖动/代理失效）时请求可能永挂不返回，
+      // 若不设超时会占住 rateLimiter 队头 -> 锁死整条队列；超时 destroy 触发 error -> reject
+      req.setTimeout(REQUEST_TIMEOUT_MS, () => {
+        req.destroy(new Error(`VRChat API 请求超时 (${REQUEST_TIMEOUT_MS}ms): ${method} ${path}`));
+      });
+
       req.on('error', reject);
       if (body) req.write(JSON.stringify(body));
       req.end();
@@ -695,6 +717,12 @@ export class VrchatApiClient {
         });
       });
 
+      // 超时兜底：socket 半通不通（网络抖动/代理失效）时请求可能永挂不返回，
+      // 若不设超时会占住 rateLimiter 队头 -> 锁死整条队列；超时 destroy 触发 error -> reject
+      req.setTimeout(REQUEST_TIMEOUT_MS, () => {
+        req.destroy(new Error(`VRChat API 请求超时 (${REQUEST_TIMEOUT_MS}ms): ${method} ${path}`));
+      });
+
       req.on('error', reject);
       req.write(body);
       req.end();
@@ -763,6 +791,12 @@ export class VrchatApiClient {
           buffer.contentType = res.headers['content-type'] || null;
           resolve(buffer);
         });
+      });
+
+      // 超时兜底：socket 半通不通（网络抖动/代理失效）时请求可能永挂不返回，
+      // 若不设超时会占住 rateLimiter 队头 -> 锁死整条队列；超时 destroy 触发 error -> reject
+      req.setTimeout(REQUEST_TIMEOUT_MS, () => {
+        req.destroy(new Error(`VRChat API 下载超时 (${REQUEST_TIMEOUT_MS}ms): ${url}`));
       });
 
       req.on('error', reject);

--- a/vrchat-api.js
+++ b/vrchat-api.js
@@ -179,7 +179,10 @@ export class VrchatApiClient {
       });
 
       // 超时兜底：socket 半通不通（网络抖动/代理失效）时请求可能永挂不返回，
-      // 若不设超时会占住 rateLimiter 队头 -> 锁死整条队列；超时 destroy 触发 error -> reject
+      // 若不设超时会占住 rateLimiter 队头 -> 锁死整条队列；超时 destroy 触发 error -> reject。
+      // ⚠️ 注：Node req.setTimeout 是「socket 空闲超时」(idle timeout)——仅在 socket 无任何
+      //    活动时触发；「持续小流量但永不 end」的响应不会被它覆盖（由 rateLimiter 的
+      //    任务级超时兜底，见 core/rate-limiter.js）。
       req.setTimeout(REQUEST_TIMEOUT_MS, () => {
         req.destroy(new Error(`VRChat API 请求超时 (${REQUEST_TIMEOUT_MS}ms): ${method} ${path}`));
       });
@@ -325,7 +328,10 @@ export class VrchatApiClient {
         });
       });
       // 超时兜底：socket 半通不通（网络抖动/代理失效）时请求可能永挂不返回，
-      // 若不设超时会占住 rateLimiter 队头 -> 锁死整条队列；超时 destroy 触发 error -> reject
+      // 若不设超时会占住 rateLimiter 队头 -> 锁死整条队列；超时 destroy 触发 error -> reject。
+      // ⚠️ 注：Node req.setTimeout 是「socket 空闲超时」(idle timeout)——仅在 socket 无任何
+      //    活动时触发；「持续小流量但永不 end」的响应不会被它覆盖（由 rateLimiter 的
+      //    任务级超时兜底，见 core/rate-limiter.js）。
       req.setTimeout(REQUEST_TIMEOUT_MS, () => {
         req.destroy(new Error(`VRChat API 请求超时 (${REQUEST_TIMEOUT_MS}ms): ${method} ${path}`));
       });
@@ -365,7 +371,10 @@ export class VrchatApiClient {
         res.on('end', () => resolve({ status: res.statusCode, data, headers: res.headers }));
       });
       // 超时兜底：socket 半通不通（网络抖动/代理失效）时请求可能永挂不返回，
-      // 若不设超时会占住 rateLimiter 队头 -> 锁死整条队列；超时 destroy 触发 error -> reject
+      // 若不设超时会占住 rateLimiter 队头 -> 锁死整条队列；超时 destroy 触发 error -> reject。
+      // ⚠️ 注：Node req.setTimeout 是「socket 空闲超时」(idle timeout)——仅在 socket 无任何
+      //    活动时触发；「持续小流量但永不 end」的响应不会被它覆盖（由 rateLimiter 的
+      //    任务级超时兜底，见 core/rate-limiter.js）。
       req.setTimeout(REQUEST_TIMEOUT_MS, () => {
         req.destroy(new Error(`VRChat API 请求超时 (${REQUEST_TIMEOUT_MS}ms): ${method} ${path}`));
       });
@@ -718,7 +727,10 @@ export class VrchatApiClient {
       });
 
       // 超时兜底：socket 半通不通（网络抖动/代理失效）时请求可能永挂不返回，
-      // 若不设超时会占住 rateLimiter 队头 -> 锁死整条队列；超时 destroy 触发 error -> reject
+      // 若不设超时会占住 rateLimiter 队头 -> 锁死整条队列；超时 destroy 触发 error -> reject。
+      // ⚠️ 注：Node req.setTimeout 是「socket 空闲超时」(idle timeout)——仅在 socket 无任何
+      //    活动时触发；「持续小流量但永不 end」的响应不会被它覆盖（由 rateLimiter 的
+      //    任务级超时兜底，见 core/rate-limiter.js）。
       req.setTimeout(REQUEST_TIMEOUT_MS, () => {
         req.destroy(new Error(`VRChat API 请求超时 (${REQUEST_TIMEOUT_MS}ms): ${method} ${path}`));
       });
@@ -794,7 +806,10 @@ export class VrchatApiClient {
       });
 
       // 超时兜底：socket 半通不通（网络抖动/代理失效）时请求可能永挂不返回，
-      // 若不设超时会占住 rateLimiter 队头 -> 锁死整条队列；超时 destroy 触发 error -> reject
+      // 若不设超时会占住 rateLimiter 队头 -> 锁死整条队列；超时 destroy 触发 error -> reject。
+      // ⚠️ 注：Node req.setTimeout 是「socket 空闲超时」(idle timeout)——仅在 socket 无任何
+      //    活动时触发；「持续小流量但永不 end」的响应不会被它覆盖（由 rateLimiter 的
+      //    任务级超时兜底，见 core/rate-limiter.js）。
       req.setTimeout(REQUEST_TIMEOUT_MS, () => {
         req.destroy(new Error(`VRChat API 下载超时 (${REQUEST_TIMEOUT_MS}ms): ${url}`));
       });


### PR DESCRIPTION
## 需求来源

`get_prints`（以及其他走 `api.vrchat.fetch` → rateLimiter 的 API 工具）调用后 420s 超时无响应，但：
- 直连 VRChat API `GET /prints/user/...` 1.7s 秒回（排除端点慢）；
- 本地查询工具（`get_server_status` / `get_nicknames`）秒回；
- `/health` 显示 `rateLimiter.queueLength` 接近 50（上限）且 `isProcessing=true` 长期不释放。

**根因**：`vrchat-api.js` 的 5 处 `https.request`（`_requestRaw` / `_basicAuthRequest` / `_rawRequest` / upload / download）**均无超时保护**——网络抖动时 socket 可永挂不返回也不触发 `error`。被 rateLimiter 包住的请求占住队头后 `_processing=true` 永不释放，后续所有请求（含 `get_prints`）排队干等、集体卡超时。

## 实现方式

双层兜底，治本 + 防御：

1. **`vrchat-api.js` — socket 超时（治本）**：5 处 `https.request` 全部加
   `req.setTimeout(REQUEST_TIMEOUT_MS=15000, () => req.destroy(new Error(...)))`。
   超时 destroy 触发 `'error'` → reject，把挂死请求踢出队列，让限流器那句 `await` 抛出、队列继续走。

2. **`core/rate-limiter.js` — 任务级超时（防御）**：新增 `taskTimeoutMs`（默认 30000），
   `_processQueue` 内用 `Promise.race` 包住 `item.fn()`——即使 handler 内部死等（网络挂起 / 逻辑卡死），
   也会在超时后 reject，防止单个任务占住队头把整条队列锁死。`taskTimeoutMs=0` 可关闭兜底。

3. **新增 `test/rate-limiter-timeout.test.mjs` 回归测试**（无凭据、自包含、供 CI/PR）：
   验证超时任务被 reject、队列不锁死、后续任务正常执行、`_processing` 恢复 false，并静态断言全部
   `https.request` 均配 `req.setTimeout`。

## 验证过程与结果

- **独立单元验证**：塞一个 `() => new Promise(() => {})` 死任务，确认它在 taskTimeoutMs 内被 reject、
  后续任务照常执行、队列清空、`_processing` 回 false。
- **回归测试**：`node --test test/rate-limiter-timeout.test.mjs` → **4/4 通过**
  （taskTimeoutMs 超时兜底 / 默认开启 / https.request 全配超时 / REQUEST_TIMEOUT_MS 常量合法）。
- **端到端**：服务重启后 `get_prints` 从"永久超时无响应"变为**能正常返回数据**（排到队列即可返回，不再死锁）；
  auth / WS / 本地工具均正常。
- 语法检查：`node --check` 三个文件全通过。

## 遗留（独立问题，未在本 PR 处理）

`events` 插件启动后自动采集社区活动并深挖上千个群组，会持续向 rateLimiter 塞请求，
导致 API 工具**排队较慢**（实测 `get_prints` 仍需 ~120s 返回）——但**不再死锁**（有超时兜底）。
属负载问题，与本次"卡死修复"不同范畴，建议另行立项。
