### PR TITLE
chore(log): 服务日志 emoji 正式化 + fix(logger) 多行消息按行落盘

### DIFF
--- a/core/fetch-x-worlds.js
+++ b/core/fetch-x-worlds.js
@@ -959,7 +959,7 @@ export async function fetchCreatorTweets(screenName, { minTweets = 0 } = {}) {
       const tweets = await fetchCreatorViaBrowser(screenName);
       return { tweets: await enrichWorldsWithTco(tweets, screenName), source: 'browser' };
     } catch (e) {
-      log(`⚠️ x-world @${screenName} 浏览器抓取失败，回退 HTTP 通道：${e.message}`);
+      log(`[警告] x-world @${screenName} 浏览器抓取失败，回退 HTTP 通道：${e.message}`);
       // 落到下方原 Nitter RSS → SearchTimeline 链
     }
   }
@@ -970,7 +970,7 @@ export async function fetchCreatorTweets(screenName, { minTweets = 0 } = {}) {
     tweets = await fetchCreatorRss(screenName);
     source = 'nitter';
     if (minTweetsEffective > 0 && tweets.length < minTweetsEffective) {
-      log(`⚠️ x-world @${screenName} Nitter 仅 ${tweets.length} 条(< minTweets=${minTweetsEffective})，尝试 SearchTimeline 补充`);
+      log(`[警告] x-world @${screenName} Nitter 仅 ${tweets.length} 条(< minTweets=${minTweetsEffective})，尝试 SearchTimeline 补充`);
       try {
         const extra = await fetchCreatorViaSearchTimeline(screenName);
         const seen = new Set(tweets.map(t => t.id));
@@ -983,7 +983,7 @@ export async function fetchCreatorTweets(screenName, { minTweets = 0 } = {}) {
       }
     }
   } catch (e) {
-    log(`⚠️ x-world @${screenName} Nitter 不可达，回退 X SearchTimeline：${e.message}`);
+    log(`[警告] x-world @${screenName} Nitter 不可达，回退 X SearchTimeline：${e.message}`);
     try {
       tweets = await fetchCreatorViaSearchTimeline(screenName);
       source = 'search_timeline';
@@ -1088,7 +1088,7 @@ export async function scanCreatorWorlds({ force = false } = {}) {
       totalWorlds += saved;
       results.push({ screen_name: screen, name: creator.name || screen, tweets: tweets.length, worlds: saved });
     } catch (e) {
-      log(`❌ x-world scan @${screen}: ${e.message}`);
+      log(`[失败] x-world scan @${screen}: ${e.message}`);
       // 结构化错误：三通道均失败 → 用户可读的降级提示
       const errorInfo = e.code === 'X_FETCH_ALL_FAILED'
         ? `Nitter / X SearchTimeline / 浏览器抓取均不可用（2026 上游反向爬 + 网络受限），该通道当前无法获取新推荐。`

--- a/core/http-server.js
+++ b/core/http-server.js
@@ -83,7 +83,7 @@ async function handleRequest(req, res) {
     try {
       await route.handler(req, res);
     } catch (err) {
-      log(`❌ 插件 HTTP 路由失败 [${route.pluginName} ${pathname}]: ${err.message}`);
+      log(`[失败] 插件 HTTP 路由失败 [${route.pluginName} ${pathname}]: ${err.message}`);
       if (!res.headersSent) {
         const body = JSON.stringify({ error: 'Internal Server Error', message: err.message });
         res.writeHead(500, { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(body) });
@@ -198,7 +198,7 @@ async function handleRpc(rpc, session, res) {
           result: { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] },
         }], session.id);
       } catch (err) {
-        log(`❌ ${name} failed: ${err.message}`);
+        log(`[失败] ${name} failed: ${err.message}`);
         sendError(res, id, err.message);
       }
       break;
@@ -238,11 +238,11 @@ export function createServer() {
   // 端口冲突 → 立即退出（防双实例并存互抢 OTP 验证码，issue #49）
   server.on('error', (err) => {
     if (err.code === 'EADDRINUSE') {
-      log(`❌ 端口 ${PORT} 已被占用，请检查是否有旧进程残留`);
+      log(`[失败] 端口 ${PORT} 已被占用，请检查是否有旧进程残留`);
       log('   检测到监控服务可能已在运行，本进程立即退出，避免双实例并存互抢 OTP 验证码');
       process.exit(1);
     } else {
-      log(`❌ 服务器错误: ${err.message}`);
+      log(`[失败] 服务器错误: ${err.message}`);
     }
   });
 

--- a/core/logger.js
+++ b/core/logger.js
@@ -396,8 +396,19 @@ function write(levelName, name, msg, meta) {
 
   if (state.fileEnabled && state.filePath) {
     try {
-      checkRotation(line);
-      fs.appendFileSync(state.filePath, `${line}\n`, 'utf8');
+      // 多行消息按行拆分落盘：每行都带完整前缀。否则「前缀+空正文」行会被解析成
+      // 空条目（日志页出现空行）、无前缀的续行（如 `\n[启动]...` 的正文、error.stack）
+      // 会被解析器整行丢弃（日志页数据丢失）。空段跳过——装饰性 '\n' 不再产生空行。
+      const fileLines = state.format === 'json'
+        ? [line]
+        : redactedMsg.split('\n')
+            .map((s) => s.trim())
+            .filter(Boolean)
+            .map((seg) => formatText(ts, levelName, name, seg));
+      for (const fl of fileLines) {
+        checkRotation(fl);
+        fs.appendFileSync(state.filePath, `${fl}\n`, 'utf8');
+      }
     } catch (err) {
       if (state.console) {
         console.error(`[logger] 写入日志文件失败: ${err.message}`);

--- a/core/notifier.js
+++ b/core/notifier.js
@@ -86,7 +86,7 @@ class AuthNotifier {
 
   _dispatch(kind, message) {
     // 无论通道是否成功都保留日志，维持现有可观测性
-    log(`🔔 [notify] ${kind}: ${message}`);
+    log(`[通知] ${kind}: ${message}`);
     for (const ch of this.channels) {
       try {
         const ret = ch(kind, message);
@@ -94,10 +94,10 @@ class AuthNotifier {
         // 否则 fetch/webhook 网络失败会 unhandled rejection → Node 15+ 默认 throw 终止进程
         // （审核实测复现，issue #69 阻断项；同步通道返回 undefined 不受影响）
         if (ret && typeof ret.catch === 'function') {
-          ret.catch((err) => log(`⚠️ [notify] 异步通道发送失败: ${err?.message || err}`));
+          ret.catch((err) => log(`[警告] [notify] 异步通道发送失败: ${err?.message || err}`));
         }
       } catch (err) {
-        log(`⚠️ [notify] 通道发送失败: ${err.message}`);
+        log(`[警告] [notify] 通道发送失败: ${err.message}`);
       }
     }
   }

--- a/core/plugin-loader.js
+++ b/core/plugin-loader.js
@@ -289,7 +289,7 @@ export class PluginLoader {
     plugin.error = error;
     plugin.loaded = false;
     this.registry.removePluginTools(plugin.name);
-    this.log(`❌ 插件加载失败 [${plugin.name}]: ${error}`);
+    this.log(`[失败] 插件加载失败 [${plugin.name}]: ${error}`);
   }
 
   /** 加载所有插件 */
@@ -458,7 +458,7 @@ export class PluginLoader {
     try {
       this._loadManifest(candidate);
       if (this.plugins.has(candidate.name)) {
-        this.log(`⚠️ 插件 ${candidate.name} 已存在，跳过新插件加载`);
+        this.log(`[警告] 插件 ${candidate.name} 已存在，跳过新插件加载`);
         return;
       }
       this._applySchema(candidate);
@@ -469,7 +469,7 @@ export class PluginLoader {
       candidate.status = 'error';
       candidate.error = err.message;
       this.plugins.set(candidate.name, candidate);
-      this.log(`❌ 插件加载失败 [${candidate.name || candidate.dir}]: ${err.message}`);
+      this.log(`[失败] 插件加载失败 [${candidate.name || candidate.dir}]: ${err.message}`);
     }
   }
 
@@ -511,7 +511,7 @@ export class PluginLoader {
         });
         this.watchers.push(watcher);
       } catch (err) {
-        this.log(`️ 插件目录监听失败 ${dir}: ${err.message}`);
+        this.log(`[警告] 插件目录监听失败 ${dir}: ${err.message}`);
       }
     }
   }

--- a/core/registry.js
+++ b/core/registry.js
@@ -149,7 +149,7 @@ export async function dispatch(name, args) {
   } catch (err) {
     if (err.needsTotp) {
       ctx.serverState.needsTotp = true;
-      log('🔑 检测到需要 TOTP 验证码，请调用 submit_totp 完成登录');
+      log('[认证] 检测到需要 TOTP 验证码，请调用 submit_totp 完成登录');
       notifier.notifyAuth('needsTotp', '运行期会话失效需 TOTP 验证码，服务暂停——请调用 submit_totp 提交当前验证码');
     }
     throw err;

--- a/core/tools/auth.js
+++ b/core/tools/auth.js
@@ -25,13 +25,13 @@ export async function handleSubmitTotp({ code }) {
     serverState.authUser = { id: user.id, displayName: user.displayName };
     serverState.needsOtp = false;
     serverState.needsTotp = false;
-    log(`🔐 TOTP 登录成功: ${user.displayName} (${user.id})`);
+    log(`[认证] TOTP 登录成功: ${user.displayName} (${user.id})`);
     notifier.notifyAuth('recovered', 'TOTP 验证码提交成功，服务已恢复正常');
 
     // 登录成功后立即让 WebSocket 重连上线
     if (wsManager) {
       wsManager.authCooldownUntil = 0;
-      try { wsManager.forceReconnect(); } catch (e) { log(`⚠️ TOTP 后 WS 重连触发失败: ${e.message}`); }
+      try { wsManager.forceReconnect(); } catch (e) { log(`[警告] TOTP 后 WS 重连触发失败: ${e.message}`); }
     }
     return { success: true, displayName: user.displayName, userId: user.id };
   } catch (err) {

--- a/core/tools/events.js
+++ b/core/tools/events.js
@@ -215,7 +215,7 @@ export async function handleGetWorldsByAuthor({ authorId, authorName, limit = 10
     offset += r.data.length;
   }
 
-  log(`🔍 get_worlds_by_author: ${resolvedAuthorName} (${resolvedAuthorId}) → ${worlds.length} 张图`);
+  log(`[查询] get_worlds_by_author: ${resolvedAuthorName} (${resolvedAuthorId}) → ${worlds.length} 张图`);
   return { authorId: resolvedAuthorId, authorName: resolvedAuthorName, total: worlds.length, worlds };
 }
 

--- a/core/tools/misc.js
+++ b/core/tools/misc.js
@@ -232,7 +232,7 @@ export function handleRateWorld({ worldId, rating = 0 }) {
     throw new Error('rating must be -1 (junk), 0 (clear), or 1 (good)');
   }
   const result = storage.rateWorld({ worldId, rating: r });
-  log(`⭐ 用户反馈: ${worldId} → rating=${result.userRating}${result.worldName ? ` (${result.worldName})` : ''}`);
+  log(`[反馈] 用户反馈: ${worldId} → rating=${result.userRating}${result.worldName ? ` (${result.worldName})` : ''}`);
   return result;
 }
 
@@ -241,7 +241,7 @@ export function handleMarkWorldVisited({ worldId }) {
   const { storage } = ctx;
   if (!worldId) throw new Error('worldId is required');
   const result = storage.markWorldVisited({ worldId });
-  log(`✅ 手动标记 visited: ${worldId}${result.worldName ? ` (${result.worldName})` : ''}`);
+  log(`[成功] 手动标记 visited: ${worldId}${result.worldName ? ` (${result.worldName})` : ''}`);
   return result;
 }
 
@@ -250,7 +250,7 @@ export function handleAddToBacklog({ worldId, reason = '', priority = 0 }) {
   const { storage } = ctx;
   if (!worldId) throw new Error('worldId is required');
   const result = storage.addToBacklog({ worldId, reason, priority });
-  log(`📌 加入待逛: ${worldId}${result.worldName ? ` (${result.worldName})` : ''} priority=${result.priority}`);
+  log(`[待办] 加入待逛: ${worldId}${result.worldName ? ` (${result.worldName})` : ''} priority=${result.priority}`);
   return result;
 }
 
@@ -264,7 +264,7 @@ export function handleRemoveFromBacklog({ worldId }) {
   const { storage } = ctx;
   if (!worldId) throw new Error('worldId is required');
   const result = storage.removeFromBacklog({ worldId });
-  log(`🗑 移出待逛: ${worldId}`);
+  log(`[删除] 移出待逛: ${worldId}`);
   return result;
 }
 
@@ -324,7 +324,7 @@ export function handleSetNickname({ userId, nickname, displayName }) {
 export async function handleBackupDatabase() {
   try {
     const result = await ctx.storage.backup(ctx.paths.BACKUP_DIR);
-    log(`💾 手动备份完成: ${result.path} (${result.size} bytes)`);
+    log(`[备份] 手动备份完成: ${result.path} (${result.size} bytes)`);
     return result;
   } catch (e) {
     return { ok: false, error: String(e.message || e) };
@@ -336,7 +336,7 @@ export function handleSetWorldSleep({ worldId, isSleep = true }) {
   const { storage } = ctx;
   if (!worldId) throw new Error('worldId is required');
   const result = storage.setWorldSleep({ worldId, isSleep: !!isSleep });
-  log(`${result.isSleep ? '🛏' : '✖️'} 标记睡觉图: ${worldId}${result.worldName ? ` (${result.worldName})` : ''} → sleep_ok=${result.isSleep ? 1 : 0}`);
+  log(`${result.isSleep ? '[睡眠]' : '[取消]'} 标记睡觉图: ${worldId}${result.worldName ? ` (${result.worldName})` : ''} → sleep_ok=${result.isSleep ? 1 : 0}`);
   return result;
 }
 

--- a/core/tools/notifications.js
+++ b/core/tools/notifications.js
@@ -81,7 +81,7 @@ export async function handleAcceptFriendRequest({ notificationId, confirm }) {
   const r = await api._request('PUT', `/auth/user/notifications/${notificationId}/accept`);
   if (r.status === 404) throw new Error('该好友请求不存在或已处理');
   if (r.status !== 200) throw new Error(`API error: ${r.status}`);
-  log(`✅ accept_friend_request: ${notificationId}`);
+  log(`[成功] accept_friend_request: ${notificationId}`);
   return { notificationId, accepted: true, ok: true };
 }
 
@@ -94,7 +94,7 @@ export async function handleDeclineFriendRequest({ notificationId, confirm }) {
   const { api } = ctx;
   const r = await api._request('PUT', `/auth/user/notifications/${notificationId}/hide`);
   if (r.status !== 200) throw new Error(`API error: ${r.status}`);
-  log(`✅ decline_friend_request: ${notificationId}`);
+  log(`[成功] decline_friend_request: ${notificationId}`);
   return { notificationId, declined: true, ok: true };
 }
 // ── MCP 自声明工具表 ──

--- a/core/ws-manager.js
+++ b/core/ws-manager.js
@@ -116,13 +116,13 @@ export class WsManager {
       } catch (authErr) {
         // 自动 2FA 通道：邮箱 OTP（otpFetcher）或 TOTP（api.totpFetcher，配置 totp_secret 后启用）
         if (authErr.needsOtp && (this.otpFetcher || this.api.totpFetcher)) {
-          log.info('⚠️ 认证需要 2FA，尝试自动获取...');
+          log.info('[警告] 认证需要 2FA，尝试自动获取...');
           try {
             await this.api.ensureAuthWithAutoOtp(this.otpFetcher);
           } catch (otpErr) {
             if (otpErr.needsTotp) {
               ctx.serverState.needsTotp = true;
-              log.info('🔑 账号需要 TOTP 验证码：自动登录未成功，可调用 MCP 工具 submit_totp 提交');
+              log.info('[认证] 账号需要 TOTP 验证码：自动登录未成功，可调用 MCP 工具 submit_totp 提交');
               notifier.notifyAuth('needsTotp', '账号需要 TOTP 验证码，服务暂停——请调用 submit_totp 提交当前验证码');
             } else {
               notifier.notifyAuth('reauthFailed', `WS 重连自动认证失败：${otpErr.message}`);
@@ -209,7 +209,7 @@ export class WsManager {
     this.attempt = 0;
     this.connectedAt = new Date();
     this._setStatus('connected');
-    log.info(`✅ 已连接 (${this.connectedAt.toISOString().slice(11, 19)})`);
+    log.info(`[成功] 已连接 (${this.connectedAt.toISOString().slice(11, 19)})`);
     recordOpsLog('ws', 'info', lastAttempt > 0
       ? 'WebSocket 已连接（重连成功，第 ' + lastAttempt + ' 次尝试）'
       : 'WebSocket 已连接（首次连接）');
@@ -262,7 +262,7 @@ export class WsManager {
   _onClose(code, reason) {
     this.disconnectedAt = new Date();
     const reasonStr = reason ? reason.toString() : '无';
-    log.info(`⚠️ 断开: code=${code}, reason=${reasonStr}`);
+    log.info(`[警告] 断开: code=${code}, reason=${reasonStr}`);
     recordOpsLog('ws', 'warn', 'WebSocket 断开 code=' + code + '（' + reasonStr + '），将自动重连');
 
     this._clearTimers();
@@ -275,7 +275,7 @@ export class WsManager {
   }
 
   _onError(err) {
-    log.error(`❌ 错误: ${err.message}`);
+    log.error(`[失败] 错误: ${err.message}`);
   }
 
   // ── 心跳 ──
@@ -292,7 +292,7 @@ export class WsManager {
         // 设置 pong 超时
         this.heartbeatTimeout = setTimeout(() => {
           if (!this._pongReceived) {
-            log.info('⚠️ 心跳超时，主动断开');
+            log.info('[警告] 心跳超时，主动断开');
             try { this.ws.terminate(); } catch {}
           }
         }, HEARTBEAT_TIMEOUT);
@@ -337,7 +337,7 @@ export class WsManager {
     const cooldownMs = isRateLimited ? 300_000 : 120_000;
     this.authCooldownUntil = Date.now() + cooldownMs;
     const secs = Math.round(cooldownMs / 1000);
-    log.info(`🔒 认证失败，冷却 ${secs} 秒后重试${isRateLimited ? ' (限流)' : ''}`);
+    log.info(`[认证] 认证失败，冷却 ${secs} 秒后重试${isRateLimited ? ' (限流)' : ''}`);
     recordOpsLog('ws', 'warn', '认证失败，冷却 ' + secs + ' 秒后重试' + (isRateLimited ? '（限流）' : ''));
   }
 
@@ -354,7 +354,7 @@ export class WsManager {
     const delay = RECONNECT_DELAYS[Math.min(this.attempt - 1, RECONNECT_DELAYS.length - 1)];
     this._setStatus('reconnecting');
 
-    log.info(`🔄 将在 ${delay} 秒后重连 (第 ${this.attempt} 次)...`);
+    log.info(`[重连] 将在 ${delay} 秒后重连 (第 ${this.attempt} 次)...`);
     recordOpsLog('ws', 'info', '将在 ' + delay + ' 秒后重连（第 ' + this.attempt + ' 次）');
     
     this.reconnectTimer = setTimeout(() => {

--- a/plugins/official/events/index.js
+++ b/plugins/official/events/index.js
@@ -243,7 +243,7 @@ export default function register(api) {
   async function collectGoogleCalendar(calId, src, lang, minDate, maxDate) {
     const googleKey = getGoogleKey();
     if (!googleKey || googleKey.includes('...')) {
-      api.log(`⚠️ 未配置 Google Calendar API key（${src} 跳过）。请经 set_community_events_google_key 录入（存入数据库）或设 VRC_MONITOR_GCAL_CRED / config.json`);
+      api.log(`[警告] 未配置 Google Calendar API key（${src} 跳过）。请经 set_community_events_google_key 录入（存入数据库）或设 VRC_MONITOR_GCAL_CRED / config.json`);
       return [];
     }
     const items = [];
@@ -261,7 +261,7 @@ export default function register(api) {
         if (!pageToken) break;
       }
     } catch (e) {
-      api.log(`⚠️ ${src} Google Calendar API 失败: ${e.message}（仅该源跳过，其余源照常）`);
+      api.log(`[警告] ${src} Google Calendar API 失败: ${e.message}（仅该源跳过，其余源照常）`);
       return [];
     }
     const out = [];
@@ -682,7 +682,7 @@ export default function register(api) {
         const HAVE_GC_KEY = !!(getGoogleKey() && !String(getGoogleKey()).includes('...'));
         const GC_UNAVAILABLE_REASON = HAVE_GC_KEY ? '' : '未配置 Google Calendar API key（用 set_community_events_google_key 录入或设 VRC_MONITOR_GCAL_CRED）';
 
-        api.log(`🔍 采集活动 window=${opts.window} focus=${opts.focus} sources=${opts.sources.join(',')}`);
+        api.log(`[查询] 采集活动 window=${opts.window} focus=${opts.focus} sources=${opts.sources.join(',')}`);
 
         // 采集（限流友好：串行，逐源）。记录每源 ok/fail 供 sourceBreakdown 区分「源不可达」与「无活动」。
             let collected = [];
@@ -728,7 +728,7 @@ export default function register(api) {
     const needMine = dedup.filter(e => !e.group_id || !(e.member_count || e.group_members));
     needMine.sort((a, b) => (b.shortcode ? 1 : 0) - (a.shortcode ? 1 : 0));
     const toMine = needMine.slice(0, maxMine);
-    api.log(`🔗 待群组处理 ${needMine.length} 个（本次挖/补 ${toMine.length}，上限 ${maxMine}；短码优先）`);
+    api.log(`[链接] 待群组处理 ${needMine.length} 个（本次挖/补 ${toMine.length}，上限 ${maxMine}；短码优先）`);
     for (const e of toMine) {
       await mineGroup(e);
     }
@@ -736,7 +736,7 @@ export default function register(api) {
     // 侧面补充源：窥探已挖掘/采集到的群组公告（peekGroups=true 时启用，有副作用）
     if (opts.peekGroups) {
       const groupIds = dedup.map(e => e.group_id).filter(Boolean);
-      api.log(`👀 窥探 ${[...new Set(groupIds)].length} 个群组公告（副作用：加入→读→退出）`);
+      api.log(`[窥探] 窥探 ${[...new Set(groupIds)].length} 个群组公告（副作用：加入→读→退出）`);
       const annEvents = await collectFromGroupAnnouncements(groupIds);
       if (annEvents.length > 0) {
         // 与已采集合并（去重交给后续统一逻辑）
@@ -744,7 +744,7 @@ export default function register(api) {
         for (const a of annEvents) {
           if (!seenNames.has(normName(a.name))) { dedup.push(a); seenNames.add(normName(a.name)); }
         }
-        api.log(`📣 群组公告补充 ${annEvents.length} 条活动线索`);
+        api.log(`[公告] 群组公告补充 ${annEvents.length} 条活动线索`);
       }
     }
 
@@ -799,7 +799,7 @@ export default function register(api) {
       }
     }
 
-    api.log(`✅ 完成：采集 ${collected.length} → 去重 ${dedup.length} → 输出 ${events.length}`);
+    api.log(`[成功] 完成：采集 ${collected.length} → 去重 ${dedup.length} → 输出 ${events.length}`);
 
     // 返回结构化 JSON（供 Agent 翻译/渲染 PDF/进一步加工）
     const HAVE_GOOGLE_KEY = getGoogleKey() ? true : false;
@@ -886,7 +886,7 @@ export default function register(api) {
         `DELETE FROM store WHERE (end_iso != '' AND end_iso < $now) OR (end_iso = '' AND start_iso < $past)`,
         { $now: now, $past: past }
       );
-      api.log(`🗑️ 清理过期活动 ${r.changes} 条`);
+      api.log(`[删除] 清理过期活动 ${r.changes} 条`);
     } catch (e) {
       api.log(`清理过期活动失败: ${e.message}`);
     }
@@ -912,7 +912,7 @@ export default function register(api) {
       return;
     }
     // status === false 表示明确离线，直接重挖三个窗口并落库
-    api.log('🌙 每日活动刷新：玩家离线，开始重挖社区活动');
+    api.log('[夜间] 每日活动刷新：玩家离线，开始重挖社区活动');
     try {
       for (const window of ['week', 'month', 'tonight']) {
         await api.tools.call('fetch_community_events', { window, maxMine: 30 });
@@ -966,7 +966,7 @@ export default function register(api) {
     cfg.run('INSERT OR REPLACE INTO config (cfg_key, cfg_val, updated_at) VALUES ($k, $v, datetime(\'now\'))',
       { $k: 'google_calendar_api_key', $v: apiKey.trim() });
     const ok = getGoogleKey() ? true : false;
-    api.log(`ℹ️ 使用者 Google API Key 已${apiKey.trim() ? '更新' : '清除'}（config 表）`);
+    api.log(`[信息] 使用者 Google API Key 已${apiKey.trim() ? '更新' : '清除'}（config 表）`);
     return {
       stored: true,
       configured: ok,

--- a/plugins/official/favorites/index.js
+++ b/plugins/official/favorites/index.js
@@ -138,7 +138,7 @@ export default function register(api) {
       const cached = await api.consume('storage.getWorldName', worldId);
       const name = cached?.name || data?.name || data?.displayName;
       if (name) result.displayName = name;
-      api.log(`⭐ 云端收藏: ${worldId} → ${group.tag} (${type})`);
+      api.log(`[收藏] 云端收藏: ${worldId} → ${group.tag} (${type})`);
       return result;
     } catch (e) {
       if (e.status >= 400) {
@@ -193,7 +193,7 @@ export default function register(api) {
     try {
       await api.consume('storage.setWorldFavorited', { worldId, favorited: 0 });
     } catch { /* 本地标记失败不影响 */ }
-    api.log(`✅ unfavorite_world: ${worldId} (${records.length} 条记录)`);
+    api.log(`[成功] unfavorite_world: ${worldId} (${records.length} 条记录)`);
     return { ok: true, worldId, removed: true, removedGroups: records.map(r => (r.tags || [])[0]) };
   }
 
@@ -358,7 +358,7 @@ export default function register(api) {
         method: 'POST',
         body: { favoriteId: targetId, tags: [group.name], type: 'friend' },
       });
-      api.log(`✅ favorite_friend: ${targetName || targetId} → ${group.displayName || group.name}`);
+      api.log(`[成功] favorite_friend: ${targetName || targetId} → ${group.displayName || group.name}`);
       return { ok: true, userId: targetId, displayName: targetName, groupName: group.displayName || group.name, favorited: true };
     } catch (e) {
       if (e.status === 400) {
@@ -395,7 +395,7 @@ export default function register(api) {
         if (e.status !== 404) throw e;
       }
     }
-    api.log(`✅ unfavorite_friend: ${targetName || targetId} (${records.length} 条记录)`);
+    api.log(`[成功] unfavorite_friend: ${targetName || targetId} (${records.length} 条记录)`);
     return { ok: true, userId: targetId, displayName: targetName, removed: true, removedGroups: records.map(r => (r.tags || [])[0]) };
   }
 
@@ -424,7 +424,7 @@ export default function register(api) {
       method: 'POST',
       body: { favoriteId: targetId, tags: [targetGroup.name], type: 'friend' },
     });
-    api.log(`✅ move_friend_group: ${targetName || targetId} → ${targetGroup.displayName || targetGroup.name}`);
+    api.log(`[成功] move_friend_group: ${targetName || targetId} → ${targetGroup.displayName || targetGroup.name}`);
     return { ok: true, userId: targetId, displayName: targetName, moved: true, fromGroups: oldRecords.map(r => (r.tags || [])[0]), toGroup: targetGroup.displayName || targetGroup.name };
   }
 
@@ -459,7 +459,7 @@ export default function register(api) {
     try {
       await api.consume('storage.setWorldFavorited', { worldId, favorited: 1 });
     } catch { /* 本地标记失败不影响 */ }
-    api.log(`✅ move_world_group: ${worldId} → ${target.displayName} (${target.type})`);
+    api.log(`[成功] move_world_group: ${worldId} → ${target.displayName} (${target.type})`);
     return { ok: true, worldId, moved: true, fromGroups: records.map(r => (r.tags || [])[0]), toGroup: target.displayName, toTag: target.tag };
   }
 
@@ -486,7 +486,7 @@ export default function register(api) {
       method: 'PUT',
       body,
     });
-    api.log(`✅ update_favorite_group: ${g.tag} ${JSON.stringify(body)}`);
+    api.log(`[成功] update_favorite_group: ${g.tag} ${JSON.stringify(body)}`);
     return { ok: true, group: g.displayName, tag: g.tag, type: g.type, updated: body };
   }
 
@@ -502,11 +502,11 @@ export default function register(api) {
     }
     if (count === 0) {
       // 空分组无内容可清，直接返回成功（DELETE 端点对空分组报 404 "favorites not found"）
-      api.log(`✅ clear_favorite_group: ${g.displayName}（空分组，无需清空）`);
+      api.log(`[成功] clear_favorite_group: ${g.displayName}（空分组，无需清空）`);
       return { ok: true, group: g.displayName, tag: g.tag, type: g.type, cleared: 0 };
     }
     await api.vrchat.fetch(`/favorite/group/${g.type}/${encodeURIComponent(g.tag)}/${g.ownerId}`, { method: 'DELETE' });
-    api.log(`✅ clear_favorite_group: ${g.displayName}（清空 ${count} 条）`);
+    api.log(`[成功] clear_favorite_group: ${g.displayName}（清空 ${count} 条）`);
     return { ok: true, group: g.displayName, tag: g.tag, type: g.type, cleared: count };
   }
 
@@ -558,7 +558,7 @@ export default function register(api) {
 
   api.registerTool({
     name: 'update_favorite_group',
-    description: '[write·收藏] 重命名收藏分组或修改可见性（PUT /favorite/group/{type}/{name}/{userId}）。group 为分组 tag 或 displayName；displayName（新名）/ visibility（friends/private/public）至少填一个。⚠️ 设为 public 会使收藏分组公开可见，隐私敏感，须显式 confirm。写操作，confirm: true 才执行。',
+    description: '[write·收藏] 重命名收藏分组或修改可见性（PUT /favorite/group/{type}/{name}/{userId}）。group 为分组 tag 或 displayName；displayName（新名）/ visibility（friends/private/public）至少填一个。注意：设为 public 会使收藏分组公开可见，隐私敏感，须显式 confirm。写操作，confirm: true 才执行。',
     inputSchema: {
       type: 'object',
       properties: {
@@ -589,7 +589,7 @@ export default function register(api) {
 
   api.registerTool({
     name: 'get_my_favorite_worlds',
-    description: '[查询·收藏] 拉取当前账号收藏的全部世界（含 VRC+ 专属收藏夹），按标签分类（🎮游戏/👻恐怖/🎵音乐体验/🌄风景观光/🧍Avatar模型/🍻社交聚会/😴休闲睡觉/📷拍照/其他），返回世界名/作者/收藏/浏览/简介/分类。数据经 GET /worlds/favorites 分页一次拉全（含实时 occupants），秒级返回，无需逐个查详情。group 参数可按收藏夹过滤。',
+    description: '[查询·收藏] 拉取当前账号收藏的全部世界（含 VRC+ 专属收藏夹），按标签分类（游戏/恐怖/音乐体验/风景观光/Avatar模型/社交聚会/休闲睡觉/拍照/其他），返回世界名/作者/收藏/浏览/简介/分类。数据经 GET /worlds/favorites 分页一次拉全（含实时 occupants），秒级返回，无需逐个查详情。group 参数可按收藏夹过滤。',
     inputSchema: {
       type: 'object',
       properties: {

--- a/plugins/official/x-creators/index.js
+++ b/plugins/official/x-creators/index.js
@@ -1,7 +1,7 @@
 export default function register(api) {
   api.registerTool({
     name: 'x_world_digest',
-    description: '[查询·X推荐] 聚合指定 X 博主近 1/3/7/15/30 天推荐的世界，按收藏数排序输出；收藏/浏览比 ≥ 1/5 的标注为 ⭐重点。可选 refresh=true 先抓取最新推文再查询。',
+    description: '[查询·X推荐] 聚合指定 X 博主近 1/3/7/15/30 天推荐的世界，按收藏数排序输出；收藏/浏览比 ≥ 1/5 的标注为 重点。可选 refresh=true 先抓取最新推文再查询。',
     inputSchema: {
       type: 'object',
       properties: {

--- a/start-monitor.js
+++ b/start-monitor.js
@@ -134,7 +134,7 @@ async function _refreshOnlineState() {
       location: f.location || '',
       worldId: f.worldId || (f.location || '').split(':')[0],
       // 在线口径与 MCP get_online_friends 一致：仅「有有效 location」计在线（offline=false 返回含
-      // active/菜单中用户，location 为空者不算在线——issue #114 [警告]2 复测遗留修复）
+      // active/菜单中用户，location 为空者不算在线——issue #114 ⚠️2 复测遗留修复）
       isOnline: !!(f.location && f.location !== 'offline'),
     })));
 
@@ -262,7 +262,7 @@ async function _seedTrackedNonFriends() {
       const del = ctx.storage.run(`DELETE FROM tracked_non_friends WHERE user_id = $u`, { $u: selfId });
       if (del.changes > 0) log(`[清理] 追踪列表移除误导入的自己（${selfId.slice(0, 12)}…）`);
     }
-    // 自动导入上限（issue #114 [警告]3 复测遗留修复）：仅导入近 30 天出现过的非好友，最多 100 人——
+    // 自动导入上限（issue #114 ⚠️3 复测遗留修复）：仅导入近 30 天出现过的非好友，最多 100 人——
     // 长历史全量导入会数百上千行，每小时逐人拉资料触发 VRChat 限流；手动添加不受此限
     const rows = ctx.storage.query(
       `SELECT user_id, MAX(display_name) AS dn FROM events

--- a/start-monitor.js
+++ b/start-monitor.js
@@ -126,7 +126,7 @@ async function _refreshOnlineState() {
       if (r.data.length < 100) { complete = true; break; }
       offset += r.data.length;
     }
-    if (!complete) { log('⚠️ 刷新在线状态: 好友列表未拉全，跳过本轮对账'); return; }
+    if (!complete) { log('[警告] 刷新在线状态: 好友列表未拉全，跳过本轮对账'); return; }
 
     friendState.batchSetOnline(online.map(f => ({
       userId: f.id,
@@ -134,7 +134,7 @@ async function _refreshOnlineState() {
       location: f.location || '',
       worldId: f.worldId || (f.location || '').split(':')[0],
       // 在线口径与 MCP get_online_friends 一致：仅「有有效 location」计在线（offline=false 返回含
-      // active/菜单中用户，location 为空者不算在线——issue #114 ⚠️2 复测遗留修复）
+      // active/菜单中用户，location 为空者不算在线——issue #114 [警告]2 复测遗留修复）
       isOnline: !!(f.location && f.location !== 'offline'),
     })));
 
@@ -186,9 +186,9 @@ async function _refreshOnlineState() {
       } catch { /* 补事件失败不影响状态对账 */ }
       fixed++;
     }
-    log(`🔄 刷新在线状态: 在线 ${online.length} 人${fixed ? `，断线窗口对账补离线 ${fixed} 人` : ''}`);
+    log(`[重连] 刷新在线状态: 在线 ${online.length} 人${fixed ? `，断线窗口对账补离线 ${fixed} 人` : ''}`);
   } catch (err) {
-    log(`⚠️ 刷新在线状态失败: ${err.message}`);
+    log(`[警告] 刷新在线状态失败: ${err.message}`);
   }
 }
 
@@ -239,9 +239,9 @@ async function _syncFriendAvatars() {
       if (r.data.length < 100) break;
     }
     }
-    if (updated) log(`🖼️ 好友头像补全: 更新 ${updated} 人（全量=在线+离线双列表）`);
+    if (updated) log(`[头像] 好友头像补全: 更新 ${updated} 人（全量=在线+离线双列表）`);
   } catch (err) {
-    log(`⚠️ 好友头像补全失败: ${err.message}`);
+    log(`[警告] 好友头像补全失败: ${err.message}`);
   }
 }
 
@@ -260,9 +260,9 @@ async function _seedTrackedNonFriends() {
     // 启动清理：移除历史误导入的自己
     if (selfId) {
       const del = ctx.storage.run(`DELETE FROM tracked_non_friends WHERE user_id = $u`, { $u: selfId });
-      if (del.changes > 0) log(`🧹 追踪列表移除误导入的自己（${selfId.slice(0, 12)}…）`);
+      if (del.changes > 0) log(`[清理] 追踪列表移除误导入的自己（${selfId.slice(0, 12)}…）`);
     }
-    // 自动导入上限（issue #114 ⚠️3 复测遗留修复）：仅导入近 30 天出现过的非好友，最多 100 人——
+    // 自动导入上限（issue #114 [警告]3 复测遗留修复）：仅导入近 30 天出现过的非好友，最多 100 人——
     // 长历史全量导入会数百上千行，每小时逐人拉资料触发 VRChat 限流；手动添加不受此限
     const rows = ctx.storage.query(
       `SELECT user_id, MAX(display_name) AS dn FROM events
@@ -286,9 +286,9 @@ async function _seedTrackedNonFriends() {
       );
       added++;
     }
-    if (added) log(`⭐ 追踪非好友: 自动导入 ${added} 人（历史非好友，定时拉取资料/头像）`);
+    if (added) log(`[追踪] 追踪非好友: 自动导入 ${added} 人（历史非好友，定时拉取资料/头像）`);
   } catch (e) {
-    log(`⚠️ 追踪非好友初始化失败: ${e.message}`);
+    log(`[警告] 追踪非好友初始化失败: ${e.message}`);
   }
 }
 
@@ -318,7 +318,7 @@ async function _refreshTrackedNonFriends() {
             contentJson: { userId: u.user_id, displayName: dn || u.display_name || '', type: 'avatar', avatarImageUrl: av, previousAvatarImageUrl: prevAv },
             worldId: '', worldName: '', createdAt: new Date().toISOString(), source: 'poll',
           });
-          log(`⭐ 追踪非好友头像变化: ${dn || u.user_id}`);
+          log(`[追踪] 追踪非好友头像变化: ${dn || u.user_id}`);
         } catch { /* 记录失败不影响刷新 */ }
       }
       const st = userObj.status || '';
@@ -347,7 +347,7 @@ async function _refreshTrackedNonFriends() {
       ok++;
     } catch { /* 404/网络错误跳过，非致命 */ }
   }
-  if (ok) log(`⭐ 追踪非好友刷新: ${ok}/${list.length} 位已更新`);
+  if (ok) log(`[追踪] 追踪非好友刷新: ${ok}/${list.length} 位已更新`);
 }
 
 // 对照 events 表该用户最新 bio/status 事件，变化则记录（事件带头像）
@@ -441,7 +441,7 @@ function registerCoreServices(loader, ctx) {
   ];
   for (const name of whitelist) {
     if (typeof ctx.storage[name] !== 'function') {
-      log(`⚠️ 核心存储服务 ${name} 不存在，跳过`);
+      log(`[警告] 核心存储服务 ${name} 不存在，跳过`);
       continue;
     }
     const svc = `storage.${name}`;
@@ -615,7 +615,7 @@ async function main() {
   //    第二个实例早已抢走/消费验证码，触发 VRChat 重复下发，造成邮箱验证码轰炸
   if (await isPortBusy(PORT)) {
     console.error('');
-    console.error(`❌ 端口 ${PORT} 已被占用，检测到监控服务可能已在运行`);
+    console.error(`[失败] 端口 ${PORT} 已被占用，检测到监控服务可能已在运行`);
     console.error('   为避免双实例并存互抢 OTP 验证码（造成邮箱验证码轰炸），本进程将退出。');
     console.error('   请先确认旧实例状态并结束残留进程后重启：');
     console.error('     Windows: netstat -ano | findstr 8799  或  tasklist | findstr node');
@@ -628,17 +628,17 @@ async function main() {
 
   // 0b. 安全模式（VRC_MONITOR_SAFE_MODE=true）：启动即剔除破坏性工具，tools/list 不暴露、tools/call 拦截
   if (isSafeModeEnabled()) {
-    log('\n🔒 安全模式已启用（VRC_MONITOR_SAFE_MODE=true）');
+    log('\n[认证] 安全模式已启用（VRC_MONITOR_SAFE_MODE=true）');
     log(`   已移除 ${DESTRUCTIVE_TOOLS.length} 个破坏性工具: ${DESTRUCTIVE_TOOLS.join(', ')}`);
   } else {
-    log('\n🔓 安全模式未启用（VRC_MONITOR_SAFE_MODE 未设置或非 true）');
+    log('\n[认证] 安全模式未启用（VRC_MONITOR_SAFE_MODE 未设置或非 true）');
   }
 
   // 0c. 旧数据迁移（issue #103）：根目录旧文件 → data/
   migrateLegacyData(__dirname, path.join(__dirname, 'data'));
 
   // 1. 初始化数据库
-  log('📦 初始化数据库...');
+  log('[初始化] 初始化数据库...');
   ctx.storage = new Storage();
 // 服务运维日志（ops_log）：认证/连接生命周期打点的落库出口
 setOpsLogSink((kind, level, message) => {
@@ -649,14 +649,14 @@ setOpsLogSink((kind, level, message) => {
   // 服务进程启动打点：必须在 storage.init（建表）与 sink 接线之后，否则静默失败
   recordOpsLog('ops', 'info', `服务进程启动（v${APP_VERSION}，部署/容器重建/手动重启）`);
   ctx.serverState.version = APP_VERSION;
-  log(`   ✅ 数据库就绪: ${DB_PATH}`);
-  log(`   📊 事件: ${stats.events} 条 | 好友: ${stats.friends} 位 | 世界缓存: ${stats.world_cache} 个`);
+  log(`   [成功] 数据库就绪: ${DB_PATH}`);
+  log(`   [统计] 事件: ${stats.events} 条 | 好友: ${stats.friends} 位 | 世界缓存: ${stats.world_cache} 个`);
   refreshWatchlistCache();  // 初始化 watchlist 内存缓存
 
   // 2. 初始化 API 客户端
-  log('\n🔑 初始化 API 客户端...');
+  log('\n[认证] 初始化 API 客户端...');
   if (!existsSync(CRED_FILE)) {
-    console.error('\n❌ 未找到 credentials.json — 无法登录 VRChat');
+    console.error('\n[失败] 未找到 credentials.json — 无法登录 VRChat');
     console.error('');
     console.error('   请先完成配置：');
     console.error('   1. 复制 credentials.example.json 为 credentials.json');
@@ -669,12 +669,12 @@ setOpsLogSink((kind, level, message) => {
   try {
     creds = JSON.parse(readFileSync(CRED_FILE, 'utf-8'));
   } catch (parseErr) {
-    console.error(`\n❌ credentials.json 解析失败: ${parseErr.message}`);
+    console.error(`\n[失败] credentials.json 解析失败: ${parseErr.message}`);
     console.error('   请检查文件是否为合法 JSON（参考 credentials.example.json 模板）');
     process.exit(1);
   }
   if (!creds.email || !creds.password) {
-    console.error('\n❌ credentials.json 缺少 email 或 password 字段');
+    console.error('\n[失败] credentials.json 缺少 email 或 password 字段');
     console.error('   请参考 credentials.example.json 补全配置');
     process.exit(1);
   }
@@ -694,9 +694,9 @@ setOpsLogSink((kind, level, message) => {
         return [counter - 1, counter, counter + 1].map((c) => generateTotp(secretBytes, c, { digits, algorithm }));
       };
       ctx.api.setTotpFetcher(totpFetcher);
-      log(`   🔐 TOTP 自动登录已启用（digits=${digits}, period=${period}s, ${algorithm}，前后窗口容错）`);
+      log(`   [认证] TOTP 自动登录已启用（digits=${digits}, period=${period}s, ${algorithm}，前后窗口容错）`);
     } catch (parseErr) {
-      console.error(`   ⚠️ totp_secret 解析失败（${parseErr.message}）：TOTP 自动登录不可用，将回退手动 submit_totp`);
+      console.error(`   [警告] totp_secret 解析失败（${parseErr.message}）：TOTP 自动登录不可用，将回退手动 submit_totp`);
     }
   }
 
@@ -708,7 +708,7 @@ setOpsLogSink((kind, level, message) => {
       notifyConfig = JSON.parse(readFileSync(NOTIFY_FILE, 'utf-8'));
     }
   } catch (cfgErr) {
-    console.error(`   ⚠️ notify-config.json 解析失败（${cfgErr.message}），通知已关闭`);
+    console.error(`   [警告] notify-config.json 解析失败（${cfgErr.message}），通知已关闭`);
     notifyConfig = { enabled: false };
   }
   notifier.configure(notifyConfig);
@@ -716,30 +716,30 @@ setOpsLogSink((kind, level, message) => {
     notifier.registerChannel(ch);
   }
   if (notifier.enabled) {
-    log(`   🔔 登录状态主动通知已启用（通道: ${(notifyConfig.channels || []).join(', ') || '无'}，连续失败阈值 ${notifier.config.consecutiveFailThreshold}，间隔 ${notifier.config.minIntervalSec}s）`);
+    log(`   [通知] 登录状态主动通知已启用（通道: ${(notifyConfig.channels || []).join(', ') || '无'}，连续失败阈值 ${notifier.config.consecutiveFailThreshold}，间隔 ${notifier.config.minIntervalSec}s）`);
   }
   ctx.api.loadCookieFromFile(COOKIE_FILE);
   try {
     const user = await ctx.api.ensureAuthWithAutoOtp(fetchOtpFromEmail);
     ctx.serverState.authUser = { id: user.id, displayName: user.displayName };
     ctx.serverState.needsOtp = false;
-    log(`   ✅ 已登录: ${user.displayName} (${user.id})`);
+    log(`   [成功] 已登录: ${user.displayName} (${user.id})`);
     ctx.api.saveCookieToFile(COOKIE_FILE);
   } catch (err) {
     ctx.serverState.needsOtp = false;
     ctx.serverState.needsTotp = !!err.needsTotp;
     if (err.needsTotp) {
       if (totpFetcher) {
-        log(`   ⚠️ 账号需要 TOTP 验证码：已配置自动登录，将在认证冷却后自动重试（或调用 submit_totp 手动提交）`);
+        log(`   [警告] 账号需要 TOTP 验证码：已配置自动登录，将在认证冷却后自动重试（或调用 submit_totp 手动提交）`);
         notifier.notifyAuth('needsTotp', '账号需要 TOTP 验证码（已配置自动登录，若持续失败请检查 totp_secret 或手动提交）');
       } else {
-        log(`   ⚠️ 账号启用 TOTP 两步验证：请调用 MCP 工具 submit_totp 提交当前验证码（或在 credentials.json 配置 totp_secret 启用自动登录）`);
+        log(`   [警告] 账号启用 TOTP 两步验证：请调用 MCP 工具 submit_totp 提交当前验证码（或在 credentials.json 配置 totp_secret 启用自动登录）`);
         notifier.notifyAuth('needsTotp', '账号需要 TOTP 验证码，服务暂停——请调用 submit_totp 提交当前验证码');
       }
     } else {
       notifier.notifyAuth('otpFailed', `启动登录失败：${err.message}`);
     }
-    log(`   ❌ 登录失败: ${err.message}`);
+    log(`   [失败] 登录失败: ${err.message}`);
     // 不退出进程，让 MCP/WS 服务启动以便后续重试
   }
 
@@ -749,7 +749,7 @@ setOpsLogSink((kind, level, message) => {
 
   // 4. 初始化好友状态管理器
   ctx.friendState = new FriendStateManager();
-  log(`\n👥 好友状态管理器就绪`);
+  log(`\n[好友] 好友状态管理器就绪`);
 
   // 5. 初始化事件处理管道
   ctx.eventPipeline = new EventPipeline(ctx.storage, null);
@@ -762,10 +762,10 @@ setOpsLogSink((kind, level, message) => {
   pluginLoader.watch();
   ctx.pluginLoader = pluginLoader;
   log(` 插件系统就绪`);
-  log(`📨 事件处理管道就绪`);
+  log(`[事件] 事件处理管道就绪`);
 
   // 6. 启动 WebSocket
-  log('\n🔌 启动 WebSocket 连接...');
+  log('\n[连接] 启动 WebSocket 连接...');
   ctx.wsManager = new WsManager({
     apiClient: ctx.api,
     otpFetcher: fetchOtpFromEmail,
@@ -778,14 +778,14 @@ setOpsLogSink((kind, level, message) => {
         if (ctx.watchlist.dirty) refreshWatchlistCache();
         const isWatched = ctx.watchlist.cache.some(w => w.user_id === event.userId);
         if (isWatched) {
-          log(`⭐ [关注] ${event.displayName || event.userId}: ${event.type}`);
+          log(`[追踪] [关注] ${event.displayName || event.userId}: ${event.type}`);
         }
       } catch (err) {
-        log(`⚠️ 事件处理失败: ${err.message}`);
+        log(`[警告] 事件处理失败: ${err.message}`);
       }
     },
     onStatusChange: (status) => {
-      log(`🔌 WebSocket: ${status}`);
+      log(`[连接] WebSocket: ${status}`);
       if (status === 'connected') {
         // 连接后延迟对账：先让重连突发的实时推送（上线/下线）落地，再对账补漏，避免双记
         setTimeout(() => { _refreshOnlineState().catch(() => {}); }, 25_000);
@@ -795,7 +795,7 @@ setOpsLogSink((kind, level, message) => {
             ctx.serverState.authUser = { id: res.user.id, displayName: res.displayName };
           }
         }).catch((err) => {
-          log(`⚠️ 认证复查失败: ${err.message}`);
+          log(`[警告] 认证复查失败: ${err.message}`);
         });
       }
     },
@@ -806,9 +806,9 @@ setOpsLogSink((kind, level, message) => {
   const runAutoBackup = async () => {
     try {
       const r = await ctx.storage.backup(BACKUP_DIR);
-      log(`💾 自动备份完成: ${r.path} (${r.size} bytes)`);
+      log(`[备份] 自动备份完成: ${r.path} (${r.size} bytes)`);
     } catch (e) {
-      log(`⚠️ 自动备份失败: ${e.message}`);
+      log(`[警告] 自动备份失败: ${e.message}`);
     }
   };
   runAutoBackup();
@@ -828,7 +828,7 @@ setOpsLogSink((kind, level, message) => {
   // 7b. 启动 MCP 服务
   const server = createServer();
   server.listen(PORT, HOST, () => {
-    log(`\n🚀 MCP 服务运行在 http://${HOST}:${PORT}/mcp\n`);
+    log(`\n[启动] MCP 服务运行在 http://${HOST}:${PORT}/mcp\n`);
     log('可用工具:');
     for (const t of registry.listTools()) {
       log(`  ${t.name} — ${t.description}`);
@@ -847,12 +847,12 @@ main().catch(err => {
 async function shutdown(signal) {
   recordOpsLog('ops', 'info', `服务进程停止（${signal}——容器重建/手动停止）`);
   const { wsManager, eventPipeline, storage } = ctx;
-  log(`\n⚠️ 收到 ${signal}，正在关闭...`);
+  log(`\n[警告] 收到 ${signal}，正在关闭...`);
   try {
     if (wsManager) wsManager.stop();
     if (eventPipeline) eventPipeline.flush();
     if (storage) storage.save();
-    log('✅ 已保存数据');
+    log('[成功] 已保存数据');
   } catch (e) {
     console.error('关闭时出错:', e);
   }
@@ -867,10 +867,10 @@ process.on('beforeExit', () => {
 
 // ── 全局异常兜底（防止僵尸进程 + 端口残留）──
 process.on('uncaughtException', (err) => {
-  console.error('💥 Uncaught Exception:', err);
+  console.error('[崩溃] Uncaught Exception:', err);
   shutdown('uncaughtException');
 });
 process.on('unhandledRejection', (reason) => {
-  console.error('💥 Unhandled Rejection:', reason);
+  console.error('[崩溃] Unhandled Rejection:', reason);
   shutdown('unhandledRejection');
 });

--- a/vrchat-api.js
+++ b/vrchat-api.js
@@ -110,7 +110,7 @@ export class VrchatApiClient {
 
     this._reauthInFlight = true;
     try {
-      console.log('[VRChat API] ⚠️ 请求返回 401，尝试自动重新登录...');
+      console.log('[VRChat API] [警告] 请求返回 401，尝试自动重新登录...');
       if (this.otpFetcher || this.totpFetcher) {
         await this.ensureAuthWithAutoOtp(this.otpFetcher);
       } else {
@@ -132,13 +132,13 @@ export class VrchatApiClient {
           throw err;
         }
       }
-      console.log('[VRChat API] ✅ 自动重新登录成功');
+      console.log('[VRChat API] [成功] 自动重新登录成功');
       return true;
     } catch (err) {
       if (err.needsTotp) throw err;
       // 非 TOTP 失败（网络/凭据错误等）：冷却 60s，避免高频重试
       this._reauthCooldownUntil = Date.now() + 60_000;
-      console.error(`[VRChat API] ❌ 自动重新登录失败: ${err.message}`);
+      console.error(`[VRChat API] [失败] 自动重新登录失败: ${err.message}`);
       return false;
     } finally {
       this._reauthInFlight = false;
@@ -182,7 +182,7 @@ export class VrchatApiClient {
 
       // 超时兜底：socket 半通不通（网络抖动/代理失效）时请求可能永挂不返回，
       // 若不设超时会占住 rateLimiter 队头 -> 锁死整条队列；超时 destroy 触发 error -> reject。
-      // ⚠️ 注：Node req.setTimeout 是「socket 空闲超时」(idle timeout)——仅在 socket 无任何
+      // [警告] 注：Node req.setTimeout 是「socket 空闲超时」(idle timeout)——仅在 socket 无任何
       //    活动时触发；「持续小流量但永不 end」的响应不会被它覆盖（由 rateLimiter 的
       //    任务级超时兜底，见 core/rate-limiter.js）。
       req.setTimeout(REQUEST_TIMEOUT_MS, () => {
@@ -268,7 +268,7 @@ export class VrchatApiClient {
 
     if (!cookies.auth) {
       const isLimited = r1.status === 401;
-      console.error(`[VRChat API] ❌ Login failed. Status: ${r1.status}${isLimited ? ' [限流?]' : ''}, Body: ${JSON.stringify(r1.data).slice(0, 200)}`);
+      console.error(`[VRChat API] [失败] Login failed. Status: ${r1.status}${isLimited ? ' [限流?]' : ''}, Body: ${JSON.stringify(r1.data).slice(0, 200)}`);
       const err = new Error('No auth cookie from login — check credentials or account status');
       if (isLimited) err.isRateLimited = true;
       throw err;
@@ -332,7 +332,7 @@ export class VrchatApiClient {
       });
       // 超时兜底：socket 半通不通（网络抖动/代理失效）时请求可能永挂不返回，
       // 若不设超时会占住 rateLimiter 队头 -> 锁死整条队列；超时 destroy 触发 error -> reject。
-      // ⚠️ 注：Node req.setTimeout 是「socket 空闲超时」(idle timeout)——仅在 socket 无任何
+      // [警告] 注：Node req.setTimeout 是「socket 空闲超时」(idle timeout)——仅在 socket 无任何
       //    活动时触发；「持续小流量但永不 end」的响应不会被它覆盖（由 rateLimiter 的
       //    任务级超时兜底，见 core/rate-limiter.js）。
       req.setTimeout(REQUEST_TIMEOUT_MS, () => {
@@ -375,7 +375,7 @@ export class VrchatApiClient {
       });
       // 超时兜底：socket 半通不通（网络抖动/代理失效）时请求可能永挂不返回，
       // 若不设超时会占住 rateLimiter 队头 -> 锁死整条队列；超时 destroy 触发 error -> reject。
-      // ⚠️ 注：Node req.setTimeout 是「socket 空闲超时」(idle timeout)——仅在 socket 无任何
+      // [警告] 注：Node req.setTimeout 是「socket 空闲超时」(idle timeout)——仅在 socket 无任何
       //    活动时触发；「持续小流量但永不 end」的响应不会被它覆盖（由 rateLimiter 的
       //    任务级超时兜底，见 core/rate-limiter.js）。
       req.setTimeout(REQUEST_TIMEOUT_MS, () => {
@@ -444,7 +444,7 @@ export class VrchatApiClient {
     }
 
     // Cookie expired — try re-login
-    console.log('[VRChat API] ⚠️ Auth cookie expired, attempting re-login...');
+    console.log('[VRChat API] [警告] Auth cookie expired, attempting re-login...');
     const result = await this.tryLoginWithCredentials();
     if (result.requiresOtp) {
       const err = new Error(result.message);
@@ -515,7 +515,7 @@ export class VrchatApiClient {
       const needTotp = types.includes('totp');
 
       if (needEmailOtp) {
-        console.log('[VRChat API] ⚠️ 需要邮箱验证码，自动获取中...');
+        console.log('[VRChat API] [警告] 需要邮箱验证码，自动获取中...');
         try {
           const otpCode = await otpFetcher();
           if (!otpCode || !/^\d{6}$/.test(String(otpCode))) {
@@ -526,10 +526,10 @@ export class VrchatApiClient {
           // 邮箱抓取失败：若账号也支持 TOTP，先试自动 TOTP 兜底，再转手动提交（保留 tempAuthCookie）
           if (needTotp) {
             if (this.totpFetcher) {
-              console.log('[VRChat API] ⚠️ 邮箱验证码获取失败，尝试自动 TOTP 兜底...');
+              console.log('[VRChat API] [警告] 邮箱验证码获取失败，尝试自动 TOTP 兜底...');
               try {
                 const user = await this._autoTotpLogin();
-                console.log('[VRChat API] ✅ 自动 TOTP 兜底登录成功');
+                console.log('[VRChat API] [成功] 自动 TOTP 兜底登录成功');
                 return user;
               } catch (totpErr) {
                 // 邮箱与自动 TOTP 双失败：补冷却等待下个窗口（与仅 TOTP 分支对称，审核 #70 🟡 建议 1）
@@ -553,10 +553,10 @@ export class VrchatApiClient {
 
       if (needTotp) {
         if (this.totpFetcher) {
-          console.log('[VRChat API] ⚠️ 需要 TOTP 验证码，自动生成中...');
+          console.log('[VRChat API] [警告] 需要 TOTP 验证码，自动生成中...');
           try {
             const user = await this._autoTotpLogin();
-            console.log('[VRChat API] ✅ TOTP 自动登录成功');
+            console.log('[VRChat API] [成功] TOTP 自动登录成功');
             return user;
           } catch (totpErr) {
             // 自动失败：保留 tempAuthCookie 转手动 submit_totp 兜底；冷却等待下一个 TOTP 窗口再自动重试
@@ -750,7 +750,7 @@ export class VrchatApiClient {
 
       // 超时兜底：socket 半通不通（网络抖动/代理失效）时请求可能永挂不返回，
       // 若不设超时会占住 rateLimiter 队头 -> 锁死整条队列；超时 destroy 触发 error -> reject。
-      // ⚠️ 注：Node req.setTimeout 是「socket 空闲超时」(idle timeout)——仅在 socket 无任何
+      // [警告] 注：Node req.setTimeout 是「socket 空闲超时」(idle timeout)——仅在 socket 无任何
       //    活动时触发；「持续小流量但永不 end」的响应不会被它覆盖（由 rateLimiter 的
       //    任务级超时兜底，见 core/rate-limiter.js）。
       req.setTimeout(REQUEST_TIMEOUT_MS, () => {
@@ -829,7 +829,7 @@ export class VrchatApiClient {
 
       // 超时兜底：socket 半通不通（网络抖动/代理失效）时请求可能永挂不返回，
       // 若不设超时会占住 rateLimiter 队头 -> 锁死整条队列；超时 destroy 触发 error -> reject。
-      // ⚠️ 注：Node req.setTimeout 是「socket 空闲超时」(idle timeout)——仅在 socket 无任何
+      // [警告] 注：Node req.setTimeout 是「socket 空闲超时」(idle timeout)——仅在 socket 无任何
       //    活动时触发；「持续小流量但永不 end」的响应不会被它覆盖（由 rateLimiter 的
       //    任务级超时兜底，见 core/rate-limiter.js）。
       req.setTimeout(REQUEST_TIMEOUT_MS, () => {


### PR DESCRIPTION
## 动机与背景

使用者反馈服务日志不够正式（原话：日志记录里能不能别用 emoji，正式一点）。同时排查中发现 logger 的一个多行消息缺陷：含 `\n` 的日志（如启动横幅 `log(\`\n[启动] MCP…\n\`)`）写文件后，「前缀+空正文」行会被日志页解析成**空条目**，而无前缀的续行（横幅正文、error.stack 堆栈）不匹配行格式被**整行丢弃**——日志页文件源存在静默数据丢失。

## 改动

**1. fix(logger) 多行消息按行落盘**（core/logger.js）
- text 格式文件写入路径按 `\n` 拆分、trim、滤空段，每段独立带完整前缀落盘；json 格式不受影响
- 效果：装饰性 `\n` 不再产生空条目；多行内容（含错误堆栈）在日志页可完整还原

**2. chore(log) 服务日志 emoji → 正式文字前缀**（16 文件）
- 映射：`✅→[成功]` `❌→[失败]` `⚠️→[警告]` `🔑🔐🔒🔓→[认证]` `🔄→[重连]` `⭐→[收藏]/[追踪]` `🔌→[连接]` `💾→[备份]` `🔍→[查询]` `📌→[待办]` `🗑→[删除]` `🔔→[通知]` `🖼→[头像]` `🧹→[清理]` `📦→[初始化]` `🚀→[启动]` `💥→[崩溃]` 等
- 范围：start-monitor.js、vrchat-api.js、core/（ws-manager/http-server/registry/notifier/plugin-loader/tools/*）、events/favorites/x-creators 插件
- 会随启动打印进 monitor.log 的 MCP 工具 description 中 emoji 一并清理；世界分类 cat 标签（功能数据，返回给 Agent）保持不变

## 验证

**自动化**：`npm test` 65/65 通过；16 个改动文件 `node --check` 语法全部通过。

**实测**（云端部署验证）：
- 重启后 monitor.log 新条目 **emoji 残留 0**（API 拉取 135+ 条扫描确认）、**空消息条目 0**
- 启动横幅带前缀可见：`[启动] MCP 服务运行在…` / `可用工具:` / `健康检查…`
- 运行日志前缀正常：`[追踪] 追踪非好友刷新: 8/8 位已更新`、`[重连] 刷新在线状态: 在线 N 人`、`[成功] 已连接`、`[备份] 自动备份完成`
- `/health` auth=true、ws=connected，服务无回归

> 已按仓库惯例先部署自用验证，现回馈上游。
