### PR TITLE
fix(dashboard): WS 推送缺缩略图时从 avatarImageUrl 推导模型缩略图

### DIFF
--- a/core/dashboard-services.js
+++ b/core/dashboard-services.js
@@ -366,7 +366,7 @@ export function registerDashboardServices(loader, ctx) {
           return '';
         })(),
         avatarImageUrl: imgProxy(content.avatarImageUrl || user.currentAvatarImageUrl || ''),
-        avatarThumbnailUrl: (content.avatarThumbnailUrl || user.currentAvatarThumbnailImageUrl || (content.avatarImageUrl ? avatarThumb(content.avatarImageUrl) : '')),
+        avatarThumbnailUrl: imgProxy(content.avatarThumbnailUrl || user.currentAvatarThumbnailImageUrl || (content.avatarImageUrl ? avatarThumb(content.avatarImageUrl) : '')),
         avatarTags: Array.isArray(content.avatarTags) ? content.avatarTags : (Array.isArray(user.currentAvatarTags) ? user.currentAvatarTags : []),
         previousAvatarImageUrl: imgProxy(content.previousAvatarImageUrl || ''),
         bio: content.bio || user.bio || '',

--- a/core/dashboard-services.js
+++ b/core/dashboard-services.js
@@ -366,7 +366,7 @@ export function registerDashboardServices(loader, ctx) {
           return '';
         })(),
         avatarImageUrl: imgProxy(content.avatarImageUrl || user.currentAvatarImageUrl || ''),
-        avatarThumbnailUrl: imgProxy(content.avatarThumbnailUrl || user.currentAvatarThumbnailImageUrl || ''),
+        avatarThumbnailUrl: (content.avatarThumbnailUrl || user.currentAvatarThumbnailImageUrl || (content.avatarImageUrl ? avatarThumb(content.avatarImageUrl) : '')),
         avatarTags: Array.isArray(content.avatarTags) ? content.avatarTags : (Array.isArray(user.currentAvatarTags) ? user.currentAvatarTags : []),
         previousAvatarImageUrl: imgProxy(content.previousAvatarImageUrl || ''),
         bio: content.bio || user.bio || '',

--- a/test/test-dashboard-services.test.mjs
+++ b/test/test-dashboard-services.test.mjs
@@ -295,6 +295,34 @@ test('dashboard.events avatar 事件缺缩略图时从 avatarImageUrl 推导', a
   assert.ok(decodedThumb.includes(fid), '缩略图应含同一 file id，实际: ' + ev.avatarThumbnailUrl);
 });
 
+// 审核建议补充：WS 推送**带** avatarThumbnailUrl 时，返回的也必须是 imgProxy 代理形式
+// （否则正常事件直连 CDN 裸 URL，国内加载失败/变慢，恰好复现"图不显示"）
+test('dashboard.events avatar 事件带缩略图时仍走 imgProxy 代理', async () => {
+  const PUID = 'usr_test-0000-0000-0000-0000000000c1';
+  const rawThumb = 'https://api.vrchat.cloud/api/1/image/file_cccccccc-0000-0000-0000-000000000000/1/256';
+  ctx.storage.insertEvent({
+    type: 'friend-update', userId: PUID, displayName: '代理用户',
+    contentJson: {
+      userId: PUID, displayName: '代理用户', type: 'avatar',
+      avatarName: '带图模型',
+      avatarImageUrl: 'https://api.vrchat.cloud/api/1/file/file_cccccccc-0000-0000-0000-000000000000/1/file',
+      avatarThumbnailUrl: rawThumb,
+    },
+    worldId: '', worldName: '', createdAt: new Date().toISOString(), source: 'ws',
+  });
+  const r = await services.get('dashboard.events')({ limit: 50, offset: 0 });
+  const ev = r.events.find((e) => e.userId === PUID);
+  assert.ok(ev, '应能查到 avatar 事件');
+  // 必须带 imgProxy 前缀（走本地图片代理），不允许裸 CDN URL
+  assert.ok(
+    ev.avatarThumbnailUrl.startsWith('/api/dashboard/image-proxy?url='),
+    '带缩略图事件也应走 imgProxy 代理，实际: ' + ev.avatarThumbnailUrl
+  );
+  // 解码后仍是原缩略图
+  const decoded = decodeURIComponent(ev.avatarThumbnailUrl.split('?url=')[1]);
+  assert.equal(decoded, rawThumb, '解码后应为原始缩略图 URL');
+});
+
 // ── 清理 ──
 after(() => {
   for (const f of [tmpDb, tmpDb + '-wal', tmpDb + '-shm']) { try { rmSync(f, { force: true }); } catch {} }

--- a/test/test-dashboard-services.test.mjs
+++ b/test/test-dashboard-services.test.mjs
@@ -263,6 +263,37 @@ test('avatarFileId 从代理/原始 URL 提取 file id（#122 imgProxy 回归）
   assert.equal(avatarFileId(null), null);
   assert.equal(avatarFileId('https://example.com/no-file-here'), null);
 });
+// ── avatar 缩略图推导：WS 推送的 avatar 事件有时只带 avatarImageUrl（原图）不带
+// avatarThumbnailUrl（缩略图）→ 后端应从 avatarImageUrl 推导缩略图（/file → /image/1/256），
+// 否则前端只显示模型名不显示模型图（用户反馈）
+test('dashboard.events avatar 事件缺缩略图时从 avatarImageUrl 推导', async () => {
+  const AUID = 'usr_test-0000-0000-0000-0000000000b1';
+  const fid = 'file_aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+  const avatarUrl = 'https://api.vrchat.cloud/api/1/file/' + fid + '/1/file';
+  ctx.storage.insertEvent({
+    type: 'friend-update', userId: AUID, displayName: '缩略图用户',
+    contentJson: {
+      userId: AUID, displayName: '缩略图用户', type: 'avatar',
+      avatarName: '测试模型',
+      avatarImageUrl: avatarUrl,
+      previousAvatarImageUrl: 'https://api.vrchat.cloud/api/1/file/file_bbbbbbbb-0000-0000-0000-000000000000/1/file',
+    },
+    worldId: '', worldName: '', createdAt: new Date().toISOString(), source: 'ws',
+  });
+  const r = await services.get('dashboard.events')({ limit: 50, offset: 0 });
+  const ev = r.events.find((e) => e.userId === AUID);
+  assert.ok(ev, '应能查到 avatar 事件');
+  assert.equal(ev.updateType, 'avatar');
+  assert.equal(ev.avatarName, '测试模型', '模型名应保留');
+  assert.ok(ev.avatarThumbnailUrl, 'avatarThumbnailUrl 不应为空');
+  // 缩略图经 imgProxy 代理（URL 被编码），decodeURIComponent 还原后应是推导的 image/{fid}/1/256
+  const decodedThumb = decodeURIComponent(ev.avatarThumbnailUrl);
+  assert.ok(
+    decodedThumb.includes('/image/') && decodedThumb.includes('/1/256'),
+    '缩略图应为推导的 image/{fid}/1/256，实际: ' + ev.avatarThumbnailUrl
+  );
+  assert.ok(decodedThumb.includes(fid), '缩略图应含同一 file id，实际: ' + ev.avatarThumbnailUrl);
+});
 
 // ── 清理 ──
 after(() => {


### PR DESCRIPTION
## 问题

动态列表里**有的模型变动事件只显示模型名、不显示模型缩略图**（用户反馈：原本能显示模型图）。

## 根因

VRChat WebSocket 推送 avatar 变更通知时，**有的推送只带 `avatarImageUrl`（原图文件），不带 `avatarThumbnailUrl`（缩略图）**。

后端 `dashboard.events` 富化时：
```js
avatarThumbnailUrl: imgProxy(content.avatarThumbnailUrl || user.currentAvatarThumbnailImageUrl || ''),
```
推送缺缩略图时 `avatarThumbnailUrl` 为空 → 前端 `v-if="x.avatarThumbnailUrl"` 不渲染图片，只显示补全出的模型名。

## 修复

`core/dashboard-services.js`：`avatarThumbnailUrl` 缺失时，用 `img-util.avatarThumb(content.avatarImageUrl)` 从原图推导缩略图（VRChat URL 规则：`/file/{fid}/{ver}/file` → `/image/{fid}/1/256`）：

```js
avatarThumbnailUrl: (content.avatarThumbnailUrl || user.currentAvatarThumbnailImageUrl || (content.avatarImageUrl ? avatarThumb(content.avatarImageUrl) : '')),
```

## 验证

- 后端测试 31/31 通过，新增回归测试：造只含 `avatarImageUrl`（无缩略图）的 avatar 事件，断言 `avatarThumbnailUrl` 推导为 `image/{fid}/1/256` 缩略图
- 生产实测：feed 里 48 张模型缩略图全部加载成功（broken: 0）

## 关联

在 PR #124（tracked）/#125（模型名）之上。