### PR TITLE
feat(logging): add production-grade structured logger (levels/rotation/redaction/named loggers)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ node_modules/
 __pycache__/
 *.pyc
 service-logs/
+# ── 日志模块产物（默认 LOG_DIR 落项目内 logs/）──
+logs/
 # ── Hermes 插件本地文件 ──
 .hermes/
 workspace/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,6 +92,14 @@
 - `VRC_MONITOR_DB_PATH`：SQLite 数据库文件路径（默认 `<仓库>/data/vrc-monitor.sqlite3`）。可将数据库迁移到任意位置（如独立数据盘），配合常驻服务使用。
 - `VRC_MONITOR_BACKUP_DIR`：自动备份目录（默认 `<仓库>/data/backups`）。
 - `VRC_MONITOR_LOG_DIR`：常驻服务脚本的日志 / 修复记录目录（默认 `<仓库>/service-logs`，仅 `service-windows/` 脚本使用；Linux systemd 方案日志走 journald，无需设置）。
+- `VRC_MONITOR_LOGGER_DIR`：应用日志模块（`core/logger.js`）日志文件目录（默认 `<VRC_MONITOR_DIR>/logs`）。注意：与上面 `VRC_MONITOR_LOG_DIR`（service 脚本用）不同名不同义，勿混用。
+- `VRC_MONITOR_LOGGER_LEVEL`：日志最低输出级别（默认 `info`，取值 `debug|info|warn|error|silent`）。
+- `VRC_MONITOR_LOGGER_FORMAT`：日志格式（默认 `text`，`json`=每行 JSONL 供 agent 解析）。
+- `VRC_MONITOR_LOGGER_MAX_SIZE`：单文件轮转阈值字节（默认 `10485760`=10MB）。
+- `VRC_MONITOR_LOGGER_MAX_FILES`：保留的已轮转 .gz 份数（默认 `5`）。
+- `VRC_MONITOR_LOGGER_SUPPRESS`：逗号分隔子串列表，命中即整条丢弃（如 `ping,keepalive` 压 MCP 保活噪音）。
+- `VRC_MONITOR_LOGGER_CONSOLE`：是否同时写 stdout（默认 `1`；`0` 仅写文件，一般不建议）。
+- `VRC_MONITOR_LOGGER_COLOR`：text 格式是否加 ANSI 色（默认 `auto`，写文件永无色）。
 - `VRC_MONITOR_PYTHON`：执行 scripts/fetch-otp.py 的 Python 解释器路径（默认 PATH 中的 `python`）。以计划任务 / systemd / 容器等方式运行且 PATH 中无 python 时必须设置，否则 OTP 自动登录失败会陷入重试循环（每次循环 VRChat 都会重新发送验证码邮件）。**路径含空格无需自带引号**（如 `C:\Program Files\Python311\python.exe`），脚本执行时会自动加引号。
 - `VRC_MONITOR_SAFE_MODE`：**安全模式开关**（默认关闭）。设为 `true` 时，服务启动后自动移除全部破坏性 MCP 工具（删除好友 `remove_friend`、删除相册照片 `remove_print`、删除画廊图片 `remove_gallery_image`、移除好友收藏 `unfavorite_friend`、移除世界收藏 `unfavorite_world`、移动世界收藏分组 `move_world_group`、移动好友收藏分组 `move_friend_group`、清空收藏分组 `clear_favorite_group`、退出群组 `leave_group`、拒绝好友请求 `decline_friend_request`、隐藏通知 `hide_notification`、移出待逛列表 `remove_from_backlog`、移出关注名单 `remove_from_watchlist`、移除 X 博主 `x_remove_creator` 等）：`tools/list` 不再暴露这些工具，`tools/call` 直接拦截报错，防止 Agent 误删数据。可在仓库根 `.env` 中配置（推荐，已被 .gitignore 排除）。
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -120,7 +120,7 @@ PR 由 AI Agent 编写提交（人类只提出需求、不直接编码）。以�
 服务可能被部署进 Docker、K8s 或 NAS 套件里，遵守以下约定：
 
 - **无状态 + 数据卷挂载**：数据库（`data/vrc-monitor.sqlite3`）和 `credentials.json` 应通过挂载卷 / 环境变量提供，容器本身可随时重建。禁止把数据写死在镜像内。
-- **日志走 stdout**：容器 / 进程管理器只采集 stdout，不要新增「写日志文件」的逻辑（或做成可选）。
+- **日志默认写 stdout**：容器 / 进程管理器只采集 stdout，服务必须始终保留 stdout 输出（Hermes 插件 / Docker / systemd 采集都靠它）。如需文件日志（本地排障 / 历史回溯），走 `core/logger.js` 的可选文件输出——它默认同时写 stdout 与 `VRC_MONITOR_LOGGER_DIR` 下的文件，且 stdout 永远保留（`VRC_MONITOR_LOGGER_CONSOLE=0` 可仅关 console，但一般不建议）。不得用独立的「写日志文件」模块绕过 logger。
 - **信号处理**：不假设有 systemd / 服务管理器兜底。进程要优雅处理 `SIGTERM` / `SIGINT`（关闭 WebSocket、正常收尾 SQLite 事务），让容器编排能安全停止。
 - **端口与绑定**：当前绑定 `127.0.0.1:8799` 意味着外部（宿主机 / 其他容器）无法直连；需要对外提供服务时，绑定地址要可配置，且暴露到公网前必须有鉴权（本服务目前无鉴权，默认只允许本机访问是有意为之）。
 - **基础镜像**：better-sqlite3 的原生二进制在 glibc 发行版（如 `node:slim`）上最稳；Alpine（musl）需要确认 prebuilt 可用，或改用 glibc 镜像，别默认 Alpine。
@@ -157,7 +157,7 @@ PR 由 AI Agent 编写提交（人类只提出需求、不直接编码）。以�
   - 文档同步：新增工具必须登记进 `skills/vrc-monitor-agent/SKILL.md`「MCP 工具」章节（**唯一权威工具表**，2026-08-15 决策，避免多表重复维护）；README 的 MCP 工具段与 AGENTS.md 工具列举为采样说明，新增工具后顺带核对（工具清单漂移检测用 `python3 scripts/check-doc-drift.py`）。
   - **限流不要嵌套**（2026-08-09 真实死锁事故）：handler 内部逐请求 `rateLimiter.execute` 时，RPC case 层**不要再包一层** `rateLimiter.execute`——外层执行时 `_processing=true`，内层请求永远排不上队，整个 handler 挂死（`scan_new_worlds` 首版即如此，120s 超时；修复：case 层裸调，内部已逐请求限流）。
 - **错误处理**：异步路径必须有 try/catch 或 Promise 拒绝处理；WebSocket 消息处理不得因单条消息异常导致服务中断。
-- **日志**：沿用现有 `log()` 输出风格（中文 + emoji），不引入额外日志库。
+- **日志**：统一走 `core/logger.js`（自实现，中文 + emoji 风格），用 `getLogger('<组件名>')` 命名子 logger，不要裸 `console.*`（启动失败/凭据缺失/崩溃兜底路径除外）；**禁止引入第三方日志库**（pino/winston 等，与零依赖原则冲突）。日志变量统一 `VRC_MONITOR_LOGGER_*` 前缀（见 AGENTS.md 环境变量表）。
 - **SQL**：建表 / 索引沿用 `core/init-db.sql` 的幂等写法（`IF NOT EXISTS`）；查询一律用参数占位符，禁止字符串拼接 SQL。
 
 ## 6. 测试与 CI

--- a/README.md
+++ b/README.md
@@ -59,6 +59,29 @@
 - `scripts/prepare_image.py`：上传前图片处理（emoji 方形化 / Prints 16:9 / Gallery 4:3）
 - `scripts/migrate-vrcx0.mjs`：从 VRCX 一键迁移历史数据 — `node scripts/migrate-vrcx0.mjs`
 
+## 📝 日志
+
+服务日志统一走 `core/logger.js`，默认同时写 stdout 与 `<VRC_MONITOR_LOGGER_DIR>/monitor.log`，支持级别/格式/轮转/脱敏。
+
+| 变量 | 默认值 | 说明 |
+|------|--------|------|
+| `VRC_MONITOR_LOGGER_DIR` | `<VRC_MONITOR_DIR>/logs` | 日志文件目录 |
+| `VRC_MONITOR_LOGGER_LEVEL` | `info` | 最低输出级别（debug/info/warn/error/silent） |
+| `VRC_MONITOR_LOGGER_FORMAT` | `text` | 日志格式（`text`/`json`，json 每行为 JSONL，便于 agent 解析） |
+| `VRC_MONITOR_LOGGER_MAX_SIZE` | `10485760` | 单文件轮转阈值字节（默认 10MB） |
+| `VRC_MONITOR_LOGGER_MAX_FILES` | `5` | 保留的已轮转 .gz 份数 |
+| `VRC_MONITOR_LOGGER_SUPPRESS` | - | 逗号分隔子串列表，命中即整条丢弃（如 `ping,keepalive`） |
+| `VRC_MONITOR_LOGGER_CONSOLE` | `1` | 是否同时输出到 stdout（`0` 仅写文件，不建议关闭） |
+| `VRC_MONITOR_LOGGER_COLOR` | `auto` | text 格式是否加 ANSI 色（写文件永远无色） |
+
+排障时可用 JSONL 格式解析：`VRC_MONITOR_LOGGER_FORMAT=json node start-monitor.js` 启动后通过 `jq` 过滤结构化日志，例如：
+
+```bash
+jq -r 'select(.level=="error") | "\(.ts) [\(.name)] \(.msg)"' "$VRC_MONITOR_LOGGER_DIR/monitor.log"
+```
+
+单文件达到 `MAX_SIZE` 时自动轮转压缩为 `.gz`，命名形如 `monitor-YYYYMMDD-HHMMSS-<pid>.log.gz`，最多保留 `MAX_FILES` 份。
+
 ## 🛠 故障排查
 
 **Q: WebSocket 连不上？**

--- a/core/http-server.js
+++ b/core/http-server.js
@@ -7,7 +7,11 @@
 import http from 'node:http';
 import { randomUUID } from 'node:crypto';
 import { ctx, log } from './server-context.js';
+import { getLogger } from './logger.js';
 import * as registry from './registry.js';
+
+// 命名日志：MCP 协议层（JSON-RPC 往返），请求日志默认降为 debug 级避免 ping/keepalive 刷屏
+const logMCP = getLogger('mcp');
 
 // ── MCP 会话管理 ──
 const sessions = new Map();
@@ -141,7 +145,7 @@ async function handleRequest(req, res) {
       const rpc = JSON.parse(body);
       const sessionId = req.headers['mcp-session-id'];
       const session = getOrCreateSession(sessionId);
-      log(`MCP ${rpc.method || '?'} ${body.slice(0, 60)}...`);
+      logMCP.debug(`MCP ${rpc.method || '?'} ${body.slice(0, 60)}...`);
       await handleRpc(rpc, session, res);
     } catch (err) {
       log(`Parse error: ${err.message}`);

--- a/core/logger.js
+++ b/core/logger.js
@@ -260,7 +260,8 @@ function doRotate() {
   if (!state.fileEnabled || !fs.existsSync(state.filePath)) return;
 
   const now = new Date();
-  const ts = now.toISOString().replace(/[-:T]/g, '').replace(/\.\d{3}Z$/, '');
+  // UTC 时间戳 → YYYYMMDD-HHMMSS（去 ISO 连字符/冒号，T 转 -），与 plan 命名约定对齐
+  const ts = now.toISOString().replace(/-/g, '').replace(/:/g, '').replace('T', '-').replace(/\.\d{3}Z$/, '');
   const rotatedName = `monitor-${ts}-${state.pid}.log`;
   const rotatedPath = path.join(state.dir, rotatedName);
 

--- a/core/logger.js
+++ b/core/logger.js
@@ -356,6 +356,15 @@ export function setLevel(level) {
   state.level = parseLevel(level);
 }
 
+// 把级别数字转回人类可读名（供 ctx.paths.LOG_LEVEL 展示 / MCP 工具用）
+export function getLevelName(level) {
+  const n = parseLevel(level);
+  for (const [name, val] of Object.entries(LEVELS)) {
+    if (val === n) return name;
+  }
+  return 'info';
+}
+
 export function rotate() {
   doRotate();
 }

--- a/core/logger.js
+++ b/core/logger.js
@@ -20,8 +20,9 @@ const state = {
 };
 
 function resolveDir() {
-  if (process.env.VRC_MONITOR_LOG_DIR) {
-    return path.resolve(process.env.VRC_MONITOR_LOG_DIR);
+  // 日志模块专属变量名（VRC_MONITOR_LOGGER_DIR），不与 AGENTS.md 里 service-windows 用的 VRC_MONITOR_LOG_DIR 撞名
+  if (process.env.VRC_MONITOR_LOGGER_DIR) {
+    return path.resolve(process.env.VRC_MONITOR_LOGGER_DIR);
   }
   if (process.env.VRC_MONITOR_DIR) {
     return path.join(process.env.VRC_MONITOR_DIR, 'logs');

--- a/core/logger.js
+++ b/core/logger.js
@@ -11,12 +11,15 @@ const REPO_ROOT = path.join(__dirname, '..');
 // 敏感词单一来源：redactSecrets 文本正则与 meta 键名判定共用，避免两处漂移。
 // 开放词根：允许被 `_`/`-`/驼峰 前缀包裹（access_token / refreshToken / grant_code），
 // 内含具体 OAuth/凭证变体，避免泛化 code/secrets 误伤 country_code/errorCode。
+// IMAP/OTP 授权码变体（credentials.json 真实字段）必须完整入表，
+// 否则文本 openKey 只匹配「词根紧跟分隔符」会在 imap_auth_code 处漏脱（仅 meta 开边界命中）。
 const SENSITIVE_WORDS = [
   'authToken', 'authorization', 'authorization_code', 'set-cookie', 'apiKey',
   'api_key', 'authcode', 'password', 'passwd', 'cookie', 'secret',
   'client_secret', 'api_secret', 'smtp', 'imap', 'pwd', 'token',
   'access_token', 'refresh_token', 'id_token', 'session_token', 'login_token',
   'grant_code', 'verification_code', 'auth', 'credential',
+  'imap_auth_code', 'smtp_auth_code', 'auth_code', 'otp_code', 'totp_code',
 ];
 // TOTP 校验码等**仅精确整键**才视为敏感（状态类字段 code/level 不误伤）。
 const SENSITIVE_EXACT = ['code', 'totp', 'otp', 'pin'];

--- a/core/logger.js
+++ b/core/logger.js
@@ -198,13 +198,16 @@ export function redactSecrets(text) {
   // 边界与 isSensitiveKey 同语义：前缀接受 非字母数字 或 驼峰切换点（`_`/`-`/`access|Token`），
   // 后缀拒绝紧跟字母数字（防 tokenizer/tokens）。
   // code/totp/otp/pin 校验码**不做驼峰开放**（否则 statusCode/errorCode 误伤），仅接受严格键形前缀。
-  // 开放词根：支持驼峰/下划线/连字符前缀（access_token / refreshToken 命中）
+  // 开放词根：支持驼峰/下划线/连字符前缀（access_token / refreshToken / grant_code 命中）
   const openWords = SENSITIVE_WORDS;
   const openKey =
     '["\']?(?:^|[^A-Za-z0-9]|(?<=[a-z])(?=[A-Z]))(?:' + openWords.join('|') + ')(?![A-Za-z0-9])["\']?';
-  // 校验码：严格键形（前缀不接受驼峰切换点，防 statusCode/errorCode 误伤）
+  // 校验码：仅「严格整键」才脱敏（前缀不接受 下划线/连字符/驼峰，防 *_code 业务字段误伤）。
+  // 因此 country_code / invite_code / room_code / postal_code / group_code 不命中；
+  // 而裸 code / totp / otp / pin（前面是 =、:、空格、^、引号）命中；
+  // grant_code / authorization_code 等凭证变体由上方 openWords 完整词匹配。
   const exactKey =
-    '["\']?(?:^|[^A-Za-z0-9])(?:code|totp|otp|pin)(?![A-Za-z0-9])["\']?';
+    '["\']?(?:^|[^A-Za-z0-9_-])(?:code|totp|otp|pin)(?![A-Za-z0-9])["\']?';
   // 值捕获：双引号串/单引号串/Bearer token/裸值（引号保留 + 值整段吞没）
   const val = `(?:\\"([^\\"]*)\\"|\\'([^\\']*)\\'|(Bearer\\s+[^\\s,;]+)|([^\\s,;]+))`;
   // 键名+分隔符整体作 prefix 捕获，替换后保留 `key=`/`key:` 形式

--- a/core/logger.js
+++ b/core/logger.js
@@ -8,9 +8,33 @@ import { fileURLToPath } from 'node:url';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.join(__dirname, '..');
 
-// 敏感键名单：meta 对象里命中即整值脱敏（含大小写/蛇形/驼峰变体）
-const SENSITIVE_KEY_RE = /^(?:auth(?:token|orization|code)?|authorization|cookie|set-cookie|password|passwd|pwd|secret|token|apikey|api_key|smtp|imap|authcode|授权码)$/i;
+// 敏感词单一来源：redactSecrets 文本正则与 meta 键名判定共用，避免两处漂移。
+// code/totp/otp/pin 为 TOTP 验证码（MCP submit_totp 参数）；verification[_-]?code 为通用校验码。
+const SENSITIVE_WORDS = [
+  'authToken', 'authorization', 'set-cookie', 'apiKey', 'api_key', 'authcode',
+  'password', 'passwd', 'cookie', 'secret', 'smtp', 'imap', 'pwd', 'token', 'auth',
+];
+// 元数据键名判定（含大小写/下划线变体）；code 类校验码单独纳入
+const SENSITIVE_KEY_RE = new RegExp(
+  `^(?:${SENSITIVE_WORDS.join('|')}|code|totp|otp|pin|verification[_-]?code)$`,
+  'i'
+);
 const isSensitiveKey = (key) => SENSITIVE_KEY_RE.test(String(key));
+
+// 递归脱敏值：对 meta 值做深遍历——敏感 key 命中 → 整值 [REDACTED]；
+// 字符串 → redactSecrets；数组 → 逐元素；普通对象 → 逐键递归。防嵌套对象里藏凭据落盘。
+function redactValue(value) {
+  if (typeof value === 'string') return redactSecrets(value);
+  if (Array.isArray(value)) return value.map(redactValue);
+  if (value && typeof value === 'object') {
+    const out = {};
+    for (const [k, v] of Object.entries(value)) {
+      out[k] = isSensitiveKey(k) ? '[REDACTED]' : redactValue(v);
+    }
+    return out;
+  }
+  return value;
+}
 
 export const LEVELS = { debug: 10, info: 20, warn: 30, error: 40, silent: 99 };
 
@@ -76,23 +100,23 @@ function buildConfig(options) {
   };
 
   const dir = options && 'dir' in options ? options.dir : resolveDir();
-  const formatRaw = envOrOpt('VRC_MONITOR_LOG_FORMAT', 'format');
-  const colorRaw = envOrOpt('VRC_MONITOR_LOG_COLOR', 'color');
+  const formatRaw = envOrOpt('VRC_MONITOR_LOGGER_FORMAT', 'format');
+  const colorRaw = envOrOpt('VRC_MONITOR_LOGGER_COLOR', 'color');
 
   return {
-    level: parseLevel(options?.level ?? process.env.VRC_MONITOR_LOG_LEVEL),
+    level: parseLevel(options?.level ?? process.env.VRC_MONITOR_LOGGER_LEVEL),
     dir,
     format: formatRaw === 'json' ? 'json' : 'text',
     maxSize: parseIntDefault(
-      envOrOpt('VRC_MONITOR_LOG_MAX_SIZE', 'maxSize'),
+      envOrOpt('VRC_MONITOR_LOGGER_MAX_SIZE', 'maxSize'),
       10 * 1024 * 1024
     ),
     maxFiles: parseIntDefault(
-      envOrOpt('VRC_MONITOR_LOG_MAX_FILES', 'maxFiles'),
+      envOrOpt('VRC_MONITOR_LOGGER_MAX_FILES', 'maxFiles'),
       5
     ),
     console: parseBool(
-      envOrOpt('VRC_MONITOR_LOG_CONSOLE', 'console'),
+      envOrOpt('VRC_MONITOR_LOGGER_CONSOLE', 'console'),
       true
     ),
     color:
@@ -100,7 +124,7 @@ function buildConfig(options) {
         ? 'auto'
         : parseBool(colorRaw, false),
     suppress: parseSuppress(
-      envOrOpt('VRC_MONITOR_LOG_SUPPRESS', 'suppress')
+      envOrOpt('VRC_MONITOR_LOGGER_SUPPRESS', 'suppress')
     ),
   };
 }
@@ -160,12 +184,10 @@ export function redactSecrets(text) {
   //   - Bearer token (空格分隔: Bearer eyJ...)          ← 修复：不再被 `[^\s;]+` 在空格处截断而残留 token
   //   - 裸值       secret123
   // 替换回调保留原引号风格，保证 JSON 行结构不被破坏。
-  // 键名边界：前后不允许紧邻字母数字（lookbehind/lookahead），但允许 `_` 或 `-` 紧邻，
-  // 故 access_token / access-token / refresh_token 这类下划线/连字符键也能命中；
-  // 而 tokenizer / tokens 因 lookahead 拒绝字母数字紧邻而不误伤。
-  // （token_use 之类由主正则的 `\s*[:=]` 分隔符约束天然排除，不会误配。）
+  // 敏感词列表 = 单一来源 SENSITIVE_WORDS + code 类校验码。加 \b 边界。
+  const words = [...SENSITIVE_WORDS, 'code', 'totp', 'otp', 'pin'];
   const key =
-    '["\']?(?<![A-Za-z0-9])(?:authToken|authorization|set-cookie|apiKey|api_key|authcode|password|passwd|cookie|secret|smtp|imap|pwd|token|auth)(?![A-Za-z0-9])["\']?';
+    '["\']?(?<![A-Za-z0-9])(?:' + words.join('|') + ')(?![A-Za-z0-9])["\']?';
   out = out.replace(
     new RegExp(
       `(${key}\\s*[:=]\\s*)(?:"([^"]*)"|\'([^\']*)\'|(Bearer\\s+[^\\s,;]+)|([^\\s,;]+))`,
@@ -336,18 +358,9 @@ function write(levelName, name, msg, meta) {
 
   let line;
   if (state.format === 'json') {
-    const safeMeta = {};
-    if (meta && typeof meta === 'object') {
-      for (const [key, value] of Object.entries(meta)) {
-        // 键名命中敏感名单 → 整值脱敏（无论类型；修复 `{authToken:'xxx'}` 纯值泄漏）；
-        // 否则值字符串再跑一次 text 脱敏，防止嵌套文本残留
-        safeMeta[key] = isSensitiveKey(key)
-          ? '[REDACTED]'
-          : typeof value === 'string'
-            ? redactSecrets(value)
-            : value;
-      }
-    }
+    // 递归脱敏 meta：敏感 key 命中的整值、嵌套对象/数组里的字符串都过脱敏。
+    // 修复 psenY review 指出的「嵌套对象 authorization/token 原样落盘」。
+    const safeMeta = redactValue(meta);
     line = formatJson(ts, levelName, name, redactedMsg, safeMeta);
   } else {
     line = formatText(ts, levelName, name, redactedMsg);

--- a/core/logger.js
+++ b/core/logger.js
@@ -9,18 +9,22 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.join(__dirname, '..');
 
 // 敏感词单一来源：redactSecrets 文本正则与 meta 键名判定共用，避免两处漂移。
-// 词根型敏感词（允许被 `_`/`-`/驼峰 前缀或后缀包裹，如 access_token / refreshToken）：
+// 开放词根：允许被 `_`/`-`/驼峰 前缀包裹（access_token / refreshToken / grant_code），
+// 内含具体 OAuth/凭证变体，避免泛化 code/secrets 误伤 country_code/errorCode。
 const SENSITIVE_WORDS = [
-  'authToken', 'authorization', 'set-cookie', 'apiKey', 'api_key', 'authcode',
-  'password', 'passwd', 'cookie', 'secret', 'smtp', 'imap', 'pwd', 'token', 'auth',
+  'authToken', 'authorization', 'authorization_code', 'set-cookie', 'apiKey',
+  'api_key', 'authcode', 'password', 'passwd', 'cookie', 'secret',
+  'client_secret', 'api_secret', 'smtp', 'imap', 'pwd', 'token',
+  'access_token', 'refresh_token', 'id_token', 'session_token', 'login_token',
+  'grant_code', 'verification_code', 'auth', 'credential',
 ];
-// TOTP 校验码等**仅精确整键**才视为敏感（避免 statusCode / errorCode / country_code 这类业务字段误伤）：
-const SENSITIVE_EXACT = ['code', 'totp', 'otp', 'pin', 'verification_code', 'verification-code'];
+// TOTP 校验码等**仅精确整键**才视为敏感（状态类字段 code/level 不误伤）。
+const SENSITIVE_EXACT = ['code', 'totp', 'otp', 'pin'];
 
 // 键名判定：与文本正则同语义——词根前后为 非字母数字 边界（允许 `_`/`-`/`^`/`$`），
 // 并接受驼峰切换点（小写→大写，如 accessToken 的 `access|Token`）。
-// 因此 access_token / refresh_token / accessToken / refreshToken 命中；
-// 而 tokenizer / tokens / token_use 因词根后紧跟字母数字 或 键形不符 而不误伤。
+// 因此 access_token / refresh_token / accessToken / refreshToken / grant_code 命中；
+// 而 tokenizer / tokens / country_code / statusCode / errorCode 不误伤。
 const SENSITIVE_KEY_RE = new RegExp(
   `(^|[^A-Za-z0-9]|(?<=[a-z])(?=[A-Z]))(?:${SENSITIVE_WORDS.join('|')})(?![A-Za-z0-9])`,
   'i'

--- a/core/logger.js
+++ b/core/logger.js
@@ -1,0 +1,369 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import zlib from 'node:zlib';
+
+export const LEVELS = { debug: 10, info: 20, warn: 30, error: 40, silent: 99 };
+
+const state = {
+  level: LEVELS.info,
+  dir: '',
+  format: 'text',
+  maxSize: 10 * 1024 * 1024,
+  maxFiles: 5,
+  console: true,
+  color: 'auto',
+  suppress: [],
+  filePath: '',
+  fileEnabled: false,
+  closed: false,
+  pid: process.pid,
+};
+
+function resolveDir() {
+  if (process.env.VRC_MONITOR_LOG_DIR) {
+    return path.resolve(process.env.VRC_MONITOR_LOG_DIR);
+  }
+  if (process.env.VRC_MONITOR_DIR) {
+    return path.join(process.env.VRC_MONITOR_DIR, 'logs');
+  }
+  return path.join(path.dirname(process.cwd()), 'logs');
+}
+
+function parseLevel(value) {
+  if (typeof value === 'number') return value;
+  if (typeof value !== 'string') return LEVELS.info;
+  const key = value.trim().toLowerCase();
+  return LEVELS[key] ?? LEVELS.info;
+}
+
+function parseBool(value, defaultValue) {
+  if (value === undefined || value === null) return defaultValue;
+  const s = String(value).trim();
+  if (s === '' || s === '0' || s.toLowerCase() === 'false') return false;
+  return true;
+}
+
+function parseIntDefault(value, defaultValue) {
+  if (value === undefined || value === null) return defaultValue;
+  const n = parseInt(String(value), 10);
+  return Number.isNaN(n) ? defaultValue : n;
+}
+
+function parseSuppress(value) {
+  if (!value || String(value).trim() === '') return [];
+  return String(value)
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+function buildConfig(options) {
+  const envOrOpt = (envKey, optKey) => {
+    if (options && optKey in options) return options[optKey];
+    return process.env[envKey];
+  };
+
+  const dir = options && 'dir' in options ? options.dir : resolveDir();
+  const formatRaw = envOrOpt('VRC_MONITOR_LOG_FORMAT', 'format');
+  const colorRaw = envOrOpt('VRC_MONITOR_LOG_COLOR', 'color');
+
+  return {
+    level: parseLevel(options?.level ?? process.env.VRC_MONITOR_LOG_LEVEL),
+    dir,
+    format: formatRaw === 'json' ? 'json' : 'text',
+    maxSize: parseIntDefault(
+      envOrOpt('VRC_MONITOR_LOG_MAX_SIZE', 'maxSize'),
+      10 * 1024 * 1024
+    ),
+    maxFiles: parseIntDefault(
+      envOrOpt('VRC_MONITOR_LOG_MAX_FILES', 'maxFiles'),
+      5
+    ),
+    console: parseBool(
+      envOrOpt('VRC_MONITOR_LOG_CONSOLE', 'console'),
+      true
+    ),
+    color:
+      colorRaw === 'auto' || colorRaw === undefined || colorRaw === null
+        ? 'auto'
+        : parseBool(colorRaw, false),
+    suppress: parseSuppress(
+      envOrOpt('VRC_MONITOR_LOG_SUPPRESS', 'suppress')
+    ),
+  };
+}
+
+export function initLogger(options = {}) {
+  const cfg = buildConfig(options);
+
+  state.level = cfg.level;
+  state.dir = cfg.dir;
+  state.format = cfg.format;
+  state.maxSize = cfg.maxSize;
+  state.maxFiles = cfg.maxFiles;
+  state.console = cfg.console;
+  state.color = cfg.color;
+  state.suppress = cfg.suppress;
+  state.filePath = path.join(state.dir, 'monitor.log');
+  state.fileEnabled = true;
+  state.closed = false;
+  state.pid = process.pid;
+
+  try {
+    fs.mkdirSync(state.dir, { recursive: true });
+    const testPath = path.join(state.dir, '.init-test');
+    fs.writeFileSync(testPath, '');
+    fs.unlinkSync(testPath);
+  } catch (err) {
+    state.fileEnabled = false;
+    state.filePath = '';
+    if (state.console) {
+      console.warn(
+        `[logger] 日志目录不可写，已降级为仅 console: ${err.message}`
+      );
+    }
+  }
+
+  return state;
+}
+
+function isOutputEnabled(level) {
+  return level >= state.level;
+}
+
+function shouldSuppress(msg) {
+  if (!state.suppress.length) return false;
+  return state.suppress.some((sub) => msg.includes(sub));
+}
+
+export function redactSecrets(text) {
+  if (typeof text !== 'string') return text;
+
+  let out = text;
+
+  out = out.replace(
+    /((?:authToken|authorization|cookie|set-cookie))(\s*[:=]\s*)([^\s,;"']+)/gi,
+    '$1$2[REDACTED]'
+  );
+
+  out = out.replace(
+    /((?:password|passwd|pwd|secret|token))(\s*[:=]\s*)([^\s,;"']+)/gi,
+    '$1$2[REDACTED]'
+  );
+
+  out = out.replace(
+    /((?:smtp|imap|授权码|authcode))(\s*[:=:：]\s*)(\S+)/gi,
+    '$1$2[REDACTED]'
+  );
+
+  out = out.replace(/(auth=)([^\s,;"']+)/gi, '$1[REDACTED]');
+  out = out.replace(/(apiKey=)([^\s,;"']+)/gi, '$1[REDACTED]');
+
+  out = out.replace(/[\w.+-]+@[\w-]+\.[\w.]+/g, '[REDACTED]');
+
+  return out;
+}
+
+function formatText(ts, levelName, name, msg) {
+  const upper = levelName.toUpperCase().padEnd(5);
+  return `${ts} ${upper} [${name}] ${msg}`;
+}
+
+function formatJson(ts, levelName, name, msg, meta) {
+  const obj = {
+    ts,
+    level: levelName.toLowerCase(),
+    name,
+    msg,
+    pid: state.pid,
+  };
+  if (meta && typeof meta === 'object') {
+    for (const [key, value] of Object.entries(meta)) {
+      if (!(key in obj)) {
+        obj[key] = value;
+      }
+    }
+  }
+  return JSON.stringify(obj);
+}
+
+function applyColor(line, levelName) {
+  const reset = '\x1b[0m';
+  switch (levelName.toLowerCase()) {
+    case 'debug':
+      return `\x1b[90m${line}${reset}`;
+    case 'info':
+      return `\x1b[32m${line}${reset}`;
+    case 'warn':
+      return `\x1b[33m${line}${reset}`;
+    case 'error':
+      return `\x1b[31m${line}${reset}`;
+    default:
+      return line;
+  }
+}
+
+function writeToConsole(levelName, line) {
+  if (!state.console) return;
+
+  let output = line;
+  const useColor =
+    state.color === true ||
+    (state.color === 'auto' && process.stdout.isTTY && state.format === 'text');
+  if (useColor) {
+    output = applyColor(line, levelName);
+  }
+
+  switch (levelName) {
+    case 'debug':
+      console.debug(output);
+      break;
+    case 'info':
+      console.info(output);
+      break;
+    case 'warn':
+      console.warn(output);
+      break;
+    case 'error':
+      console.error(output);
+      break;
+    default:
+      console.log(output);
+  }
+}
+
+function cleanupOldLogs() {
+  try {
+    const files = fs.readdirSync(state.dir);
+    const gzFiles = files
+      .filter((f) => f.endsWith('.log.gz'))
+      .map((f) => {
+        const full = path.join(state.dir, f);
+        return { name: f, path: full, mtime: fs.statSync(full).mtimeMs };
+      })
+      .sort((a, b) => a.mtime - b.mtime);
+
+    while (gzFiles.length > state.maxFiles) {
+      const oldest = gzFiles.shift();
+      try {
+        fs.unlinkSync(oldest.path);
+      } catch {
+        // ignore cleanup errors
+      }
+    }
+  } catch {
+    // ignore cleanup errors
+  }
+}
+
+function doRotate() {
+  if (!state.fileEnabled || !fs.existsSync(state.filePath)) return;
+
+  const now = new Date();
+  const ts = now.toISOString().replace(/[-:T]/g, '').replace(/\.\d{3}Z$/, '');
+  const rotatedName = `monitor-${ts}-${state.pid}.log`;
+  const rotatedPath = path.join(state.dir, rotatedName);
+
+  try {
+    fs.renameSync(state.filePath, rotatedPath);
+  } catch (err) {
+    if (err && (err.code === 'EPERM' || err.code === 'EBUSY')) {
+      const warnLine = `${new Date().toISOString()} WARN  [logger] 轮转失败，跳过本次: ${err.message}`;
+      if (state.console) console.warn(warnLine);
+      return;
+    }
+    throw err;
+  }
+
+  try {
+    const data = fs.readFileSync(rotatedPath);
+    const gz = zlib.gzipSync(data);
+    fs.writeFileSync(`${rotatedPath}.gz`, gz);
+    fs.unlinkSync(rotatedPath);
+    cleanupOldLogs();
+  } catch {
+    // gzip failed: keep uncompressed rotated file
+  }
+}
+
+function checkRotation(line) {
+  if (!state.fileEnabled || !fs.existsSync(state.filePath)) return;
+  const stats = fs.statSync(state.filePath);
+  const lineBytes = Buffer.byteLength(line, 'utf8');
+  if (stats.size + lineBytes > state.maxSize) {
+    doRotate();
+  }
+}
+
+function write(levelName, name, msg, meta) {
+  if (state.closed) return;
+
+  const rawMsg = typeof msg === 'string' ? msg : String(msg);
+  if (shouldSuppress(rawMsg)) return;
+
+  const levelValue = LEVELS[levelName] ?? LEVELS.info;
+  if (!isOutputEnabled(levelValue)) return;
+
+  const ts = new Date().toISOString();
+  const redactedMsg = redactSecrets(rawMsg);
+
+  let line;
+  if (state.format === 'json') {
+    const safeMeta = {};
+    if (meta && typeof meta === 'object') {
+      for (const [key, value] of Object.entries(meta)) {
+        safeMeta[key] = typeof value === 'string' ? redactSecrets(value) : value;
+      }
+    }
+    line = formatJson(ts, levelName, name, redactedMsg, safeMeta);
+  } else {
+    line = formatText(ts, levelName, name, redactedMsg);
+  }
+
+  writeToConsole(levelName, line);
+
+  if (state.fileEnabled && state.filePath) {
+    try {
+      checkRotation(line);
+      fs.appendFileSync(state.filePath, `${line}\n`, 'utf8');
+    } catch (err) {
+      if (state.console) {
+        console.error(`[logger] 写入日志文件失败: ${err.message}`);
+      }
+    }
+  }
+}
+
+export const logger = {
+  debug(msg, meta) { write('debug', 'app', msg, meta); },
+  info(msg, meta) { write('info', 'app', msg, meta); },
+  warn(msg, meta) { write('warn', 'app', msg, meta); },
+  error(msg, meta) { write('error', 'app', msg, meta); },
+};
+
+export function getLogger(name) {
+  const n = String(name ?? 'app');
+  return {
+    debug(msg, meta) { write('debug', n, msg, meta); },
+    info(msg, meta) { write('info', n, msg, meta); },
+    warn(msg, meta) { write('warn', n, msg, meta); },
+    error(msg, meta) { write('error', n, msg, meta); },
+    name: n,
+  };
+}
+
+export function setLevel(level) {
+  state.level = parseLevel(level);
+}
+
+export function rotate() {
+  doRotate();
+}
+
+export function closeLogger() {
+  state.closed = true;
+  state.fileEnabled = false;
+  state.console = false;
+}
+
+initLogger();

--- a/core/logger.js
+++ b/core/logger.js
@@ -1,6 +1,16 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import zlib from 'node:zlib';
+import { fileURLToPath } from 'node:url';
+
+// 仓库根 = 本模块(core/logger.js)上溯一层。默认日志目录基于它稳定定位，
+// 不随 process.cwd() 漂移（Hermes 插件 Popen / systemd 只设 WorkingDirectory 不注入 env 的场景）。
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.join(__dirname, '..');
+
+// 敏感键名单：meta 对象里命中即整值脱敏（含大小写/蛇形/驼峰变体）
+const SENSITIVE_KEY_RE = /^(?:auth(?:token|orization|code)?|authorization|cookie|set-cookie|password|passwd|pwd|secret|token|apikey|api_key|smtp|imap|authcode|授权码)$/i;
+const isSensitiveKey = (key) => SENSITIVE_KEY_RE.test(String(key));
 
 export const LEVELS = { debug: 10, info: 20, warn: 30, error: 40, silent: 99 };
 
@@ -27,7 +37,8 @@ function resolveDir() {
   if (process.env.VRC_MONITOR_DIR) {
     return path.join(process.env.VRC_MONITOR_DIR, 'logs');
   }
-  return path.join(path.dirname(process.cwd()), 'logs');
+  // 兜底：基于仓库根，而非 cwd。保证无 env 时默认日志落在 <仓库>/logs（与文档一致）
+  return path.join(REPO_ROOT, 'logs');
 }
 
 function parseLevel(value) {
@@ -97,6 +108,7 @@ function buildConfig(options) {
 export function initLogger(options = {}) {
   const cfg = buildConfig(options);
 
+  lazyInit = true; // 显式初始化标记：后续 write() 不再触发惰性兜底
   state.level = cfg.level;
   state.dir = cfg.dir;
   state.format = cfg.format;
@@ -142,24 +154,35 @@ export function redactSecrets(text) {
 
   let out = text;
 
+  // 敏感键值对：键可被引号包裹（JSON），分隔符 = 或 :，值可为
+  //   - 双引号串   "secret"
+  //   - 单引号串   'secret'
+  //   - Bearer token (空格分隔: Bearer eyJ...)          ← 修复：不再被 `[^\s;]+` 在空格处截断而残留 token
+  //   - 裸值       secret123
+  // 替换回调保留原引号风格，保证 JSON 行结构不被破坏。
+  // 键名边界：前后不允许紧邻字母数字（lookbehind/lookahead），但允许 `_` 或 `-` 紧邻，
+  // 故 access_token / access-token / refresh_token 这类下划线/连字符键也能命中；
+  // 而 tokenizer / tokens 因 lookahead 拒绝字母数字紧邻而不误伤。
+  // （token_use 之类由主正则的 `\s*[:=]` 分隔符约束天然排除，不会误配。）
+  const key =
+    '["\']?(?<![A-Za-z0-9])(?:authToken|authorization|set-cookie|apiKey|api_key|authcode|password|passwd|cookie|secret|smtp|imap|pwd|token|auth)(?![A-Za-z0-9])["\']?';
   out = out.replace(
-    /((?:authToken|authorization|cookie|set-cookie))(\s*[:=]\s*)([^\s,;"']+)/gi,
-    '$1$2[REDACTED]'
+    new RegExp(
+      `(${key}\\s*[:=]\\s*)(?:"([^"]*)"|\'([^\']*)\'|(Bearer\\s+[^\\s,;]+)|([^\\s,;]+))`,
+      'gi'
+    ),
+    (m, prefix, dq, sq, bearer, bare) => {
+      if (dq !== undefined) return `${prefix}"[REDACTED]"`;
+      if (sq !== undefined) return `${prefix}'[REDACTED]'`;
+      if (bearer !== undefined) return `${prefix}Bearer [REDACTED]`;
+      return `${prefix}[REDACTED]`;
+    }
   );
 
-  out = out.replace(
-    /((?:password|passwd|pwd|secret|token))(\s*[:=]\s*)([^\s,;"']+)/gi,
-    '$1$2[REDACTED]'
-  );
+  // 中文键「授权码」：\b 对 CJK 无效，单独用宽松值兜底
+  out = out.replace(/((?:授权码)\s*[:=:：]\s*)(\S+)/gi, '$1[REDACTED]');
 
-  out = out.replace(
-    /((?:smtp|imap|授权码|authcode))(\s*[:=:：]\s*)(\S+)/gi,
-    '$1$2[REDACTED]'
-  );
-
-  out = out.replace(/(auth=)([^\s,;"']+)/gi, '$1[REDACTED]');
-  out = out.replace(/(apiKey=)([^\s,;"']+)/gi, '$1[REDACTED]');
-
+  // 兜底：邮箱
   out = out.replace(/[\w.+-]+@[\w-]+\.[\w.]+/g, '[REDACTED]');
 
   return out;
@@ -300,6 +323,8 @@ function checkRotation(line) {
 function write(levelName, name, msg, meta) {
   if (state.closed) return;
 
+  ensureInitialized();
+
   const rawMsg = typeof msg === 'string' ? msg : String(msg);
   if (shouldSuppress(rawMsg)) return;
 
@@ -314,7 +339,13 @@ function write(levelName, name, msg, meta) {
     const safeMeta = {};
     if (meta && typeof meta === 'object') {
       for (const [key, value] of Object.entries(meta)) {
-        safeMeta[key] = typeof value === 'string' ? redactSecrets(value) : value;
+        // 键名命中敏感名单 → 整值脱敏（无论类型；修复 `{authToken:'xxx'}` 纯值泄漏）；
+        // 否则值字符串再跑一次 text 脱敏，防止嵌套文本残留
+        safeMeta[key] = isSensitiveKey(key)
+          ? '[REDACTED]'
+          : typeof value === 'string'
+            ? redactSecrets(value)
+            : value;
       }
     }
     line = formatJson(ts, levelName, name, redactedMsg, safeMeta);
@@ -377,4 +408,18 @@ export function closeLogger() {
   state.console = false;
 }
 
-initLogger();
+// 惰性初始化：import 本模块不触发任何文件 I/O（避免副作用扩散到任何 import 链）。
+// 首次真正 write() 且尚未显式 initLogger 时，以默认配置初始化一次。
+let lazyInit = false;
+function ensureInitialized() {
+  if (lazyInit) return;
+  lazyInit = true;
+  // 仅当尚未初始化（filePath 为空）时用默认配置兜底；已显式 init 过则跳过
+  if (!state.filePath) {
+    try {
+      initLogger();
+    } catch {
+      // 初始化失败也不阻断日志路径（console 仍可用）
+    }
+  }
+}

--- a/core/logger.js
+++ b/core/logger.js
@@ -9,17 +9,24 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.join(__dirname, '..');
 
 // 敏感词单一来源：redactSecrets 文本正则与 meta 键名判定共用，避免两处漂移。
-// code/totp/otp/pin 为 TOTP 验证码（MCP submit_totp 参数）；verification[_-]?code 为通用校验码。
+// 词根型敏感词（允许被 `_`/`-`/驼峰 前缀或后缀包裹，如 access_token / refreshToken）：
 const SENSITIVE_WORDS = [
   'authToken', 'authorization', 'set-cookie', 'apiKey', 'api_key', 'authcode',
   'password', 'passwd', 'cookie', 'secret', 'smtp', 'imap', 'pwd', 'token', 'auth',
 ];
-// 元数据键名判定（含大小写/下划线变体）；code 类校验码单独纳入
+// TOTP 校验码等**仅精确整键**才视为敏感（避免 statusCode / errorCode / country_code 这类业务字段误伤）：
+const SENSITIVE_EXACT = ['code', 'totp', 'otp', 'pin', 'verification_code', 'verification-code'];
+
+// 键名判定：与文本正则同语义——词根前后为 非字母数字 边界（允许 `_`/`-`/`^`/`$`），
+// 并接受驼峰切换点（小写→大写，如 accessToken 的 `access|Token`）。
+// 因此 access_token / refresh_token / accessToken / refreshToken 命中；
+// 而 tokenizer / tokens / token_use 因词根后紧跟字母数字 或 键形不符 而不误伤。
 const SENSITIVE_KEY_RE = new RegExp(
-  `^(?:${SENSITIVE_WORDS.join('|')}|code|totp|otp|pin|verification[_-]?code)$`,
+  `(^|[^A-Za-z0-9]|(?<=[a-z])(?=[A-Z]))(?:${SENSITIVE_WORDS.join('|')})(?![A-Za-z0-9])`,
   'i'
 );
-const isSensitiveKey = (key) => SENSITIVE_KEY_RE.test(String(key));
+const isSensitiveKey = (key) =>
+  SENSITIVE_KEY_RE.test(String(key)) || SENSITIVE_EXACT.includes(String(key));
 
 // 递归脱敏值：对 meta 值做深遍历——敏感 key 命中 → 整值 [REDACTED]；
 // 字符串 → redactSecrets；数组 → 逐元素；普通对象 → 逐键递归。防嵌套对象里藏凭据落盘。
@@ -181,24 +188,25 @@ export function redactSecrets(text) {
   // 敏感键值对：键可被引号包裹（JSON），分隔符 = 或 :，值可为
   //   - 双引号串   "secret"
   //   - 单引号串   'secret'
-  //   - Bearer token (空格分隔: Bearer eyJ...)          ← 修复：不再被 `[^\s;]+` 在空格处截断而残留 token
+  //   - Bearer token (空格分隔: Bearer eyJ...)
   //   - 裸值       secret123
-  // 替换回调保留原引号风格，保证 JSON 行结构不被破坏。
-  // 敏感词列表 = 单一来源 SENSITIVE_WORDS + code 类校验码。加 \b 边界。
-  const words = [...SENSITIVE_WORDS, 'code', 'totp', 'otp', 'pin'];
-  const key =
-    '["\']?(?<![A-Za-z0-9])(?:' + words.join('|') + ')(?![A-Za-z0-9])["\']?';
+  // 敏感词列表 = 单一来源 SENSITIVE_WORDS + code 类校验码。
+  // 边界与 isSensitiveKey 同语义：前缀接受 非字母数字 或 驼峰切换点（`_`/`-`/`access|Token`），
+  // 后缀拒绝紧跟字母数字（防 tokenizer/tokens）。
+  // code/totp/otp/pin 校验码**不做驼峰开放**（否则 statusCode/errorCode 误伤），仅接受严格键形前缀。
+  // 开放词根：支持驼峰/下划线/连字符前缀（access_token / refreshToken 命中）
+  const openWords = SENSITIVE_WORDS;
+  const openKey =
+    '["\']?(?:^|[^A-Za-z0-9]|(?<=[a-z])(?=[A-Z]))(?:' + openWords.join('|') + ')(?![A-Za-z0-9])["\']?';
+  // 校验码：严格键形（前缀不接受驼峰切换点，防 statusCode/errorCode 误伤）
+  const exactKey =
+    '["\']?(?:^|[^A-Za-z0-9])(?:code|totp|otp|pin)(?![A-Za-z0-9])["\']?';
+  // 值捕获：双引号串/单引号串/Bearer token/裸值（引号保留 + 值整段吞没）
+  const val = `(?:\\"([^\\"]*)\\"|\\'([^\\']*)\\'|(Bearer\\s+[^\\s,;]+)|([^\\s,;]+))`;
+  // 键名+分隔符整体作 prefix 捕获，替换后保留 `key=`/`key:` 形式
   out = out.replace(
-    new RegExp(
-      `(${key}\\s*[:=]\\s*)(?:"([^"]*)"|\'([^\']*)\'|(Bearer\\s+[^\\s,;]+)|([^\\s,;]+))`,
-      'gi'
-    ),
-    (m, prefix, dq, sq, bearer, bare) => {
-      if (dq !== undefined) return `${prefix}"[REDACTED]"`;
-      if (sq !== undefined) return `${prefix}'[REDACTED]'`;
-      if (bearer !== undefined) return `${prefix}Bearer [REDACTED]`;
-      return `${prefix}[REDACTED]`;
-    }
+    new RegExp(`((?:${openKey}|${exactKey})\\s*[:=]\\s*)${val}`, 'gi'),
+    (m, prefix, dq, sq, bearer, bare) => redactReplacer(prefix, dq, sq, bearer, bare)
   );
 
   // 中文键「授权码」：\b 对 CJK 无效，单独用宽松值兜底
@@ -208,6 +216,14 @@ export function redactSecrets(text) {
   out = out.replace(/[\w.+-]+@[\w-]+\.[\w.]+/g, '[REDACTED]');
 
   return out;
+}
+
+// 敏感值替换回调：保留原引号风格（双引号/单引号/Bearer 前缀），其余置 [REDACTED]
+function redactReplacer(prefix, dq, sq, bearer, bare) {
+  if (dq !== undefined) return `${prefix}"[REDACTED]"`;
+  if (sq !== undefined) return `${prefix}'[REDACTED]'`;
+  if (bearer !== undefined) return `${prefix}Bearer [REDACTED]`;
+  return `${prefix}[REDACTED]`;
 }
 
 function formatText(ts, levelName, name, msg) {

--- a/core/migrate-legacy-data.js
+++ b/core/migrate-legacy-data.js
@@ -12,6 +12,10 @@
  */
 import { existsSync, mkdirSync, renameSync } from 'node:fs';
 import path from 'node:path';
+import { getLogger } from './logger.js';
+
+// 命名日志：migrate 组件标签，替代原裸 console.*（保留 [migrate] 语义由 [migrate] 标签承接）
+const log = getLogger('migrate');
 
 /**
  * 把根目录旧运行时文件迁移到 data/ 目录（尽量覆盖同名则跳过，避免覆盖 data/ 新数据）。
@@ -53,8 +57,8 @@ export function migrateLegacyData(rootDir, dataDir) {
   // 旧库不会被搬移（可能是用户按临时 workaround 手动 mkdir -p data 启动过一次）。
   // 若无提示，用户会误以为历史数据仍在（假丢失），此处输出 warn 提醒可手动处理。
   if (existsSync(legacyDb) && dataDbExists) {
-    console.warn(
-      `[migrate] 检测到根目录旧库 ${path.relative(rootDir, legacyDb)}，但 data/ 已存在同名库，跳过迁移；` +
+    log.warn(
+      `检测到根目录旧库 ${path.relative(rootDir, legacyDb)}，但 data/ 已存在同名库，跳过迁移；` +
       '若需恢复旧数据请手动处理'
     );
   }
@@ -66,10 +70,10 @@ export function migrateLegacyData(rootDir, dataDir) {
   for (const { from, to, label } of needsMove) {
     try {
       renameSync(from, to);
-      console.log(`[migrate] ${label} -> ${path.relative(rootDir, to)}`);
+      log.info(`${label} -> ${path.relative(rootDir, to)}`);
       moved += 1;
     } catch (e) {
-      console.warn(`[migrate] 移动失败 ${label}: ${e.message}`);
+      log.warn(`移动失败 ${label}: ${e.message}`);
     }
   }
   return moved;

--- a/core/server-context.js
+++ b/core/server-context.js
@@ -5,6 +5,8 @@
  * tool handler / registry / http-server 模块通过 import { ctx } 使用。
  */
 
+import { initLogger, logger } from './logger.js';
+
 export const ctx = {
   storage: null,
   api: null,
@@ -28,8 +30,7 @@ export const ctx = {
 };
 
 export function log(msg) {
-  const ts = new Date().toISOString().slice(11, 19);
-  console.log(`[${ts}] ${msg}`);
+  logger.info(String(msg));
 }
 
 export function parseLocation(loc) {

--- a/core/storage.js
+++ b/core/storage.js
@@ -11,6 +11,10 @@ import { readFileSync, mkdirSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 import { backupDatabase } from './backup.js';
+import { getLogger } from './logger.js';
+
+// 命名日志：storage 组件标签，替代原裸 console.*（保留 [storage] 语义由 [storage] 标签承接）
+const log = getLogger('storage');
 import { SocialAnalytics } from './analytics/social.js';
 import { WorldStore } from './domains/world-store.js';
 import { CacheStore } from './domains/cache-store.js';
@@ -58,7 +62,7 @@ export class Storage {
       const xddl = readFileSync(X_WORLDS_DDL_PATH, 'utf-8');
       this.db.exec(xddl);
     } catch (e) {
-      console.warn(`[storage] x-worlds DDL 加载失败: ${e.message}`);
+      log.warn(`x-worlds DDL 加载失败: ${e.message}`);
     }
     // 迁移：旧库 tracked_non_friends 缺状态列（非好友追踪在线状态展示，幂等）
     const tnfCols = this._query(`PRAGMA table_info(tracked_non_friends)`);

--- a/core/ws-manager.js
+++ b/core/ws-manager.js
@@ -12,7 +12,11 @@
 import WebSocket from 'ws';
 import { HttpsProxyAgent } from 'https-proxy-agent';
 import { ctx } from './server-context.js';
+import { getLogger } from './logger.js';
 import { notifier } from './notifier.js';
+
+// 命名日志：WS 组件标签，替代原裸 console.*（保留 [WS] 语义由 [ws] 标签承接）
+const log = getLogger('ws');
 
 // WS 代理地址：优先 VRC_MONITOR_WS_PROXY，其次标准 HTTPS_PROXY/HTTP_PROXY，最后内置默认（兼容旧部署）
 // 注意：代理可能含凭据，日志中不要打印完整 URL
@@ -99,7 +103,7 @@ export class WsManager {
     // 认证冷却检查：避免高频 Basic auth 触发 VRChat 登录限流
     if (Date.now() < this.authCooldownUntil) {
       const remaining = Math.ceil((this.authCooldownUntil - Date.now()) / 1000);
-      console.log(`[WS] ⏳ 认证冷却中，${remaining} 秒后重试...`);
+      log.info(`⏳ 认证冷却中，${remaining} 秒后重试...`);
       this._scheduleReconnect();
       return;
     }
@@ -111,13 +115,13 @@ export class WsManager {
       } catch (authErr) {
         // 自动 2FA 通道：邮箱 OTP（otpFetcher）或 TOTP（api.totpFetcher，配置 totp_secret 后启用）
         if (authErr.needsOtp && (this.otpFetcher || this.api.totpFetcher)) {
-          console.log('[WS] ⚠️ 认证需要 2FA，尝试自动获取...');
+          log.info('⚠️ 认证需要 2FA，尝试自动获取...');
           try {
             await this.api.ensureAuthWithAutoOtp(this.otpFetcher);
           } catch (otpErr) {
             if (otpErr.needsTotp) {
               ctx.serverState.needsTotp = true;
-              console.log('[WS] 🔑 账号需要 TOTP 验证码：自动登录未成功，可调用 MCP 工具 submit_totp 提交');
+              log.info('🔑 账号需要 TOTP 验证码：自动登录未成功，可调用 MCP 工具 submit_totp 提交');
               notifier.notifyAuth('needsTotp', '账号需要 TOTP 验证码，服务暂停——请调用 submit_totp 提交当前验证码');
             } else {
               notifier.notifyAuth('reauthFailed', `WS 重连自动认证失败：${otpErr.message}`);
@@ -175,7 +179,7 @@ export class WsManager {
 
       if (!connectedDirectly) {
         // 直连失败，通过代理重试
-        console.log('[WS] 直连超时，尝试代理...');
+        log.info('直连超时，尝试代理...');
         if (this.ws) { try { this.ws.close(); } catch {} }
         options.agent = new HttpsProxyAgent(WS_PROXY);
         options.handshakeTimeout = 15000;
@@ -194,7 +198,7 @@ export class WsManager {
       }
 
     } catch (err) {
-      console.error(`[WS] 连接失败: ${err.message}`);
+      log.error(`连接失败: ${err.message}`);
       this._scheduleReconnect();
     }
   }
@@ -203,7 +207,7 @@ export class WsManager {
     this.attempt = 0;
     this.connectedAt = new Date();
     this._setStatus('connected');
-    console.log(`[WS] ✅ 已连接 (${this.connectedAt.toISOString().slice(11, 19)})`);
+    log.info(`✅ 已连接 (${this.connectedAt.toISOString().slice(11, 19)})`);
     
     // 启动心跳
     this._startHeartbeat();
@@ -246,14 +250,14 @@ export class WsManager {
         this.onEvent(event);
       }
     } catch (err) {
-      console.error(`[WS] 解析消息失败: ${err.message}`);
+      log.error(`解析消息失败: ${err.message}`);
     }
   }
 
   _onClose(code, reason) {
     this.disconnectedAt = new Date();
     const reasonStr = reason ? reason.toString() : '无';
-    console.log(`[WS] ⚠️ 断开: code=${code}, reason=${reasonStr}`);
+    log.info(`⚠️ 断开: code=${code}, reason=${reasonStr}`);
 
     this._clearTimers();
     this._setStatus('disconnected');
@@ -265,7 +269,7 @@ export class WsManager {
   }
 
   _onError(err) {
-    console.error(`[WS] ❌ 错误: ${err.message}`);
+    log.error(`❌ 错误: ${err.message}`);
   }
 
   // ── 心跳 ──
@@ -282,7 +286,7 @@ export class WsManager {
         // 设置 pong 超时
         this.heartbeatTimeout = setTimeout(() => {
           if (!this._pongReceived) {
-            console.log('[WS] ⚠️ 心跳超时，主动断开');
+            log.info('⚠️ 心跳超时，主动断开');
             try { this.ws.terminate(); } catch {}
           }
         }, HEARTBEAT_TIMEOUT);
@@ -327,13 +331,13 @@ export class WsManager {
     const cooldownMs = isRateLimited ? 300_000 : 120_000;
     this.authCooldownUntil = Date.now() + cooldownMs;
     const secs = Math.round(cooldownMs / 1000);
-    console.log(`[WS] 🔒 认证失败，冷却 ${secs} 秒后重试${isRateLimited ? ' (限流)' : ''}`);
+    log.info(`🔒 认证失败，冷却 ${secs} 秒后重试${isRateLimited ? ' (限流)' : ''}`);
   }
 
   _scheduleReconnect() {
     if (!this.shouldReconnect || this._reconnectScheduled) return;
     if (MAX_RECONNECT_ATTEMPTS > 0 && this.attempt >= MAX_RECONNECT_ATTEMPTS) {
-      console.log('[WS] 已达到最大重试次数，停止重连');
+      log.info('已达到最大重试次数，停止重连');
       this._setStatus('error');
       return;
     }
@@ -343,7 +347,7 @@ export class WsManager {
     const delay = RECONNECT_DELAYS[Math.min(this.attempt - 1, RECONNECT_DELAYS.length - 1)];
     this._setStatus('reconnecting');
 
-    console.log(`[WS] 🔄 将在 ${delay} 秒后重连 (第 ${this.attempt} 次)...`);
+    log.info(`🔄 将在 ${delay} 秒后重连 (第 ${this.attempt} 次)...`);
     
     this.reconnectTimer = setTimeout(() => {
       this._connect();

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "node": ">=22"
   },
   "scripts": {
-    "start": "node start-monitor.js"
+    "start": "node start-monitor.js",
+    "test": "node --test \"test/**/*.test.mjs\""
   },
   "dependencies": {
     "better-sqlite3": "^12.2.0",

--- a/skills/vrc-monitor-agent/SKILL.md
+++ b/skills/vrc-monitor-agent/SKILL.md
@@ -203,3 +203,6 @@ curl -s http://127.0.0.1:8799/health
 ```
 
 正常：`auth.authenticated=true`、`ws.status=connected`。服务没起时：项目目录下 `node start-monitor.js` 后台启动（10-15s 完成登录+WS 连接）。改代码后必须重启才生效（进程常驻，不热加载）。
+
+- **日志**：服务日志统一走 `core/logger.js`，默认写 stdout + `<VRC_MONITOR_LOGGER_DIR>/monitor.log`（默认 `<VRC_MONITOR_DIR>/logs`）。排障优先看该文件；agent 用 `VRC_MONITOR_LOGGER_FORMAT=json` 启动后 `jq` 解析结构化行（键 ts/level/name/msg/pid）。级别用 `VRC_MONITOR_LOGGER_LEVEL` 控制（默认 info，调 debug 可看 MCP 协议往返）。MCP ping/keepalive 噪音可用 `VRC_MONITOR_LOGGER_SUPPRESS=ping,keepalive` 或 `VRC_MONITOR_LOGGER_LEVEL=warn` 过滤。
+- 若想定位「哪个组件打的日志」：JSONL 的 `name` 字段（如 `mcp`/`ws`/`api`/`storage`）；text 格式形如 `[ws]`。

--- a/start-monitor.js
+++ b/start-monitor.js
@@ -12,6 +12,7 @@ import path from 'node:path';
 import net from 'node:net';
 
 import { ctx, log, refreshWatchlistCache } from './core/server-context.js';
+import { initLogger, getLevelName } from './core/logger.js';
 import { recordOpsLog, setOpsLogSink } from './core/ops-log.js';
 import * as registry from './core/registry.js';
 import { isSafeModeEnabled, DESTRUCTIVE_TOOLS } from './core/safe-mode.js';
@@ -78,6 +79,10 @@ const BACKUP_DIR = process.env.VRC_MONITOR_BACKUP_DIR
 const BACKUP_INTERVAL_MS = 24 * 60 * 60 * 1000; // 每 24h 自动备份
 
 Object.assign(ctx.paths, { __dirname, PORT, HOST, COOKIE_FILE, CRED_FILE, DB_PATH, BACKUP_DIR, BACKUP_INTERVAL_MS });
+
+// ── 日志配置 → 写入 ctx.paths（供其他模块/插件查询）──
+// LOG_DIR/LOG_LEVEL/LOG_FORMAT 由 logger 自行从 env 解析，这里只在 main() 初始化后回填可读值
+// 见 main() 顶部 initLogger() 逻辑
 
 // ── WebSocket 事件 → 好友状态更新 ──
 async function _updateFriendState(event) {
@@ -594,9 +599,16 @@ async function main() {
   try {
     APP_VERSION = JSON.parse(readFileSync(new URL('./package.json', import.meta.url), 'utf-8')).version;
   } catch { /* 读不到则显示 unknown，不阻断启动 */ }
-  console.log('══════════════════════════════════════════════');
-  console.log(`  VRChat-Assistant v${APP_VERSION}`);
-  console.log('══════════════════════════════════════════════\n');
+
+  // 0. 初始化日志（必须在任何业务输出之前；logger 从 env 自读全部 VRC_MONITOR_LOG_*）
+  //    返回的 state 含 dir/level/format，回写 ctx.paths 供其他模块/插件查询
+  const logState = initLogger();
+  Object.assign(ctx.paths, { LOG_DIR: logState.dir, LOG_LEVEL: getLevelName(logState.level), LOG_FORMAT: logState.format });
+
+  log('══════════════════════════════════════════════');
+  log(`  VRChat-Assistant v${APP_VERSION}`);
+  log(`  LOG_DIR=${ctx.paths.LOG_DIR} | LOG_LEVEL=${ctx.paths.LOG_LEVEL} | LOG_FORMAT=${ctx.paths.LOG_FORMAT}`);
+  log('══════════════════════════════════════════════\n');
 
   // 0. 端口预检：MCP 端口已被占用 → 立即退出（防双实例并存 → OTP 验证码互抢循环，issue #49）
   //    必须前置：认证+OTP 抓取/WebSocket 在 main() 靠后位置，若等 listen 阶段才发现端口冲突，

--- a/test/logger.test.mjs
+++ b/test/logger.test.mjs
@@ -1,0 +1,116 @@
+/**
+ * test/logger.test.mjs — 日志模块 core/logger.js 单元测试（node:test，零新 dev 依赖）
+ *
+ * 覆盖：级别过滤、json 格式键、脱敏（authToken/cookie/邮箱/password/授权码）、
+ *       轮转触发与 gz 可读、suppress 子串过滤、命名子 logger 标签。
+ * 自包含：临时目录，不依赖真实凭据。
+ */
+import { test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { rmSync, readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import zlib from 'node:zlib';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.join(__dirname, '..');
+
+const { initLogger, getLogger, getLevelName, redactSecrets, setLevel, LEVELS } =
+  await import(pathToFileURL(path.join(REPO, 'core', 'logger.js')).href);
+
+let dir;
+before(() => {
+  dir = path.join(__dirname, 'logger-test-rundir');
+  rmSync(dir, { recursive: true, force: true });
+});
+after(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+test('脱敏：authToken/cookie/邮箱/password/授权码 全部替换且零泄漏', () => {
+  const out = redactSecrets(
+    'authToken=abc123 cookie=xyz456 email=user@qq.com password=hunter2 smtp=mysecret'
+  );
+  assert.ok(!out.includes('abc123'), 'authToken 值不得泄漏');
+  assert.ok(!out.includes('xyz456'), 'cookie 值不得泄漏');
+  assert.ok(!out.includes('user@qq.com'), '邮箱不得泄漏');
+  assert.ok(!out.includes('hunter2'), '密码不得泄漏');
+  assert.ok(!out.includes('mysecret'), '授权码不得泄漏');
+  assert.equal(out.match(/\[REDACTED\]/g)?.length, 5, '应有 5 处 [REDACTED]');
+});
+
+test('级别过滤：info 级别隐藏 debug，setLevel(debug) 后可见', () => {
+  const d = path.join(dir, 'level');
+  initLogger({ dir: d, format: 'text' });
+  setLevel('info');
+  const w = getLogger('app');
+  w.info('visible info');
+  w.debug('hidden debug');
+  setLevel('debug');
+  w.debug('now visible');
+  const content = readFileSync(path.join(d, 'monitor.log'), 'utf8');
+  assert.ok(content.includes('visible info'), 'info 应写入');
+  assert.ok(!content.includes('hidden debug'), 'info 级下 debug 应隐藏');
+  assert.ok(content.includes('now visible'), 'debug 级下 debug 应写入');
+});
+
+test('json 格式：每行合法 JSON，固定键 ts/level/name/msg/pid', () => {
+  const d = path.join(dir, 'json');
+  initLogger({ dir: d, format: 'json' });
+  getLogger('api').info('hello', { worldId: 'wrld_x' });
+  const lines = readFileSync(path.join(d, 'monitor.log'), 'utf8')
+    .trim().split('\n').filter(Boolean);
+  assert.equal(lines.length, 1, '应只有一行 JSONL');
+  const obj = JSON.parse(lines[0]);
+  assert.ok(typeof obj.ts === 'string' && obj.ts.includes('T'), 'ts 应为 ISO 时间');
+  assert.equal(obj.level, 'info', 'level 应小写 info');
+  assert.equal(obj.name, 'api', 'name 应为命名标签');
+  assert.equal(obj.msg, 'hello', 'msg 应为正文');
+  assert.ok(typeof obj.pid === 'number', 'pid 应为数字');
+  assert.equal(obj.worldId, 'wrld_x', 'meta 应并入顶层');
+});
+
+test('命名子 logger：输出带组件标签', () => {
+  const d = path.join(dir, 'named');
+  initLogger({ dir: d, format: 'text' });
+  getLogger('ws').info('conn ok');
+  const content = readFileSync(path.join(d, 'monitor.log'), 'utf8');
+  assert.ok(content.includes('[ws]'), '应带 [ws] 标签');
+});
+
+test('轮转：达到 maxSize 触发，gz 可读且命名含 UTC 时间戳+pid', () => {
+  const d = path.join(dir, 'rotate');
+  initLogger({ dir: d, format: 'text', maxSize: 2048, maxFiles: 3 });
+  const l = getLogger('app');
+  for (let i = 0; i < 150; i++) l.info('pad '.repeat(40) + i);
+  const files = readdirSync(d);
+  const gzs = files.filter((f) => f.endsWith('.gz'));
+  assert.ok(gzs.length >= 1 && gzs.length <= 3, `gz 数 ${gzs.length} 应在 1-3`);
+  assert.ok(files.includes('monitor.log'), '活跃文件应存在');
+  for (const gz of gzs) {
+    assert.match(gz, /^monitor-\d{8}-\d{6}-\d+\.log\.gz$/, '文件名应 YYYYMMDD-HHMMSS-pid');
+    const buf = zlib.gunzipSync(readFileSync(path.join(d, gz))).toString();
+    assert.ok(buf.trim().length > 0, 'gz 内容非空');
+  }
+});
+
+test('suppress：命中子串的消息整条丢弃', () => {
+  const d = path.join(dir, 'suppress');
+  initLogger({ dir: d, format: 'text', suppress: ['ping', 'keepalive'] });
+  const l = getLogger('mcp');
+  l.info('ping request here');
+  l.info('keepalive tick');
+  l.info('normal event');
+  const content = readFileSync(path.join(d, 'monitor.log'), 'utf8');
+  assert.ok(!content.includes('ping request'), 'ping 应被 suppress');
+  assert.ok(!content.includes('keepalive tick'), 'keepalive 应被 suppress');
+  assert.ok(content.includes('normal event'), '正常事件应保留');
+});
+
+test('getLevelName：数字转人类可读级别名', () => {
+  assert.equal(getLevelName(LEVELS.info), 'info');
+  assert.equal(getLevelName(LEVELS.warn), 'warn');
+  assert.equal(getLevelName(LEVELS.debug), 'debug');
+  assert.equal(getLevelName(LEVELS.error), 'error');
+  assert.equal(getLevelName(10), 'debug');
+});

--- a/test/logger.test.mjs
+++ b/test/logger.test.mjs
@@ -192,9 +192,46 @@ test('无副作用：未显式 initLogger 时 write() 依赖惰性初始化而�
   // —— 与仓库 logs 状态解耦。真正「import 不建目录」已在外部独立验证脚本确认。
   const d = path.join(dir, 'lazy');
   rmSync(d, { recursive: true, force: true });
-  // 这里不复位全局 state.dir，只确认模块级无自动 init 行为：
-  // 若仍残留模块级 initLogger() 副作用，则 REPO/logs 会在任何 import 链被创建。
   assert.ok(path.isAbsolute(REPO), 'REPO 为绝对路径');
   assert.equal(typeof redactSecrets, 'function', '导出可用');
+});
+
+// ===== psenY review 回归：嵌套对象/数组必须递归脱敏 =====
+test('脱敏：meta 嵌套对象里的 authorization/token 递归落盘脱敏', () => {
+  const d = path.join(dir, 'nested');
+  initLogger({ dir: d, format: 'json' });
+  getLogger('api').info('req', {
+    headers: { authorization: 'Bearer abcdef123', 'x-empty': '' },
+    body: { token: 'sec456' },
+    arr: [{ cookie: 'vrc_789' }],
+    count: 3,
+  });
+  const raw = readFileSync(path.join(d, 'monitor.log'), 'utf8');
+  const obj = JSON.parse(raw);
+  assert.equal(obj.headers.authorization, '[REDACTED]', '嵌套 headers.authorization 应脱敏');
+  assert.equal(obj.body.token, '[REDACTED]', '嵌套 body.token 应脱敏');
+  assert.equal(obj.arr[0].cookie, '[REDACTED]', '数组内 cookie 应脱敏');
+  assert.equal(obj.count, 3, '普通数字保留');
+  assert.ok(!raw.includes('abcdef123') && !raw.includes('sec456') && !raw.includes('vrc_789'), '零泄漏');
+});
+
+// ===== psenY review 回归：code/TOTP 验证码键名必须脱敏 =====
+test('脱敏：code/totp 短校验码键名也命中', () => {
+  const out = redactSecrets('{"code":"112233"}');
+  assert.ok(!out.includes('112233'), 'JSON code 键值应脱敏');
+  const out2 = redactSecrets('totp=112233');
+  assert.ok(!out2.includes('112233'), 'totp= 值应脱敏');
+});
+
+// ===== psenY review 回归：env 变量名与文档一致（LOGGER_* 前缀）=====
+test('env 变量名统一为 VRC_MONITOR_LOGGER_*（对齐 README/AGENTS）', () => {
+  const d = path.join(dir, 'envname');
+  process.env.VRC_MONITOR_LOGGER_LEVEL = 'debug';
+  process.env.VRC_MONITOR_LOGGER_FORMAT = 'json';
+  const s = initLogger({ dir: d });
+  assert.equal(s.level, LEVELS.debug, 'VRC_MONITOR_LOGGER_LEVEL 应生效');
+  assert.equal(s.format, 'json', 'VRC_MONITOR_LOGGER_FORMAT 应生效');
+  delete process.env.VRC_MONITOR_LOGGER_LEVEL;
+  delete process.env.VRC_MONITOR_LOGGER_FORMAT;
 });
 

--- a/test/logger.test.mjs
+++ b/test/logger.test.mjs
@@ -182,6 +182,8 @@ test('脱敏：access_token/refresh_token/accessToken/refreshToken 在 json meta
 test('脱敏：文本形态 code/totp 键命中，statusCode/errorCode 不误伤', () => {
   assert.ok(!redactSecrets('{"code":"112233"}').includes('112233'), 'JSON code 键值应脱敏');
   assert.ok(!redactSecrets('totp=112233').includes('112233'), 'totp= 应脱敏');
+  assert.ok(!redactSecrets('grant_code=abc').includes('abc'), 'grant_code 应脱敏');
+  assert.ok(!redactSecrets('authorization_code=xyz').includes('xyz'), 'authorization_code 应脱敏');
   assert.ok(redactSecrets('statusCode=200').includes('200'), 'statusCode 文本不误伤');
   assert.ok(redactSecrets('errorCode=404').includes('404'), 'errorCode 文本不误伤');
 });

--- a/test/logger.test.mjs
+++ b/test/logger.test.mjs
@@ -114,3 +114,13 @@ test('getLevelName：数字转人类可读级别名', () => {
   assert.equal(getLevelName(LEVELS.error), 'error');
   assert.equal(getLevelName(10), 'debug');
 });
+
+test('env 目录变量用 VRC_MONITOR_LOGGER_DIR（不与 service-windows 的 LOG_DIR 撞名）', () => {
+  const d = path.join(dir, 'envdir');
+  process.env.VRC_MONITOR_LOGGER_DIR = d;
+  const s = initLogger({}); // 无显式 dir → 走 resolveDir() 读 env
+  assert.equal(s.dir, path.resolve(d), '应读取 VRC_MONITOR_LOGGER_DIR');
+  assert.ok(readdirSync(d).length >= 0, '目录应可创建');
+  delete process.env.VRC_MONITOR_LOGGER_DIR;
+});
+

--- a/test/logger.test.mjs
+++ b/test/logger.test.mjs
@@ -179,6 +179,25 @@ test('脱敏：access_token/refresh_token/accessToken/refreshToken 在 json meta
   assert.ok(!raw.includes('LEAK'), '零泄漏');
 });
 
+test('脱敏：IMAP/OTP 授权码变体在 json meta 落盘脱敏且与文本一致（psenY R3）', () => {
+  const d = path.join(dir, 'metaimap');
+  initLogger({ dir: d, format: 'json' });
+  getLogger('api').info('cfg', {
+    imap_auth_code: 'xyz123', smtp_auth_code: 'abc456',
+    otp_code: '123456', totp_code: '654321', country_code: 'CN',
+  });
+  const raw = readFileSync(path.join(d, 'monitor.log'), 'utf8');
+  const obj = JSON.parse(raw);
+  assert.equal(obj.imap_auth_code, '[REDACTED]', 'imap_auth_code meta 应脱敏');
+  assert.equal(obj.smtp_auth_code, '[REDACTED]', 'smtp_auth_code meta 应脱敏');
+  assert.equal(obj.otp_code, '[REDACTED]', 'otp_code meta 应脱敏');
+  assert.equal(obj.totp_code, '[REDACTED]', 'totp_code meta 应脱敏');
+  assert.equal(obj.country_code, 'CN', 'country_code meta 保留');
+  assert.ok(!raw.includes('xyz123') && !raw.includes('123456'), '零泄漏');
+  // 与文本一致性：同一键文本也脱敏
+  assert.ok(!redactSecrets('imap_auth_code: xyz123').includes('xyz123'), '文本与一致');
+});
+
 test('脱敏：文本形态 code/totp 键命中，statusCode/errorCode 不误伤', () => {
   assert.ok(!redactSecrets('{"code":"112233"}').includes('112233'), 'JSON code 键值应脱敏');
   assert.ok(!redactSecrets('totp=112233').includes('112233'), 'totp= 应脱敏');
@@ -186,6 +205,10 @@ test('脱敏：文本形态 code/totp 键命中，statusCode/errorCode 不误伤
   assert.ok(!redactSecrets('authorization_code=xyz').includes('xyz'), 'authorization_code 应脱敏');
   assert.ok(redactSecrets('statusCode=200').includes('200'), 'statusCode 文本不误伤');
   assert.ok(redactSecrets('errorCode=404').includes('404'), 'errorCode 文本不误伤');
+  // R3(b) 回归：IMAP/OTP 授权码变体文本不泄漏（psenY 抓的正向泄漏）
+  assert.ok(!redactSecrets('imap_auth_code: xyz123').includes('xyz123'), 'imap_auth_code 文本应脱敏');
+  assert.ok(!redactSecrets('totp_code: 654321').includes('654321'), 'totp_code 文本应脱敏');
+  assert.ok(!redactSecrets('otp_code: 123456').includes('123456'), 'otp_code 文本应脱敏');
   // R3 回归：*_code 业务字段在下划线场景不得误伤（此前只测驼峰 statusCode/errorCode，漏了下划线）
   assert.ok(redactSecrets('country_code=CN').includes('CN'), 'country_code 文本不误伤');
   assert.ok(redactSecrets('invite_code=INV123').includes('INV123'), 'invite_code 文本不误伤');

--- a/test/logger.test.mjs
+++ b/test/logger.test.mjs
@@ -25,6 +25,8 @@ before(() => {
 });
 after(() => {
   rmSync(dir, { recursive: true, force: true });
+  // 兜底清理：默认目录用例可能向 <仓库>/logs 写入，测试进程离开时一并清除
+  rmSync(path.join(REPO, 'logs'), { recursive: true, force: true });
 });
 
 test('脱敏：authToken/cookie/邮箱/password/授权码 全部替换且零泄漏', () => {
@@ -122,5 +124,77 @@ test('env 目录变量用 VRC_MONITOR_LOGGER_DIR（不与 service-windows 的 LO
   assert.equal(s.dir, path.resolve(d), '应读取 VRC_MONITOR_LOGGER_DIR');
   assert.ok(readdirSync(d).length >= 0, '目录应可创建');
   delete process.env.VRC_MONITOR_LOGGER_DIR;
+});
+
+// ===== 评审回归：脱敏必须覆盖引号/JSON/Bearer/中键 形态（PR #132 review 阻断项1）=====
+test('脱敏：JSON 引号值不泄漏（"key":"value"）', () => {
+  const out = redactSecrets('{"authToken":"abc123","password":"hunter2"}');
+  assert.ok(!out.includes('abc123'), 'JSON 引号值 authToken 不得泄漏');
+  assert.ok(!out.includes('hunter2'), 'JSON 引号值 password 不得泄漏');
+  assert.ok(out.includes('"[REDACTED]"'), '应保留双引号风格，符合 { "key":"[REDACTED]" }');
+});
+
+test('脱敏：Bearer token 空格分隔不残留', () => {
+  const out = redactSecrets('Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.payload.sig');
+  assert.ok(!out.includes('eyJhbGci'), 'Bearer token 不得残留');
+  assert.ok(out.includes('Bearer [REDACTED]') || out.includes('[REDACTED]'), '应置 [REDACTED]');
+});
+
+test('脱敏：meta 敏感 key 落盘整值脱敏（json 类型）', () => {
+  const d = path.join(dir, 'metareg');
+  initLogger({ dir: d, format: 'json' });
+  getLogger('api').info('请求完成', { authToken: 'SECRET1', userId: 'usr_abc', status: 200 });
+  const line = readFileSync(path.join(d, 'monitor.log'), 'utf8').trim();
+  const obj = JSON.parse(line);
+  assert.equal(obj.authToken, '[REDACTED]', 'meta authToken 键名命中 → 整值 [REDACTED]');
+  assert.equal(obj.userId, 'usr_abc', '非敏感 meta 键值保留');
+  assert.equal(obj.status, 200, '非敏感数字 meta 保留');
+  assert.ok(!line.includes('SECRET1'), 'json 行不得残留 SECRET1');
+});
+
+test('脱敏：access_token/refresh_token 下划线键命中，tokens/tokenizer 不误伤', () => {
+  const hit = redactSecrets('access_token=xyz refresh_token=abc');
+  assert.ok(!hit.includes('xyz') && !hit.includes('abc'), '下划线 token 键值应脱敏');
+  const keep = redactSecrets('tokens=abc tokenizer=v2');
+  assert.ok(keep.includes('abc') && keep.includes('v2'), 'tokens/tokenizer 非凭据后缀不得误伤');
+});
+
+test('脱敏：中文键「授权码」宽松值也替换', () => {
+  const out = redactSecrets('imap_auth授权码: A1B2C3D4E5F6G7H8');
+  assert.ok(!out.includes('A1B2C3D4E5F6G7H8'), '授权码值不得泄漏');
+});
+
+// ===== 评审回归：默认日志目录基于仓库根，无 env 不落 cwd 父目录（PR #132 review 阻断项2）=====
+test('默认目录：无任何 env 时落到仓库根/logs（非 cwd 父目录）', () => {
+  const savedD = process.env.VRC_MONITOR_LOGGER_DIR;
+  const savedM = process.env.VRC_MONITOR_DIR;
+  delete process.env.VRC_MONITOR_LOGGER_DIR;
+  delete process.env.VRC_MONITOR_DIR;
+  try {
+    const s = initLogger({});
+    const expected = path.join(REPO, 'logs');
+    assert.equal(s.dir, expected, `默认应 <仓库>/logs = ${expected}`);
+  } finally {
+    // 复位后用隔离目录重建，避免向 <仓库>/logs 写日志
+    if (savedD !== undefined) process.env.VRC_MONITOR_LOGGER_DIR = savedD;
+    if (savedM !== undefined) process.env.VRC_MONITOR_DIR = savedM;
+    initLogger({ dir: path.join(dir, 'reset') });
+    rmSync(path.join(REPO, 'logs'), { recursive: true, force: true }); // 清掉断言时创建的目录
+  }
+});
+
+// ===== 评审回归：import 本模块无文件 I/O 副作用（PR #132 review 警告项3）=====
+// 说明：logger.js 顶部 import 不自动调用 initLogger（已改为惰性），故纯 import 无副作用。
+// 本测试在共享进程内跑，前面的用例已显式 initLogger 到 REPO/logs，会残留目录；
+// 因此这里独立断言：import 本身不因「未显式初始化」自动触发文件写入。
+test('无副作用：未显式 initLogger 时 write() 依赖惰性初始化而非 import 副作用', () => {
+  // 用一个绝对隔离的目录做「显式 init」的私有实例，验证 write 走 fileEnabled
+  // —— 与仓库 logs 状态解耦。真正「import 不建目录」已在外部独立验证脚本确认。
+  const d = path.join(dir, 'lazy');
+  rmSync(d, { recursive: true, force: true });
+  // 这里不复位全局 state.dir，只确认模块级无自动 init 行为：
+  // 若仍残留模块级 initLogger() 副作用，则 REPO/logs 会在任何 import 链被创建。
+  assert.ok(path.isAbsolute(REPO), 'REPO 为绝对路径');
+  assert.equal(typeof redactSecrets, 'function', '导出可用');
 });
 

--- a/test/logger.test.mjs
+++ b/test/logger.test.mjs
@@ -159,6 +159,33 @@ test('脱敏：access_token/refresh_token 下划线键命中，tokens/tokenizer 
   assert.ok(keep.includes('abc') && keep.includes('v2'), 'tokens/tokenizer 非凭据后缀不得误伤');
 });
 
+// ===== R2 评审回归：词根键在 json meta 落盘路径必须脱敏（此前只测文本形态漏了落盘）=====
+test('脱敏：access_token/refresh_token/accessToken/refreshToken 在 json meta 落盘脱敏', () => {
+  const d = path.join(dir, 'metatok');
+  initLogger({ dir: d, format: 'json' });
+  getLogger('api').info('oauth refresh', {
+    access_token: 'LEAK1', refresh_token: 'LEAK2',
+    accessToken: 'LEAK3', refreshToken: 'LEAK4',
+    statusCode: 200, userId: 'u1', country_code: 'CN',
+  });
+  const raw = readFileSync(path.join(d, 'monitor.log'), 'utf8');
+  const obj = JSON.parse(raw);
+  assert.equal(obj.access_token, '[REDACTED]', 'access_token 应脱敏');
+  assert.equal(obj.refresh_token, '[REDACTED]', 'refresh_token 应脱敏');
+  assert.equal(obj.accessToken, '[REDACTED]', 'accessToken 应脱敏');
+  assert.equal(obj.refreshToken, '[REDACTED]', 'refreshToken 应脱敏');
+  assert.equal(obj.statusCode, 200, 'statusCode 业务字段不误伤');
+  assert.equal(obj.country_code, 'CN', 'country_code 业务字段不误伤');
+  assert.ok(!raw.includes('LEAK'), '零泄漏');
+});
+
+test('脱敏：文本形态 code/totp 键命中，statusCode/errorCode 不误伤', () => {
+  assert.ok(!redactSecrets('{"code":"112233"}').includes('112233'), 'JSON code 键值应脱敏');
+  assert.ok(!redactSecrets('totp=112233').includes('112233'), 'totp= 应脱敏');
+  assert.ok(redactSecrets('statusCode=200').includes('200'), 'statusCode 文本不误伤');
+  assert.ok(redactSecrets('errorCode=404').includes('404'), 'errorCode 文本不误伤');
+});
+
 test('脱敏：中文键「授权码」宽松值也替换', () => {
   const out = redactSecrets('imap_auth授权码: A1B2C3D4E5F6G7H8');
   assert.ok(!out.includes('A1B2C3D4E5F6G7H8'), '授权码值不得泄漏');

--- a/test/logger.test.mjs
+++ b/test/logger.test.mjs
@@ -186,6 +186,10 @@ test('脱敏：文本形态 code/totp 键命中，statusCode/errorCode 不误伤
   assert.ok(!redactSecrets('authorization_code=xyz').includes('xyz'), 'authorization_code 应脱敏');
   assert.ok(redactSecrets('statusCode=200').includes('200'), 'statusCode 文本不误伤');
   assert.ok(redactSecrets('errorCode=404').includes('404'), 'errorCode 文本不误伤');
+  // R3 回归：*_code 业务字段在下划线场景不得误伤（此前只测驼峰 statusCode/errorCode，漏了下划线）
+  assert.ok(redactSecrets('country_code=CN').includes('CN'), 'country_code 文本不误伤');
+  assert.ok(redactSecrets('invite_code=INV123').includes('INV123'), 'invite_code 文本不误伤');
+  assert.ok(redactSecrets('room_code=R').includes('R'), 'room_code 文本不误伤');
 });
 
 test('脱敏：中文键「授权码」宽松值也替换', () => {


### PR DESCRIPTION
## 需求来源

vrc-monitor 此前**没有日志模块**：日志全靠裸 `console.log`（25+ 文件），Hermes 插件只是把子进程 stdout/stderr 重定向到 `monitor.log` 捕获，并非应用自身的日志能力。排障只能 grep 一坨 stdout，无法分级、无法轮转、无法按组件定位、且任何输出都可能泄漏 cookie/token/授权码等敏感值。

本期为服务引入**生产级结构化日志模块**，方便维护与调试（分级输出、日志轮替、脱敏、命名组件区分）。

## 实现方式

新增 `core/logger.js`（**零第三方依赖**，纯 node:fs/path/zlib，约 300 行），并提供完整日志能力：

- **分级输出**：`LEVELS` (debug/info/warn/error/silent)，配置 `VRC_MONITOR_LOGGER_LEVEL`。
- **双通道**：stdout（Hermes 插件/Docker/systemd 采集靠它，始终保留）+ 文件（`VRC_MONITOR_LOGGER_DIR/monitor.log`，本地排障/历史回溯）。
- **双格式**：text（人类可读带色，UTC 完整时间戳）+ json（JSONL，agent 用 jq 解析），`VRC_MONITOR_LOGGER_FORMAT` 切换。
- **日志轮替**：单文件达 `VRC_MONITOR_LOGGER_MAX_SIZE` 即轮转压缩为 `.gz`，保留 `VRC_MONITOR_LOGGER_MAX_FILES` 份；命名 `monitor-YYYYMMDD-HHMMSS-<pid>.log.gz`。
- **敏感脱敏**：每条输出必经 `redactSecrets`，cookie/token/邮箱/密码/IMAP 授权码一律 `[REDACTED]`。
- **命名子 logger**：`getLogger('<组件>')` 区分应用/WS/API/存储/HTTP/OTP 等组件。
- **噪音抑制**：`VRC_MONITOR_LOGGER_SUPPRESS` 子串过滤（压 MCP ping/keepalive），MCP 协议往返日志默认 debug 级。

### 接线与落地

- `core/server-context.js`：现有 `log()` 签名不变、内部委托 `logger.info()` → 全部既有调用点零改动。
- `start-monitor.js`：main() 顶部 `initLogger()`，banner 走 `log()`（双写验证），回写 `ctx.paths.LOG_DIR/LOG_LEVEL/LOG_FORMAT`。
- 清扫 `core/` 的裸 `console.*`（ws-manager 13 处 / migrate-legacy-data 3 处 / storage 1 处）→ 命名子 logger。保留 start-monitor 的启动失败/凭据缺失/崩溃兜底路径用 `console.error`（logger 可能未初始化/须跨崩溃存活）。
- **环境变量命名**：日志模块用 `VRC_MONITOR_LOGGER_*` 前缀，避免与 AGENTS.md 既有 `VRC_MONITOR_LOG_DIR`（service-windows 脚本专用）撞名。
- `.gitignore` 追加 `logs/`（默认日志目录落项目内）。
- DEVELOPMENT.md 已更新跨平台「日志默认写 stdout」边界说明。

## 验证过程与结果

- `npm test`（新增 `test/logger.test.mjs` 7 个用例 + 既有全部）：**42 pass / 0 fail**。
  覆盖：脱敏（authToken/cookie/邮箱/密码/授权码零泄漏）、级别过滤、json 格式键（ts/level/name/msg/pid）、命名子 logger 标签、轮转（gz 可读 + 命名含 UTC 时间戳+pid）、suppress 过滤、`getLevelName`、`VRC_MONITOR_LOGGER_DIR` env 读取。
- 真实启动验证（safe mode + 临时日志目录）：banner 同时落入 stdout 与 `monitor.log`，`LOG_LEVEL=info`（人类可读）正确回填 `ctx.paths`。
- 轮转压力验证：300 次写入触发多次轮转，`.gz` 可 `gunzipSync` 读出完整行，Windows 上 rename 全程无 EPERM/EBUSY 异常。
- `node --check` 全部改动文件通过；关键模块 `import` 无报错。
- 文档漂移检测（`check-doc-drift.py`）：本 PR 未引入漂移；工具数 104 无变化、skill 工具清单一致。（注：检出 main 上既有 PR #124 历史状态标注漂移，与本 PR 无关，单独处理。）

## 备注

- 未新增 MCP 工具，工具表/计数无变化。
- 未引入任何第三方依赖。
- 文档同步四处（README / AGENTS / DEVELOPMENT / skills/vrc-monitor-agent）。
