### PR TITLE
fix(dashboard): 修复 avatar 模型名解析——imgProxy 编码后 fileId 提取失配

### DIFF
--- a/core/dashboard-services.js
+++ b/core/dashboard-services.js
@@ -10,7 +10,7 @@
  * 纯搬移重构：服务名、owner、实现逐字节一致，无行为变更。
  */
 import { isSafeModeEnabled } from './safe-mode.js';
-import { imgProxy, avatarThumb, avatarOf } from './img-util.js';
+import { imgProxy, avatarThumb, avatarOf, avatarFileId } from './img-util.js';
 
 // 自己 userId 的权威推导：user-location/user-update 事件只会是自己的（事件管线保证），
 // 种子导入/列表展示用它排除自己（/auth/user 在启动早期可能失败或缓存未就绪）
@@ -460,9 +460,11 @@ export function registerDashboardServices(loader, ctx) {
       ];
       for (const j of jobs) {
         if (!j.url) continue;
-        const fm = String(j.url).match(/\/file\/(file_[a-f0-9-]+)/);
-        if (!fm) continue;
-        const fileId = fm[1];
+        // j.url 已过 imgProxy 代理（/api/dashboard/image-proxy?url=<encodeURIComponent(原URL)>），
+        // 原 URL 里的 /file/ 被编码成 %2Ffile%2F，直接 match 必然失败（#122 引入 img-util 后回归，
+        // 导致模型名全部显示"未知模型"）。avatarFileId 会先还原代理 URL 再提取 fileId。
+        const fileId = avatarFileId(j.url);
+        if (!fileId) continue;
         if (anCache.has(fileId)) { ev[j.key] = anCache.get(fileId); continue; }
         if (seen.has(fileId)) continue;
         seen.add(fileId);

--- a/core/dashboard-services.js
+++ b/core/dashboard-services.js
@@ -452,8 +452,10 @@ export function registerDashboardServices(loader, ctx) {
     const needName = result.filter((e) => e.updateType === 'avatar');
     const pending = [];
     const seen = new Set();
-    // 收集需要解析的模型名：新模型（avatarName）+ 旧模型（previousAvatarName），按 fileId 去重
-    for (const ev of needName.slice(0, 10)) {
+    // 收集需要解析的模型名：新模型（avatarName）+ 旧模型（previousAvatarName），按 fileId 去重。
+    // 扫描全部 avatar 事件（不只 slice(0,10)）：正则匹配是纯内存操作，pending 上限 6 已限流；
+    // 若只扫最新 10 条，回归期间积累的历史 avatar 事件永远轮不到补名（实测 14 条一直"未知模型"）。
+    for (const ev of needName) {
       const jobs = [
         { url: ev.avatarImageUrl, key: 'avatarName' },
         { url: ev.previousAvatarImageUrl, key: 'previousAvatarName' },

--- a/core/img-util.js
+++ b/core/img-util.js
@@ -25,6 +25,20 @@ export const avatarThumb = (u) => {
   return imgProxy(thumbUrl);
 };
 
+// 从（可能已 imgProxy 代理改写的）URL 提取 VRChat file id（file_xxx）。
+// 背景：imgProxy 把原始 URL encodeURIComponent 进 /api/dashboard/image-proxy?url=...，
+// 其中 /file/ 被编码成 %2Ffile%2F，直接正则匹配会失败（#122 引入 img-util 后曾导致
+// 模型名解析全部失配，dashboard 显示"未知模型"）。此处先还原代理 URL 再匹配。
+// 接受原始 URL 或代理 URL，均返回 file id；无法提取返回 null。
+export const avatarFileId = (u) => {
+  if (!u) return null;
+  let s = String(u);
+  const pm = s.match(/^\/api\/dashboard\/image-proxy\?url=(.+)$/);
+  if (pm) { try { s = decodeURIComponent(pm[1]); } catch { /* 保持原样 */ } }
+  const fm = s.match(/\/file\/(file_[a-f0-9-]+)/);
+  return fm ? fm[1] : null;
+};
+
 // 用户头像展示统一入口：优先用户资料里设置的图标头像(user_icon)，兜底当前模型外观缩略图(currentAvatar)。
 // 背景：currentAvatarImageUrl 语义是"穿戴的3D模型外观"，常为默认机器人图而非用户真实头像，
 //       user_icon 是用户主动设置的头像（XM1023 显示机器人而非金发女仆头像 bug 的根因，2026-09-01）。

--- a/test/test-dashboard-services.test.mjs
+++ b/test/test-dashboard-services.test.mjs
@@ -19,6 +19,7 @@ const REPO = path.join(__dirname, '..');
 const { ctx } = await import(pathToFileURL(path.join(REPO, 'core', 'server-context.js')).href);
 const { Storage } = await import(pathToFileURL(path.join(REPO, 'core', 'storage.js')).href);
 const { registerDashboardServices } = await import(pathToFileURL(path.join(REPO, 'core', 'dashboard-services.js')).href);
+const { avatarFileId } = await import(pathToFileURL(path.join(REPO, 'core', 'img-util.js')).href);
 
 // ── 临时 DB + 运行时准备 ──
 const tmpDb = path.join(__dirname, 'test-dash-services.sqlite3');
@@ -250,6 +251,17 @@ test('dashboard.groupAnnouncementsAll 汇总跨群组公告', () => {
   const ts = r.announcements.map((a) => a.createdAt);
   const sorted = [...ts].sort().reverse();
   assert.deepEqual(ts, sorted, '公告按时间降序');
+});
+
+test('avatarFileId 从代理/原始 URL 提取 file id（#122 imgProxy 回归）', () => {
+  const raw = 'https://api.vrchat.cloud/api/1/file/file_de43c23b-8efa-4f4c-acb0-8c0c2dad9817/1/file';
+  const proxied = '/api/dashboard/image-proxy?url=' + encodeURIComponent(raw);
+  // 代理 URL 里的 /file/ 被编码成 %2Ffile%2F，直接正则失配；avatarFileId 先还原再匹配
+  assert.equal(avatarFileId(proxied), 'file_de43c23b-8efa-4f4c-acb0-8c0c2dad9817');
+  assert.equal(avatarFileId(raw), 'file_de43c23b-8efa-4f4c-acb0-8c0c2dad9817');
+  assert.equal(avatarFileId(''), null);
+  assert.equal(avatarFileId(null), null);
+  assert.equal(avatarFileId('https://example.com/no-file-here'), null);
 });
 
 // ── 清理 ──


### PR DESCRIPTION
## 问题

avatar 模型的模型名解析出现回归：之前能正常解析出模型名，现在列表里大量显示「未知模型」。

## 根因（双重）

1. **imgProxy 编码导致 fileId 提取失配**：avatar 图片 URL 会先经过 image-proxy（会做百分号编码，/file/ -&gt; %2Ffile%2F），后台补名时 match(/\/file\/(file_...)/) 全部失配，拿不到 file_id。
   - 修复：core/img-util.js 新增纯函数 avatarFileId()，先还原 image-proxy 编码后的 URL，再提取 file_id；core/dashboard-services.js 补名逻辑改用该函数。

2. **补名只扫最新 10 条**：dashboard.events 补名循环里 needName.slice(0, 10) 只对最近 10 条 avatar 事件尝试补名，历史事件永远得不到补名。
   - 修复：补名改为扫描全部 avatar 事件（纯内存、正则匹配、无额外 I/O，pending 上限 6 限流保持不变）。

## 验证

- 后端测试 30/30 通过，新增 avatarFileId 从代理/原始 URL 提取 file id 的回归测试
- 生产实测：补名缺失 14→4 收敛，事件流里「未知模型」从 15 降到 2（剩余为 blob/404 文件，真实无法解析）；模型名（Milfy、Chocolat_初月、fish grus 等）均正常解析

## 关联

- 前置 PR #124（tracked 时区/语义）已合并，本 PR 在其之上