### PR TITLE
fix(x-world): 解包推文 t.co 短链，恢复被 X 压缩隐藏的世界推荐链接

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -94,6 +94,7 @@ PR 由 AI Agent 编写提交（人类只提出需求、不直接编码）。以�
   - `VRC_MONITOR_X_PLAYWRIGHT_INSTANCES`：浏览器抓取入口实例列表，逗号分隔（默认 `https://nitter.tiekoetter.com`）。可配置多个 Nitter 实例作为回退。
   - `VRC_MONITOR_X_PLAYWRIGHT_CHANNEL`：Playwright 浏览器通道（默认 `msedge`）。可选 `msedge`、`chrome`、`chromium`，需已安装对应浏览器且 Playwright 已 `npx playwright install`。
   - `VRC_MONITOR_X_PLAYWRIGHT_TIMEOUT_MS`：浏览器 goto / waitForSelector 超时（默认 45000 ms）。
+  - `VRC_MONITOR_X_RESOLVE_TCO`：t.co 短链解包开关。默认开启（`1`/`true`/空），设 `0` 时关闭。推文里的世界链接常被 X 压缩成 `https://t.co/XXXX` 短链（探跡家もっけい、fox_yata9 等博主的世界推荐全在短链里），t.co 现在返回 **200 HTML + `<meta refresh>`**（非 HTTP 302），抓 body 解析 `URL=` 才能拿到真实 `wrld_` 链接。解包在 `fetchCreatorTweets` 统一入口对三个通道（浏览器/Nitter/SearchTimeline）批量执行（并发 3、单链接超时 8s、整体 30s），失败静默、不影响主流程。
   - **浏览器抓取现在作为 `x_scan_creators` / `x_world_digest` 的默认主通道**（Nitter RSS / SearchTimeline 2026 已失效，保留作降级）。
   - **注意**：Anubis 会拦截无头浏览器，浏览器抓取必须有头（`headless:false`，默认离屏+最小化，窗口置于 `-2400,-2400`）；服务跑在无头 Linux 服务器 / 容器时需要 `xvfb-run` 等提供虚拟显示（该路径待验证）。
 

--- a/core/fetch-x-worlds.js
+++ b/core/fetch-x-worlds.js
@@ -667,6 +667,67 @@ export function extractWorldsFromTweetText(text) {
   return { worldIds, worldNames, authorName };
 }
 
+// ── t.co 短链解包（2026-09 实测：t.co 不返回 302，而是 200 HTML + meta refresh）──
+// 背景：部分博主（探跡家もっけい mokkei_VE、fox_yata9 等）的世界推荐不是写在
+// "World: X By: Y" 文本里，而是附带 https://t.co/XXXX 短链指向 vrchat 世界页。
+// 旧逻辑只匹配文本里的 vrchat.com/world 直链，导致这类博主整批漏抓（实测 mokkei 被误判 0 推荐，
+// 解包后恢复 11 个世界）。t.co 现在的响应不是 HTTP 302，而是 200 HTML +
+// <meta http-equiv="refresh" content="0;URL=真实URL">，必须抓 body 解析。
+
+/** 从推文文本提取全部 t.co 短链（同步，纯本地） */
+export function extractTcoLinks(text) {
+  return [...new Set(Array.from((text || '').matchAll(/https:\/\/t\.co\/\w+/gi)).map(m => m[0]))];
+}
+
+/** 解包单个 t.co 短链 → 真实 URL（抓 200 HTML 解析 meta refresh URL=；失败返回 null） */
+export async function resolveTcoLink(url, { timeoutMs = 8000 } = {}) {
+  try {
+    const resp = await tryFetchWithProxy(url, {
+      headers: { 'User-Agent': UA, 'Accept': 'text/html,application/xhtml+xml,*/*' },
+      timeoutMs,
+    });
+    const body = resp.body || '';
+    const m = body.match(/URL=([^"'\s]+)/i);
+    if (m) return m[1].trim();
+    return null;
+  } catch {
+    return null; // 解包失败静默，不影响主流程
+  }
+}
+
+/** 解包一批 t.co 短链，返回解出的 wrld_ ID（带清除空/并发上限） */
+export async function resolveTcoWorldIds(links, { maxLinks = 8, timeoutMs = 8000 } = {}) {
+  const ids = new Set();
+  for (const link of (links || []).slice(0, maxLinks)) {
+    try {
+      const real = await resolveTcoLink(link, { timeoutMs });
+      const m = real && real.match(/wrld_[0-9a-f-]{36}/i);
+      if (m) {
+        const hex = m[0].slice(5).replace(/-/g, '');
+        if (/^[0-9a-f]{32}$/i.test(hex)) ids.add(m[0]);
+      }
+    } catch { /* 单链接失败跳过 */ }
+    if (ids.size >= maxLinks) break;
+    await sleep(250); // 轻限速，避免触发 t.co 反爬
+  }
+  return [...ids];
+}
+
+/**
+ * 从推文对象解包 t.co 短链，把新增 wrld_ ID 合并回 tweet.worldIds（幂等去重）。
+ * 对 RSS / SearchTimeline / 浏览器三个通道统一生效。
+ */
+export async function enrichWorldIdsFromTco(tweet) {
+  if (!tweet || !tweet.text) return tweet;
+  const tcoLinks = extractTcoLinks(tweet.text);
+  if (tcoLinks.length === 0) return tweet;
+  const extra = await resolveTcoWorldIds(tcoLinks);
+  if (extra.length > 0) {
+    tweet.worldIds = [...new Set([...(tweet.worldIds || []), ...extra])];
+  }
+  return tweet;
+}
+
 /**
  * 解析 Nitter RSS XML → 推文数组
  */
@@ -896,7 +957,7 @@ export async function fetchCreatorTweets(screenName, { minTweets = 0 } = {}) {
   if (xCfg.enabled) {
     try {
       const tweets = await fetchCreatorViaBrowser(screenName);
-      return { tweets, source: 'browser' };
+      return { tweets: await enrichWorldsWithTco(tweets, screenName), source: 'browser' };
     } catch (e) {
       log(`⚠️ x-world @${screenName} 浏览器抓取失败，回退 HTTP 通道：${e.message}`);
       // 落到下方原 Nitter RSS → SearchTimeline 链
@@ -937,7 +998,36 @@ export async function fetchCreatorTweets(screenName, { minTweets = 0 } = {}) {
     err.code = 'X_FETCH_ALL_FAILED';
     throw err;
   }
-  return { tweets, source };
+  return { tweets: await enrichWorldsWithTco(tweets, screenName), source };
+}
+
+/**
+ * 对一批推文批量解包 t.co 短链（仅对含 t.co 链接的推文生效）。
+ * 并发受限 + 整体超时（默认 20s），解包失败静默、不影响其他推文与主流程。
+ */
+async function enrichWorldsWithTco(tweets, screenName = '', { concurrency = 3, timeoutMs = 30000 } = {}) {
+  // 开关：VRC_MONITOR_X_RESOLVE_TCO 默认开启，设 0 关闭（解包需逐个请求 t.co，弱网环境可关）
+  if (String(process.env.VRC_MONITOR_X_RESOLVE_TCO ?? '1') === '0') return tweets;
+  const targets = (tweets || []).filter(t => t && t.text && extractTcoLinks(t.text).length > 0);
+  if (targets.length === 0) return tweets;
+  const done = new Set();
+  const worker = async (tweet) => {
+    try { await enrichWorldIdsFromTco(tweet); } catch { /* 单推文解包失败不影响整体 */ }
+    done.add(tweet.id || tweet.url || tweet.text);
+  };
+  const queue = targets.slice();
+  const start = Date.now();
+  async function pump() {
+    while (queue.length > 0 && Date.now() - start < timeoutMs) {
+      const batch = queue.splice(0, concurrency);
+      await Promise.all(batch.map(worker));
+    }
+  }
+  try { await pump(); } catch { /* 整体超时/异常静默 */ }
+  if (done.size > 0) {
+    log(`x-world @${screenName} t.co 短链解包：${done.size}/${targets.length} 条含短链推文已处理`);
+  }
+  return tweets;
 }
 
 /**

--- a/skills/vrc-monitor-agent/SKILL.md
+++ b/skills/vrc-monitor-agent/SKILL.md
@@ -100,7 +100,7 @@ metadata:
 | `record_join_choice` | 记录一次推荐选择（自动补全上下文，≥5 次后自动学习权重） |
 | `get_join_learning` | 查看选择学习状态与生效的权重调整 |
 | `x_world_digest` | **X 博主世界推荐聚合**：聚合指定 X 博主近 1/3/7/15/30 天推荐的世界，按收藏数排序；收藏/浏览比 ≥ 1/5 标 ⭐重点。`refresh=true` 先抓最新推文再查询 |
-| `x_scan_creators` | **X 推荐抓取**：立即抓取所有已配置博主的最新推文，提取推荐世界并查询收藏/浏览数据入库。双数据源降级：Nitter RSS 失败自动回退 X SearchTimeline GraphQL（完整推文流，可解决 Nitter 404 的博主）；两者都挂时返回可读错误提示 |
+| `x_scan_creators` | **X 推荐抓取**：立即抓取所有已配置博主的最新推文，提取推荐世界并查询收藏/浏览数据入库。双数据源降级：Nitter RSS 失败自动回退 X SearchTimeline GraphQL（完整推文流，可解决 Nitter 404 的博主）；两者都挂时返回可读错误提示。**内置 t.co 短链解包**（推文里的世界链接常被 X 压缩成 `https://t.co/XXXX` 短链，如探跡家もっけい/fox_yata9 等博主的世界推荐全在短链里，不解包会整批漏抓；`VRC_MONITOR_X_RESOLVE_TCO=0` 可关闭） |
 | `x_creators` | 列出当前配置的 X 博主清单 |
 | `x_add_creator` | 添加要追踪的 X 博主（VRChat 世界推荐博主；`screen_name` 不带 @） |
 | `x_remove_creator` | 移除追踪的 X 博主 |

--- a/skills/vrchat-world-queries/SKILL.md
+++ b/skills/vrchat-world-queries/SKILL.md
@@ -106,6 +106,10 @@ metadata:
 4. **扫描**：`x_scan_creators` 抓全部博主推文→提取世界链接→逐个查 VRChat API 收藏/浏览入库（限流 ~2.6s/个）。**⚠️ 数十个世界要几分钟，MCP 客户端会超时但服务端照常跑完**——超时后等几分钟直接查 `x_world_recommendations` 表验证，别重发
 5. **查询**：`x_world_digest {days, limit, creator?, refresh?}` 按收藏排序输出，`favoriteVisitRatio ≥ highlightRatio(默认0.2)` 标 ⭐重点。未配置博主（x_creators=[]）返回空 worlds 不是故障
 
+### ⚠️ 世界挖取经验：t.co 短链解包（2026-09 实测，防漏抓核心）
+
+部分博主（探跡家もっけい mokkei_VE、fox_yata9 等）的世界推荐**不是写在推文文本 `World: X By: Y` 里，而是附带 `https://t.co/XXXX` 短链指向 vrchat 世界页**。t.co 现返回 **200 HTML + `<meta http-equiv=refresh content="0;URL=...">`**（非 HTTP 302），必须抓 body 解析 `URL=` 拿真实 wrld_。服务端 `fetchCreatorTweets` 已内置批量解包（`VRC_MONITOR_X_RESOLVE_TCO=0` 关闭）；**若发现某博主"0 推荐"但用户坚持有，先检查推文是否全是 t.co 短链型**，勿用文本匹配结果反驳。
+
 ## 6. 地图列表展示格式（通用推荐）
 
 展示地图列表时按此格式（6 列）：

--- a/test/test-fetch-x-worlds.mjs
+++ b/test/test-fetch-x-worlds.mjs
@@ -1,5 +1,8 @@
-// 测试 fetch-x-worlds.js 的新函数（extractWorldsFromTweetText + 降级）
-import { extractWorldsFromTweetText, fetchCreatorTweets, fetchCreatorViaSearchTimeline } from '../core/fetch-x-worlds.js';
+// 测试 fetch-x-worlds.js 的新函数（extractWorldsFromTweetText + 降级 + t.co 短链解包）
+import {
+  extractWorldsFromTweetText, fetchCreatorTweets, fetchCreatorViaSearchTimeline,
+  extractTcoLinks, resolveTcoLink, resolveTcoWorldIds, enrichWorldIdsFromTco,
+} from '../core/fetch-x-worlds.js';
 
 let pass = 0, fail = 0;
 function assert(label, cond) {
@@ -31,7 +34,39 @@ assert('launch worldId 提取', r.worldIds.includes('wrld_b1992535-7aca-4cbb-844
 r = extractWorldsFromTweetText('World name: Freedom.\nBy: Ina Crow\nPlatform: PC');
 assert('特殊字符世界名 Freedom.', r.worldNames.some(n => n.includes('Freedom')));
 
-console.log(`\n=== 2. 降级流程测试（需 --network 参数，依赖网络）===`);
+console.log('\n=== 2. t.co 短链解包函数单元测试（纯本地） ===');
+
+// extractTcoLinks：提取全部 t.co 短链（去重）
+const tcoText = '世界推荐 https://t.co/abc123XYZ 好美，还有 https://t.co/abc123XYZ 与 https://t.co/def456UVW';
+const tcoLinks = extractTcoLinks(tcoText);
+assert('extractTcoLinks 提取 2 个去重短链', tcoLinks.length === 2);
+assert('extractTcoLinks 内容正确', tcoLinks.includes('https://t.co/abc123XYZ') && tcoLinks.includes('https://t.co/def456UVW'));
+
+// 空文本 / 无短链
+assert('extractTcoLinks 空文本返回空数组', extractTcoLinks('').length === 0);
+assert('extractTcoLinks 无短链返回空数组', extractTcoLinks('只是一个普通文本，没有链接').length === 0);
+
+// enrichWorldIdsFromTco：无 t.co 链接时原样返回（不产生副作用）
+const plainTweet = { id: 't0', text: 'World:Something\nBy:Somebody', worldIds: ['wrld_00000000-0000-4000-8000-000000000000'], worldNames: ['Something'] };
+const plainResult = await enrichWorldIdsFromTco(plainTweet);
+assert('enrichWorldIdsFromTco 无短链不改 worldIds', plainResult.worldIds.length === 1);
+
+console.log(`\n=== 3. t.co 解包网络测试（需 --network 参数，t.co 返回 200 HTML + meta refresh）===`);
+if (process.argv.includes('--network')) {
+  try {
+    const real = await resolveTcoLink('https://t.co/PG75RyfR9R');
+    assert('resolveTcoLink 解出 vrchat 链接', real && real.includes('vrchat.com/home/world/'));
+    const ids = await resolveTcoWorldIds(['https://t.co/PG75RyfR9R']);
+    assert('resolveTcoWorldIds 解出 wrld_ ID', ids.length > 0 && /^wrld_[0-9a-f-]{36}$/.test(ids[0]));
+  } catch (e) {
+    console.log(`  ✗ t.co 解包网络测试失败: ${e.message.slice(0, 100)}`);
+    fail++;
+  }
+} else {
+  console.log('  （跳过：无 --network 参数。t.co 解包依赖网络，不稳定）');
+}
+
+console.log(`\n=== 4. 降级流程测试（需 --network 参数，依赖网络）===`);
 if (process.argv.includes('--network')) {
   try {
     const { tweets, source } = await fetchCreatorTweets('Bradlee1011');


### PR DESCRIPTION
## 需求来源

使用者提出：探跡家もっけい（mokkei_VE）近七天至少推荐了六七个世界、fox_yata9 也至少推荐十来个，但 `x_scan_creators` / `x_world_digest` 的抓取结果里这些博主却显示 0 推荐或大量缺失。

排查发现根因：这两位博主的世界推荐**不是写在推文文本的 `World: X By: Y` 格式里，而是附带 `https://t.co/XXXX` 短链指向 vrchat 世界页**。旧逻辑只匹配文本直链，导致整批漏抓（mokkei_VE 被误判 0 推荐，t.co 解包后恢复 **11 个世界**；fox_yata9 恢复 5 个此前名称搜索失败被剔的世界）。

## 实现方式

在 `core/fetch-x-worlds.js`（核心抓取模块）新增 t.co 短链解包：

- `extractTcoLinks(text)`：从推文文本提取全部 `https://t.co/XXXX` 短链（纯本地）
- `resolveTcoLink(url)`：解包单个短链——**t.co 现返回 200 HTML + `<meta http-equiv=refresh content="0;URL=...">`（不再是 HTTP 302）**，抓 body 正则解析 `URL=` 拿到真实 vrchat 链接
- `resolveTcoWorldIds(links)` / `enrichWorldIdsFromTco(tweet)`：批量解包并把 `wrld_` ID 合并回推文 `worldIds`（幂等去重）
- 在 `fetchCreatorTweets` 统一入口对三个通道（浏览器 / Nitter / SearchTimeline）返回的推文批量解包：并发 3、单链接超时 8s、整体超时 30s，**解包失败静默、不影响主流程与既有推文**
- env `VRC_MONITOR_X_RESOLVE_TCO` 默认开启，弱网环境可设 `0` 关闭
- **同步挖取经验到 2 处 skill**（`skills/vrchat-world-queries` §5 世界挖取经验 + `skills/vrc-monitor-agent` 工具表 `x_scan_creators` 描述）与 `DEVELOPMENT.md` §3.4，避免后续 Agent 重踩漏抓坑

## 验证过程与结果

- `node test/test-fetch-x-worlds.mjs`：12 项本地单测全通过（含新增 `extractTcoLinks` / `enrichWorldIdsFromTco` 用例）；加 `--network` 后 `resolveTcoLink` 实测解出真实 vrchat 世界链接、`resolveTcoWorldIds` 解出合法 `wrld_` UUID
- `node test/test-registry.mjs`：registry integrity PASS（104 tools，顺序+定义 OK）
- `python scripts/check-doc-drift.py --json`：`has_drift=false`
- `hermes verify`（bootstrap）：`npm install` 0 vulnerabilities
- 说明：`fetchCreatorTweets` 端到端网络测试在当前环境因 Nitter 410/429、浏览器超时而失败，属通道可达性限制（与本次改动无关），解包函数本体已用真实短链实测通过

> 本 PR 的 head 分支（fix/x-worlds-tco-clean）基于 upstream/main 重建、仅包含本次改动的 5 个文件（core/fetch-x-worlds.js / test/test-fetch-x-worlds.mjs / DEVELOPMENT.md / skills 两处），不含 fork 本地其他提交。