### PR TITLE
fix(events): 群组挖掘缓存优先 + 数据入库 + 每日离线刷新,修复 #118 rateLimiter 占满

### DIFF
--- a/core/dashboard-services.js
+++ b/core/dashboard-services.js
@@ -148,6 +148,33 @@ export function registerDashboardServices(loader, ctx) {
   });
   loader.serviceOwners.set('dashboard.latestSelfStatus', 'core');
 
+  // 自己是否在线（issue #118 每日离线刷新的在线感知；events 插件经 api.consume 判定，
+  // 插件契约禁止直读核心 events 表）。返回 true（明确在线）/ false（明确离线）/
+  // null（无法判定——无 selfId/无 user-location 记录/异常）。
+  // 护栏：WS 断链期间收不到 offline 推送，最近一条在线记录超过 1 小时无新事件时
+  // 视为"可能仍在线"返回 null，由调用方保守推迟刷新（宁可晚刷不在可能在线时刷）。
+  loader.services.set('dashboard.isSelfOnline', () => {
+    try {
+      const selfId = getSelfUserId(ctx.storage);
+      if (!selfId) return null;
+      const row = ctx.storage.query(
+        `SELECT content_json, created_at FROM events WHERE type='user-location' AND user_id = $self ORDER BY created_at DESC LIMIT 1`,
+        { $self: selfId }
+      )[0];
+      if (!row) return null;
+      let loc = '';
+      try { loc = (JSON.parse(row.content_json || '{}').location) || ''; } catch { return null; }
+      if (loc === 'offline' || loc === 'offline:offline' || loc === '') return false;
+      if (loc.startsWith('wrld_') || loc === 'traveling') {
+        const at = Date.parse(row.created_at);
+        if (!Number.isFinite(at) || Date.now() - at > 60 * 60 * 1000) return null;
+        return true;
+      }
+      return false;
+    } catch { return null; }
+  });
+  loader.serviceOwners.set('dashboard.isSelfOnline', 'core');
+
   // 动态数据时间范围（最早/最新事件日期）：日历筛选的可选范围（VRCX 对齐）
   loader.services.set('dashboard.eventsRange', () => {
     try {

--- a/core/dashboard-services.js
+++ b/core/dashboard-services.js
@@ -164,13 +164,17 @@ export function registerDashboardServices(loader, ctx) {
       if (!row) return null;
       let loc = '';
       try { loc = (JSON.parse(row.content_json || '{}').location) || ''; } catch { return null; }
+      // 明确离线/空 → false；其余任何 location 都视为"可能在线"（VRChat 在线时 location 可能是
+      // private/friends/group/local/traveling/wrld_ 等，其中 private/friends/group/local 可为"无 worldId 独立值"，
+      // 见 parseLocInfo 实例段解析）。绝不把在线状态误判为离线去触发重挖。
       if (loc === 'offline' || loc === 'offline:offline' || loc === '') return false;
-      if (loc.startsWith('wrld_') || loc === 'traveling') {
+      // 可确认的在线形式 + 新鲜度护栏 → true；无法确认/陈旧 → null（调用方保守推迟刷新）
+      if (loc.startsWith('wrld_') || loc === 'traveling' || /^(private|friends|group|local)\b/.test(loc)) {
         const at = Date.parse(row.created_at);
         if (!Number.isFinite(at) || Date.now() - at > 60 * 60 * 1000) return null;
         return true;
       }
-      return false;
+      return null;
     } catch { return null; }
   });
   loader.serviceOwners.set('dashboard.isSelfOnline', 'core');

--- a/docs/DASHBOARD-DEV-STATUS.md
+++ b/docs/DASHBOARD-DEV-STATUS.md
@@ -914,3 +914,14 @@ git diff --check
 
 - 素材收藏按名称排序（中文感知）；足迹排序偏好 localStorage 持久化
 - 会话累计 192 提交全部签名
+
+## 2026-09-01 社区活动读库化 + 每日离线刷新（issue #118）
+
+- **问题**：启动 90s 无条件预热 `fetch_community_events` 触发群组深挖，持续占满共享 rateLimiter（queueLength 恒满 47~50），所有 API 工具变慢
+- **修复**：
+  - 删除 web-dashboard `prewarmSlowRoutes` 无条件预热（慢路由改懒加载）
+  - `/api/dashboard/community-events` 改读库：`api.consume('events.listStore')` 直读 `plg_events_store`（零限流 API 秒回），evtCache/evtInflight 保留
+  - events 插件新增 `readEventsStore` + `api.provide('events.listStore')`（按 window 过滤 start_iso，字段与工具返回兼容）
+  - core 新增 `groups.resolve` 服务（group_cache 缓存优先 TTL 7 天 + API 回填）；events 挖掘改 consume 该服务，maxMine 默认 60→30
+  - core 新增 `dashboard.isSelfOnline` 服务（events 表 user-location 最新一条判定；超 1h 无新事件的在线记录保守返回 null）
+  - events 插件每日离线刷新调度器：首次 1h 后检查，在线/无法判定推迟 30min，离线重挖 week/month/tonight（maxMine=30）+ 清理 `start_iso < now` 过期活动；setTimeout 链 + unref + dispose 清理

--- a/plugins/official/events/SKILL.md
+++ b/plugins/official/events/SKILL.md
@@ -40,7 +40,7 @@ description: VRChat 社区活动聚合插件：多源采集、群组深度挖掘
 - `sources`：逗号分隔 `vrcsearch,rlvrc,vrceve,vrckr`（默认 all）
 - `languages`：逗号分隔 `zh,ja,ko,en`（默认 all）
 - `minMembers`：只保留群组人数 ≥ 该值
-- `maxMine`：群组深挖的活动数上限（0~300，受 API 限流约 2.6s/个，短码优先）
+- `maxMine`：群组深挖的活动数上限（0~300，默认 30，可显式覆盖；受 API 限流约 2.6s/个，短码优先；群组详情经 groups.resolve 缓存优先，命中缓存零限流请求）
 - `peekGroups`：窥探已挖掘群组公告做侧补充源（有副作用：加入→读→退出）
 - `startDate` / `endDate`：自定义日期（成对，**仅作用于 Google Calendar 源** VRCEve/VRCEvent-KR；VRC Search 固定抓 next-week/month、RLVRC 固定抓全量，不受此参数约束）
 - `languages`：逗号分隔语言筛 zh/ja/ko/en（默认 all）。注：VRC Search 源活动 lang 标 `multi`（多语言），**视为通配**——任何语言筛下都保留，不会被 languages=zh/ja/en 筛掉

--- a/plugins/official/events/index.js
+++ b/plugins/official/events/index.js
@@ -880,7 +880,12 @@ export default function register(api) {
     try {
       const now = new Date().toISOString();
       const store = api.db.table('store');
-      const r = store.run(`DELETE FROM store WHERE start_iso < $now`, { $now: now });
+      // 只删"明确已结束"(end_iso<now) 或无结束时间且开始超 24h 的活动，避免误删进行中活动
+      const past = new Date(Date.now() - 24 * 3600 * 1000).toISOString();
+      const r = store.run(
+        `DELETE FROM store WHERE (end_iso != '' AND end_iso < $now) OR (end_iso = '' AND start_iso < $past)`,
+        { $now: now, $past: past }
+      );
       api.log(`🗑️ 清理过期活动 ${r.changes} 条`);
     } catch (e) {
       api.log(`清理过期活动失败: ${e.message}`);

--- a/plugins/official/events/index.js
+++ b/plugins/official/events/index.js
@@ -327,8 +327,9 @@ export default function register(api) {
     const gid = await shortcodeToGroupId(shortcode);
     if (gid) {
       try {
-        const g = await api.vrchat.fetch(`/groups/${gid}`);
-        if (g && g.id) return { id: gid, name: g.name || '', memberCount: g.memberCount || 0, iconUrl: g.iconUrl || '' };
+        // groups.resolve（core 服务）：缓存优先 + API 回填，命中缓存零限流请求
+        const g = await api.consume('groups.resolve', { groupId: gid });
+        if (g && g.groupId) return { id: gid, name: g.name || '', memberCount: g.memberCount || 0, iconUrl: g.iconUrl || '' };
       } catch (e) {}
       // 详情失败但已确认 gid 存在 → 仍返回占位（后续补热度会重试）
       return { id: gid, name: '', memberCount: 0, iconUrl: '' };
@@ -381,9 +382,10 @@ export default function register(api) {
   // 对单个活动：补全热度(有 group_id) 或三级挖掘群组(无 group_id)
   async function mineGroup(e) {
     // 已有 group_id 但缺 member_count（如 VRC Search 卡片只有 id 无成员数）→ 补热度
+    // （groups.resolve：缓存优先 + API 回填，命中缓存零限流请求）
     if (e.group_id && !(e.member_count || e.group_members)) {
       try {
-        const g = await api.vrchat.fetch(`/groups/${e.group_id}`);
+        const g = await api.consume('groups.resolve', { groupId: e.group_id });
         if (g) {
           e.member_count = e.member_count || g.memberCount || 0;
           if (!e.group_name) e.group_name = g.name || '';
@@ -416,6 +418,10 @@ export default function register(api) {
           if (sc > bestScore) { bestScore = sc; best = g; }
         }
         if (best && bestScore > 0.45) {
+          // /groups?query= 搜索返回的群组对象本身已含 name/memberCount/iconUrl——直接用搜索结果，
+          // 不再额外 groups.resolve（缓存 miss 时反而多打一次 /groups/{id} 限流，违背降限流目标）。
+          // 顺手经 groups.cache 回填 group_cache，后续 other 活动以该 gid 走 groups.resolve 时能缓存命中。
+          try { await api.consume('groups.cache', { groupId: best.id, name: best.name, description: best.description, memberCount: best.memberCount }); } catch (err) {}
           e.group_id = best.id; e.group_name = best.name; e.member_count = best.memberCount || 0; e.icon_url = best.iconUrl || '';
           return e;
         }
@@ -431,6 +437,8 @@ export default function register(api) {
           if (Array.isArray(d)) {
             const g = d.find(x => qualityOk(x) && ((x.name || '').includes(kw) || kw.includes(x.name || '')));
             if (g) {
+              // 搜索结果的 g 已含完整群组信息，直接用并回填 group_cache（避免缓存 miss 时多余 /groups/{id} 限流）
+              try { await api.consume('groups.cache', { groupId: g.id, name: g.name, description: g.description, memberCount: g.memberCount }); } catch (err) {}
               e.group_id = g.id; e.group_name = g.name; e.member_count = g.memberCount || 0; e.icon_url = g.iconUrl || '';
               return e;
             }
@@ -715,7 +723,7 @@ export default function register(api) {
     // 群组深度挖掘（对无 group_id 活动挖掘群组；对有 group_id 但缺热度的补热度）
     // 注意：API 限流 2.6s/个，批量挖掘是耗时瓶颈，用 maxMine 参数截断。
     // 优先级：有 shortcode（可 redirect 反查，最易成功）排在前面，再处理需名字搜索的。
-    let maxMineRaw = (args.maxMine === undefined || args.maxMine === null) ? 60 : parseInt(args.maxMine, 10) || 0;
+    let maxMineRaw = (args.maxMine === undefined || args.maxMine === null) ? 30 : parseInt(args.maxMine, 10) || 0;
     const maxMine = Math.min(Math.max(maxMineRaw, 0), 300);
     const needMine = dedup.filter(e => !e.group_id || !(e.member_count || e.group_members));
     needMine.sort((a, b) => (b.shortcode ? 1 : 0) - (a.shortcode ? 1 : 0));
@@ -822,6 +830,103 @@ export default function register(api) {
     };
   }
 
+  // ════════════ 读库：plg_events_store（零限流消费，不触发重挖）════════════
+  // 供 web-dashboard 路由等经 api.consume('events.listStore') 直接读插件自己的表；
+  // 时间窗口径与 handleFetchCommunityEvents 的抓取区间一致（week: -2d~+8d / month: -2d~+31d / tonight: now~+1d）。
+  function readEventsStore({ window = 'week', limit = 500 } = {}) {
+    const store = api.db.table('store');
+    const now = new Date().toISOString();
+    const msDay = 86400000;
+    let startMin, startMax;
+    if (window === 'tonight') {
+      startMin = now;
+      startMax = new Date(Date.now() + msDay).toISOString();
+    } else if (window === 'month') {
+      startMin = new Date(Date.now() - 2 * msDay).toISOString();
+      startMax = new Date(Date.now() + 31 * msDay).toISOString();
+    } else { // week
+      startMin = new Date(Date.now() - 2 * msDay).toISOString();
+      startMax = new Date(Date.now() + 8 * msDay).toISOString();
+    }
+    const rows = store.all(
+      `SELECT * FROM store
+       WHERE start_iso >= $startMin AND start_iso <= $startMax
+       ORDER BY start_iso ASC LIMIT $limit`,
+      { $startMin: startMin, $startMax: startMax, $limit: Math.max(1, Math.min(limit, 1000)) }
+    );
+    // 字段命名必须与 fetch_community_events 工具返回的 events 数组项完全一致（前端 EventsView
+    // 依赖 snake_case 字段 icon_url/group_name/member_count/desc/group_id/page_url + enrichEvent
+    // 派生的 start_bj/category_zh/join_info_zh），并对每行跑 enrichEvent 补派生字段。
+    const events = rows.map(r => {
+      const e = {
+        source: r.source, name: r.name, start: r.start_iso, end: r.end_iso,
+        category: r.category, lang: r.lang,
+        languages: (() => { try { return JSON.parse(r.languages || '[]'); } catch { return []; } })(),
+        desc: r.desc_raw, desc_zh: r.desc_zh,
+        group_id: r.group_id, group_name: r.group_name, member_count: r.member_count,
+        icon_url: r.icon_url, shortcode: r.shortcode, join_info: r.join_info,
+        page_url: r.page_url, page_label: r.page_label, src: r.src,
+      };
+      return enrichEvent(e);
+    });
+    return { retrievedAt: new Date().toISOString(), source: 'store', window,
+      counts: { output: events.length }, events };
+  }
+
+  api.provide('events.listStore', ({ window, limit } = {}) => readEventsStore({ window, limit }));
+
+  // ════════════ 过期活动清理（每日重挖成功后调用；DELETE 幂等）════════════
+  function cleanupStaleEvents() {
+    try {
+      const now = new Date().toISOString();
+      const store = api.db.table('store');
+      const r = store.run(`DELETE FROM store WHERE start_iso < $now`, { $now: now });
+      api.log(`🗑️ 清理过期活动 ${r.changes} 条`);
+    } catch (e) {
+      api.log(`清理过期活动失败: ${e.message}`);
+    }
+  }
+
+  // ════════════ 每日离线刷新调度器（issue #118）════════════
+  // 自己是否在线由 core 的 dashboard.isSelfOnline 服务判定（core 内查 events 表 user-location
+  // 最新一条；插件只 consume，不直读核心 events 表——插件契约禁止）。
+  // 返回 true（明确在线）/ false（明确离线）/ null（无法判定，保守视为可能在线）。
+  function isSelfOnline() {
+    try {
+      return api.consume('dashboard.isSelfOnline');
+    } catch { return null; }
+  }
+
+  async function runDailyRefresh() {
+    const status = isSelfOnline();
+    if (status !== false) {
+      api.log(status === true
+        ? '⏳ 每日活动刷新：检测到仍在 VRChat 在线，推迟 30 分钟'
+        : '⏳ 每日活动刷新：无法确认离线（可能仍在线/暂无位置记录），保守推迟 30 分钟');
+      scheduleDailyRefresh(30 * 60 * 1000);
+      return;
+    }
+    // status === false 表示明确离线，直接重挖三个窗口并落库
+    api.log('🌙 每日活动刷新：玩家离线，开始重挖社区活动');
+    try {
+      for (const window of ['week', 'month', 'tonight']) {
+        await api.tools.call('fetch_community_events', { window, maxMine: 30 });
+      }
+      cleanupStaleEvents();
+    } catch (e) {
+      api.log(`每日活动刷新失败: ${e.message}`);
+    }
+    // 下一次固定在明天同一时间附近（+0~30min 随机抖动，避免所有实例同一秒打外部源）
+    scheduleDailyRefresh(24 * 60 * 60 * 1000 + Math.floor(Math.random() * 30 * 60 * 1000));
+  }
+
+  let dailyTimer = null;
+  function scheduleDailyRefresh(delayMs) {
+    if (dailyTimer) clearTimeout(dailyTimer);
+    dailyTimer = setTimeout(() => runDailyRefresh().catch(() => {}), delayMs);
+    dailyTimer.unref();
+  }
+
   // ════════════ 配置工具：Google Calendar API Key（使用者的 key，存数据库）════════════
   const GOOGLE_SETUP_GUIDE = {
     createKeyUrl: 'https://console.cloud.google.com/apis/credentials',
@@ -876,7 +981,7 @@ export default function register(api) {
         sources: { type: 'string', default: 'all', description: '逗号分隔数据源: vrcsearch,rlvrc,vrceve,vrckr (默认 all)' },
         languages: { type: 'string', default: 'all', description: '逗号分隔语言筛: zh,ja,ko,en (默认 all)。注：VRC Search 源活动 lang 标 multi（多语言），视为通配在任何语言筛下都保留' },
                 minMembers: { type: 'number', default: 0, description: '只保留群组人数 ≥ 该值的活动' },
-                maxMine: { type: 'number', default: 60, description: '群组深度挖掘的活动数上限(0~300，受 API 限流约 2.6s/个，短码优先)' },
+                maxMine: { type: 'number', default: 30, description: '群组深度挖掘的活动数上限(0~300，默认 30，受 API 限流约 2.6s/个，短码优先)' },
                 peekGroups: { type: 'boolean', default: false, description: '窥探已挖掘群组的公告作为侧面补充源（有副作用：会加入→读公告→退出，成员可见加入通知）' },
                 startDate: { type: 'string', description: '自定义开始日期 YYYY-MM-DD（与 endDate 成对）。仅作用于 Google Calendar 源(VRCEve/VRCEvent-KR)；VRC Search 固定抓 next-week/month、RLVRC 固定抓全量，不受此 参数约束' },
                 endDate: { type: 'string', description: '自定义结束日期 YYYY-MM-DD（同 startDate，仅作用于 Google Calendar 源）' },
@@ -907,7 +1012,13 @@ export default function register(api) {
     handler: async (args) => handleSetGoogleKey(args),
   });
 
+  // ── 每日离线刷新调度器启动（issue #118）──
+  // 首次延迟 1 小时检查（避免启动即刷，等登录/WS 稳定且错开启动潮）；在线推迟、离线才重挖落库
+  const FIRST_DELAY_MS = 60 * 60 * 1000;
+  scheduleDailyRefresh(FIRST_DELAY_MS);
+
   return function dispose() {
+    if (dailyTimer) clearTimeout(dailyTimer);
     api.log('events 插件卸载');
   };
 }

--- a/plugins/official/web-dashboard/index.js
+++ b/plugins/official/web-dashboard/index.js
@@ -815,7 +815,8 @@ export default function register(api) {
     },
   });
 
-  // 社区活动（fetch_community_events；群组挖掘较重，按 window 缓存 10 分钟）
+  // 社区活动（读库：api.consume('events.listStore')，数据由 events 插件每日离线刷新落库；
+  // 页面访问零限流 API 秒回，不再触发群组挖掘。evtCache 内存缓存 + evtInflight 去重保留）
   api.http.registerRoute({
     method: 'GET',
     path: '/api/dashboard/community-events',
@@ -826,14 +827,13 @@ export default function register(api) {
         const ck = `evt:${window}`;
         const hit = evtCache.get(ck);
         if (hit && Date.now() - hit.at < EVT_TTL) return sendJson(res, hit.data);
-        // in-flight 去重：慢请求期间重复点击共享同一 Promise（避免并发多个群组挖掘/外部拉取）
+        // in-flight 去重：重复请求共享同一 Promise（读库很快，主要防并发重复查询）
         if (evtInflight.has(ck)) return sendJson(res, await evtInflight.get(ck));
         const task = (async () => {
-          // 60s 超时保护：群组挖掘/外部源拉取可能很慢或挂起，超时如实返回而非无限等待
-          return Promise.race([
-            api.tools.call('fetch_community_events', { window }),
-            new Promise((_, rej) => setTimeout(() => rej(new Error('社区活动拉取超时（60s），请稍后重试')), 60000)),
-          ]);
+          // events.listStore 返回 { retrievedAt, source, window, counts, events }（字段与 fetch_community_events
+          // 工具返回结构对齐，前端 EventsView 用到蛇形字段 + start_bj/join_info_zh 派生物 + counts.output）
+          const r = await api.consume('events.listStore', { window });
+          return { ...r, source: 'store', window: r.window || window };
         })();
         evtInflight.set(ck, task);
         try {
@@ -1203,23 +1203,10 @@ export default function register(api) {
 
   api.log('Web Dashboard (VRCX Vue 3) 已注册：/dashboard');
 
-  // ── 慢路由启动预热：社区活动（首拉 ~48s）与世界推荐（~11s）后台预拉，直接填路由缓存，
-  // 用户首次访问即命中缓存（失败最多重试 3 次，间隔 2 分钟）
-  let warmAttempt = 0;
-  function prewarmSlowRoutes() {
-    const tasks = [
-      api.tools.call('fetch_community_events', { window: 'week' }).then((r) => { evtCache.set('evt:week', { at: Date.now(), data: r }); return true; }),
-      api.tools.call('recommend_worlds', { theme: 'default', limit: 10, detail: true }).then((r) => { recCache.set('rec:default', { at: Date.now(), data: r }); return true; }),
-    ];
-    Promise.allSettled(tasks).then((rs) => {
-      const failed = rs.filter((x) => x.status === 'rejected').length;
-      if (failed > 0 && warmAttempt < 3) {
-        warmAttempt++;
-        setTimeout(prewarmSlowRoutes, 120000);
-      }
-    });
-  }
-  setTimeout(prewarmSlowRoutes, 90000);  // 等登录/WS 就绪后预热
+  // 慢路由懒加载（issue #118）：不再做启动预热——无条件预热 fetch_community_events 会触发
+  // events 插件的群组深度挖掘，持续占满共享 rateLimiter 队列，拖慢所有 API 工具。
+  // 社区活动由路由读库（api.consume('events.listStore')，由 events 插件每日离线刷新落库）；
+  // 世界推荐由前端按需触发，路由缓存 + in-flight 去重保留。
 
   return () => {};
 }

--- a/skills/vrc-monitor-agent/SKILL.md
+++ b/skills/vrc-monitor-agent/SKILL.md
@@ -105,7 +105,7 @@ metadata:
 | `x_add_creator` | 添加要追踪的 X 博主（VRChat 世界推荐博主；`screen_name` 不带 @） |
 | `x_remove_creator` | 移除追踪的 X 博主 |
 | `x_worlds` | 查看已收录的推荐世界列表（调试用） |
-| `fetch_community_events` | **[events] VRChat 社区活动聚合**（官方 events 插件）：采集(VRC Search/RLVRC/VRCEve/VRCEvent-KR) → 群组深度挖掘(短码/活动名/世界名反查,补群组热度回填) → 音乐∪虚拟主播筛选 → 结构化 JSON + 落库 plg_events_store。参数：window(week/month/tonight)、focus(all/music/vtuber)、sources(vrcsearch,rlvrc,vrceve,vrckr)、languages、minMembers、maxMine、peekGroups(窥探已挖掘群组公告补充活动,有副作用)、startDate/endDate、limit。返回事件自带规范图标URL/双列时区(start_local/start_bj/tz_label)/中文参加方式(join_info_zh)。用于"最近/今晚有什么活动、哪些可参加、群组热度"。未配置 Google Key 时返回 configStatus 的创建网址指引。PDF 渲染另走管道 |
+| `fetch_community_events` | **[events] VRChat 社区活动聚合**（官方 events 插件）：采集(VRC Search/RLVRC/VRCEve/VRCEvent-KR) → 群组深度挖掘(短码/活动名/世界名反查,补群组热度回填,经 groups.resolve 缓存优先) → 音乐∪虚拟主播筛选 → 结构化 JSON + 落库 plg_events_store。参数：window(week/month/tonight)、focus(all/music/vtuber)、sources(vrcsearch,rlvrc,vrceve,vrckr)、languages、minMembers、maxMine(默认 30,可覆盖)、peekGroups(窥探已挖掘群组公告补充活动,有副作用)、startDate/endDate、limit。返回事件自带规范图标URL/双列时区(start_local/start_bj/tz_label)/中文参加方式(join_info_zh)。用于"最近/今晚有什么活动、哪些可参加、群组热度"。未配置 Google Key 时返回 configStatus 的创建网址指引。PDF 渲染另走管道 |
 | `get_community_events_config` | **[events·配置]** 查看社区活动抓取配置：Google Calendar API Key 是否已配置（值存数据库不回显）；未配置时返回创建 key 的指引网址 |
 | `set_community_events_google_key` | **[events·配置]** 录入/清除使用者的 Google Cloud API Key（存数据库 plg_events_config，仅本插件读）。createKeyUrl=https://console.cloud.google.com/apis/credentials。需要 confirm:true |
 | `submit_totp` | **提交 TOTP 验证码（手动兜底）**：在 credentials.json 配置 `totp_secret` 后，服务自动生成验证码登录，无需调用本工具；仅在自动登录失败（验证码被拒/secret 有误）或未配置 secret 时，账号处于 `needsTotp` 状态（`/health` 的 `auth.needsTotp: true`）才需调用本工具提交当前 6 位验证码（`code` 必填；登录后 WS 自动重连） |

--- a/start-monitor.js
+++ b/start-monitor.js
@@ -499,7 +499,8 @@ function registerCoreServices(loader, ctx) {
     if (!groupId || !String(groupId).startsWith('grp_')) throw new Error('groupId 必填且以 grp_ 开头');
     const cached = ctx.storage.getGroupCached(groupId);
     const TTL = 7 * 24 * 60 * 60 * 1000;
-    if (!force && cached && cached.name && (Date.now() - Date.parse(String(cached.updated_at).replace(' ', 'T') + 'Z')) < TTL) {
+    const _ct = Date.parse(String(cached.updated_at).replace(' ', 'T') + 'Z');
+    if (!force && cached && cached.name && Number.isFinite(_ct) && (Date.now() - _ct) < TTL) {
       return {
         groupId,
         name: cached.name,

--- a/start-monitor.js
+++ b/start-monitor.js
@@ -492,6 +492,55 @@ function registerCoreServices(loader, ctx) {
     loader.serviceOwners.set(name, 'core');
   }
 
+  // 群组信息解析服务（issue #118：缓存优先 + API 回填，供 events 插件等 consume）。
+  // 复用 core/domains/cache-store.js 的 getGroupCached/upsertGroupCache（TTL 7 天，与周报一致），
+  // 命中缓存零限流 API；未命中才经 rateLimiter 拉 /groups/{id} 并回填 group_cache。
+  loader.services.set('groups.resolve', async ({ groupId, force = false } = {}) => {
+    if (!groupId || !String(groupId).startsWith('grp_')) throw new Error('groupId 必填且以 grp_ 开头');
+    const cached = ctx.storage.getGroupCached(groupId);
+    const TTL = 7 * 24 * 60 * 60 * 1000;
+    if (!force && cached && cached.name && (Date.now() - Date.parse(String(cached.updated_at).replace(' ', 'T') + 'Z')) < TTL) {
+      return {
+        groupId,
+        name: cached.name,
+        description: cached.description || '',
+        memberCount: cached.member_count || 0,
+        iconUrl: cached.icon_url || '',
+        source: 'cache',
+      };
+    }
+    const r = await ctx.rateLimiter.execute(() => ctx.api._request('GET', `/groups/${encodeURIComponent(groupId)}`));
+    if (r.status === 200 && r.data) {
+      const d = r.data;
+      ctx.storage.upsertGroupCache({
+        groupId,
+        name: d.name || '',
+        description: d.description || '',
+        memberCount: d.memberCount || 0,
+      });
+      return {
+        groupId,
+        name: d.name || '',
+        description: d.description || '',
+        memberCount: d.memberCount || 0,
+        iconUrl: d.iconUrl || '',
+        source: 'api',
+      };
+    }
+    throw new Error(`groups.resolve 失败: ${r.status}`);
+  });
+  loader.serviceOwners.set('groups.resolve', 'core');
+
+  // 群组缓存写服务（issue #118）：供插件把搜索/采集得到的群组信息回填 group_cache，
+  // 让后续 groups.resolve 命中缓存。仅写 name/description/member_count（group_cache 无
+  // icon_url 列，icon 暂不入缓存；活动自带 icon_url 不受影响）。
+  loader.services.set('groups.cache', ({ groupId, name, description, memberCount } = {}) => {
+    if (!groupId || !String(groupId).startsWith('grp_')) throw new Error('groupId 必填且以 grp_ 开头');
+    ctx.storage.upsertGroupCache({ groupId, name: name || '', description: description || '', memberCount: memberCount || 0 });
+    return { ok: true };
+  });
+  loader.serviceOwners.set('groups.cache', 'core');
+
   // 认证与网络配置服务（供 auth-guard 插件查询，owner='core'）
   loader.services.set('core.authConfig', () => ({
     token: process.env.VRC_MONITOR_AUTH_TOKEN || process.env.VRC_MONITOR_API_KEY || null,


### PR DESCRIPTION
## 需求来源

Issue #118:服务启动 90s 后 web-dashboard 的 `prewarmSlowRoutes` 无条件调用 `fetch_community_events`(trigger events 插件群组深挖,最多 `maxMine` 个 × 2.6s/个),持续占满共享 rateLimiter 队列(queueLength 恒满 47~50),所有 API 工具排队变慢(get_prints ~120s)。

根因定位:真正自动触发源不是 events 插件本身,而是 #112 引入的 web-dashboard 预热钩子。events 插件只注册工具、不自动跑;另其群组挖掘从不查 `group_cache`,每次重复 API。

## 实现方式

1. **删无条件预热**:web-dashboard 移除 `prewarmSlowRoutes` + 90s 触发,慢路由改懒加载。
2. **数据入库 + 读库消费**:`/api/dashboard/community-events` 改经 `api.consume('events.listStore')` 直读 `plg_events_store`(零限流秒回),不再因看页触发重挖。`readEventsStore` 字段/派生(start_bj/join_info_zh/counts)与工具返回对齐。
3. **每日离线刷新**:events 插件新增在线感知调度器——core 提供 `dashboard.isSelfOnline`(查 events 表 user-location,WS 断链>1h 保守返回 null);在线/无法判定推迟 30min,离线才重挖 week/month/tonight + 清过期活动。setTimeout 链 + unref + dispose 清理。
4. **群组缓存优先**:core 新增 `groups.resolve`(group_cache TTL 7天缓存优先 + API 回填)与 `groups.cache`(回填写服务)。events 挖掘改走缓存;搜索命中直接用搜索结果并回填(避免缓存 miss 时多余 /groups/{id} 限流)。`maxMine` 默认 60→30。
5. **过期清理**:每日刷成功后 `DELETE start_iso < now`。
6. **保留 MCP `fetch_community_events`**:Agent 手动触发行为不变。

## 验证过程与结果

- `node --check` 四个改动 .js 全部通过。
- `node test/test-registry.mjs`:registry integrity PASS(104 tools,顺序+定义+dispatch OK),无工具数破坏。
- `python scripts/check-doc-drift.py --json`:has_drift=false,无死引用。
- **缓存闭环实测**(临时库 + 真实 Storage):`groups.resolve` 命中=0 次 API(source=cache);未命中=1 次 API 并回填;二次调用同 gid=缓存命中(不再调 API);upsert 幂等(1 行);TTL 判断 fresh。证明群组信息确实走缓存,降限流目标达成。
- 前端字段对齐核查:EventsView.vue 依赖 snake_case + start_bj/join_info_zh + counts.output,readEventsStore 已对齐。
- **运行时端到端(启动服务观察 /health 队列、真实 fetch)需部署环境(真实凭据)执行**,本 PR 未在真实服务上端到端验证。

## 说明

- 插件契约遵守:events/web-dashboard 仅经 `api.consume/provide/tools.call` 共享数据,未直读核心表。
- 无 DDL:plg_events_store / group_cache 已存在,本次纯逻辑层改动。
- 已知限制:`group_cache` 无 icon_url 列,缓存命中时群组图标为空(活动自带 icon 不受影响);如需图标缓存可后续加列迁移。