### PR TITLE
fix(monitor): 离线好友空名字回填 + friend-delete 移除好友（issue #127 补漏）

### DIFF
--- a/core/event-pipeline.js
+++ b/core/event-pipeline.js
@@ -272,6 +272,12 @@ export class EventPipeline {
 
   async _handleDelete(event) {
     this._storeEvent(event);
+    // issue #127 补漏：friend-delete 只存事件不移除好友 → 解友的用户（如维护者删除某人）残留在
+    // friends 表，继续显示在 dashboard 好友列表（名字常为空显示 '?'）。friend-delete 应同步从
+    // friends 表移除该好友（事件历史/同屏数据在 events 表，不受影响；若日后重新加好友，friend-add 会重建）。
+    try {
+      if (event.userId) this.storage.run('DELETE FROM friends WHERE user_id = $u', { $u: event.userId });
+    } catch { /* 移除失败不影响事件记录 */ }
   }
 
   async _handleNotification(event) {

--- a/start-monitor.js
+++ b/start-monitor.js
@@ -222,8 +222,12 @@ async function _syncFriendAvatars() {
         const tl = f.trustLevel || inferTrustFromTags(f.tags);
         if (!av && !ic && !tl) continue;
         const ex = storage.getFriend(f.id);
-        if (ex && (ex.avatar_image_url || ex.user_icon) && ex.trust_level) continue; // 头像+信任等级都有则不覆盖
-        storage.upsertFriend({ userId: f.id, avatarImageUrl: av, userIcon: ic, trustLevel: tl });
+        // issue #127 补漏：好友列表 API 响应带 f.displayName，但此前 upsert 未传 displayName，
+        // 离线好友（无 WS 事件带名字）的 display_name 永远为空 → 前端显示 '?'。故：
+        // ① 跳过条件要求 display_name 也已填（否则名字空的好友被 continue 漏掉）；
+        // ② upsert 补传 displayName，下次头像同步即回填离线好友名字。
+        if (ex && (ex.avatar_image_url || ex.user_icon) && ex.trust_level && ex.display_name) continue; // 头像+信任等级+display_name 都有则不覆盖
+        storage.upsertFriend({ userId: f.id, displayName: f.displayName, avatarImageUrl: av, userIcon: ic, trustLevel: tl });
         updated++;
       }
       offset += r.data.length;


### PR DESCRIPTION
## 需求

issue #127 遗留：dashboard 右侧栏部分**离线好友显示 `?`（空名字）**，以及**已解除好友的用户残留在好友列表**。

排查发现两个独立根因（都不在 #128/#129 已修范围内）：

1. **离线好友名字从未被填**：`_syncFriendAvatars` 从 VRChat 好友列表 API（响应带 `f.displayName`）拉全量好友补头像/信任等级，但 `upsertFriend` 未传 `displayName`，导致离线好友（不产生带名字的 WS 事件）的 `display_name` 恒为空。实测 426 位好友中 **31 位**空名（均有头像，名前显示 `?`）。
2. **friend-delete 不移除好友**：`_handleDelete` 对 friend-delete 事件**只存事件、不 `DELETE` friends 表行**，解除好友的用户残留在表里继续显示。实测 1 位（水色猫猫，API 已确认 `isFriend:false`，属用户删除的）。

## 实现

- `start-monitor.js` `_syncFriendAvatars`：`upsertFriend` 补传 `displayName: f.displayName`；跳过条件增加 `&& ex.display_name`（否则名字空的好友被 continue 漏掉）。下次头像同步即回填离线好友名字。
- `core/event-pipeline.js` `_handleDelete`：friend-delete 事件同步 `DELETE FROM friends WHERE user_id=$u`（事件历史/同屏数据在 events 表不受影响；重新加好友由 friend-add 重建）。

## 验证

- 聚焦测试 `.test-delfriend.mjs` 6/6 PASS：friend-delete 后该好友被移除、不影响他人、事件仍入 events 表、重新加好友可重建。
- 隔离环境 + 生产库实测：31 位空名好友经头像同步回填（31→0），水色猫猫（陈旧好友）从 friends 表移除（426→425），离线好友名字显示真实名（如 `- La La La -`、`-夜序-`、`-悠綿 UM_`、`1010chan`），不再显示 `?`。
- 服务健康：`authenticated:true`、`friends:425`、WS connected。

## 说明

未加「好友列表对账」兜底（比对当前好友列表清理非好友）——维护者评估其日常 API 资源消耗过大，暂不做。friend-delete 移除是事件驱动，仅在收到 friend-delete 事件时清理。
