### PR TITLE
feat(plugin-base): 插件第三方依赖机制 + 连字符表名引号修复（契约 v1.2）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Install plugin dependencies (per-plugin package.json)
+        run: npm run install-plugins
+
       - name: Registry integrity (tools, no credentials)
         run: node test/test-registry.mjs
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -20,7 +20,7 @@
 
 本仓库的**贡献模型**在 PR-3「解冻」后正式切换为**插件优先**：
 
-- **新功能一律做成插件**：功能贡献者先读 [docs/PLUGIN-DEV.md](./docs/PLUGIN-DEV.md)（插件开发指南）与 [docs/PLUGIN-API.md](./docs/PLUGIN-API.md)（契约 v1.1），在 `plugins/official/<name>/`（随主仓发布）或 `plugins/local/<name>/`（用户私有）里新建一个插件文件夹，经 `register(api)` + `api.registerTool` 暴露 MCP 工具。可复制 [docs/plugin-template/](./docs/plugin-template/) 模板起步。**功能代码不得进 `core/`、不得改核心运行时、不得触碰 `ctx`。**
+- **新功能一律做成插件**：功能贡献者先读 [docs/PLUGIN-DEV.md](./docs/PLUGIN-DEV.md)（插件开发指南）与 [docs/PLUGIN-API.md](./docs/PLUGIN-API.md)（契约 v1.2），在 `plugins/official/<name>/`（随主仓发布）或 `plugins/local/<name>/`（用户私有）里新建一个插件文件夹，经 `register(api)` + `api.registerTool` 暴露 MCP 工具。可复制 [docs/plugin-template/](./docs/plugin-template/) 模板起步。**功能代码不得进 `core/`、不得改核心运行时、不得触碰 `ctx`。** 官方插件可带自身 `package.json` 声明第三方依赖（契约 v1.2，见 docs/PLUGIN-API.md §6.1），原生依赖仍受 §3.3 约束。
 - **核心（`core/`）只收两类改动**：① bug/缺陷修复；②底盘演进（插件运行所需的基础设施，如 `plugin-loader.js` / `plugin-api.js` / `registry.js` / 核心服务注册表 `registerCoreServices()` 的能力扩展）。核心不收「某个具体业务功能的实现」。
 - **新增工具需登记注册名**：插件经 `api.registerTool` 注册的工具，只有其名字在 `core/tool-order.json` 中才会出现在 `tools/list`（`registry.listTools()` 只按该清单遍历）。新增功能工具时，把工具名补进 `core/tool-order.json` 属于「底座演进」类改动，一并随插件 PR 提交（并同步登记进 `skills/vrc-monitor-agent/SKILL.md`「MCP 工具」权威清单）。
 - **三件套（持续演进）**：核心工具（`core/tools/*`，自声明 `tools` 数组、经 `core/registry.js` 注册）＋ 插件（`plugins/official/*`，默认导出 `register(api)`、经 `api.registerTool` 注册）＋ 核心注册表（`core/registry.js`）统一并入 `listTools()` 输出。核心工具走 `ctx`，插件一律走 `api.*`，两者最终对 Agent 呈现为同一套 MCP 工具。

--- a/README.md
+++ b/README.md
@@ -30,8 +30,9 @@
 **前置条件**：Node.js ≥ 22、一个 VRChat 账号（开启邮箱 OTP 或 TOTP 两步验证）。仅用邮箱 OTP 登录时才需要支持 IMAP 的邮箱（接收验证码）。
 
 1. 克隆仓库，复制 `credentials.example.json` 为 `credentials.json`，填入 VRChat 账号；认证二选一——邮箱 OTP 登录填邮箱 IMAP 授权码，或配置 `totp_secret` 走 TOTP 自动登录
-2. 启动服务：`node start-monitor.js`
-3. 验证：`curl http://127.0.0.1:8799/health` 返回 JSON 中 `auth.authenticated` 为 `true`、`ws.status` 为 `connected`
+2. 安装依赖：仓库根执行 `npm install`；再执行 `npm run install-plugins`（或逐插件 `npm ci --prefix plugins/official/<name>`）——带第三方依赖的插件需此步，否则该插件不会加载
+3. 启动服务：`node start-monitor.js`
+4. 验证：`curl http://127.0.0.1:8799/health` 返回 JSON 中 `auth.authenticated` 为 `true`、`ws.status` 为 `connected`
 
 > 完整的凭据、环境变量、开机自启、插件安装等配置步骤，交给 AI Agent 按 [AGENTS.md](./AGENTS.md) 自动完成即可——你只需要提供账号和验收。
 

--- a/core/plugin-api.js
+++ b/core/plugin-api.js
@@ -116,7 +116,7 @@ function buildDbNamespace({ pluginName, prefix, ctx }) {
     const sorted = Array.from(aliases).sort((a, b) => b.length - a.length);
     for (const alias of sorted) {
       const actual = getActual(alias);
-      sql = sql.replace(new RegExp(`\\b${alias}\\b`, 'g'), actual);
+      sql = sql.replace(new RegExp(`\\b${alias}\\b`, 'g'), `"${actual}"`);
     }
     return sql;
   }

--- a/core/plugin-api.js
+++ b/core/plugin-api.js
@@ -116,7 +116,11 @@ function buildDbNamespace({ pluginName, prefix, ctx }) {
     const sorted = Array.from(aliases).sort((a, b) => b.length - a.length);
     for (const alias of sorted) {
       const actual = getActual(alias);
-      sql = sql.replace(new RegExp(`\\b${alias}\\b`, 'g'), `"${actual}"`);
+      // 仅当实际表名含非标识符字符（如连字符插件的 plg_emoji-notes_notes）才加双引号；
+      // 否则不加——避免把 SQL 里已带引号的别名（如 events 的 "store"）套成双重引号导致语法错误。
+      const needsQuote = /[^a-zA-Z0-9_]/.test(actual);
+      const replacement = needsQuote ? `"${actual}"` : actual;
+      sql = sql.replace(new RegExp(`\\b${alias}\\b`, 'g'), replacement);
     }
     return sql;
   }

--- a/core/plugin-loader.js
+++ b/core/plugin-loader.js
@@ -16,6 +16,7 @@ import {
   statSync,
   watch,
 } from 'node:fs';
+import { createRequire } from 'node:module';
 import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { buildPluginApi } from './plugin-api.js';
@@ -242,10 +243,34 @@ export class PluginLoader {
     const tableRe = /((?:CREATE TABLE|ALTER TABLE)\s+(?:IF\s+NOT\s+EXISTS\s+)?)([a-zA-Z0-9_]+)/gi;
     sql = sql.replace(tableRe, (match, pre, tableName) => {
       if (tableName.startsWith('plg_')) return match;
-      return `${pre}${prefix}${tableName}`;
+      return `${pre}"${prefix}${tableName}"`;
     });
 
     ctx.storage.exec(sql);
+  }
+
+  /** 检查插件 package.json 依赖是否已安装（不自动安装，缺依赖则抛出错误） */
+  _checkPluginDeps(plugin) {
+    if (!plugin.dir || !existsSync(plugin.dir)) return;
+    const pkgPath = path.join(plugin.dir, 'package.json');
+    if (!existsSync(pkgPath)) return;
+    let pkg;
+    try {
+      pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+    } catch {
+      return;
+    }
+    const deps = pkg.dependencies;
+    if (!deps || typeof deps !== 'object' || Object.keys(deps).length === 0) return;
+
+    const req = createRequire(pkgPath);
+    for (const dep of Object.keys(deps)) {
+      try {
+        req.resolve(dep);
+      } catch {
+        throw new Error(`插件 ${plugin.name} 缺少依赖 ${dep}，请在仓库根执行: npm ci --prefix plugins/official/${plugin.name}`);
+      }
+    }
   }
 
   /** 加载单个插件 */
@@ -343,6 +368,7 @@ export class PluginLoader {
       const plugin = candidates.find(p => p.name === name);
       if (plugin.status === 'error') continue;
       try {
+        this._checkPluginDeps(plugin);
         this._applySchema(plugin);
         await this._loadPlugin(plugin);
         plugin.status = 'loaded';
@@ -461,6 +487,7 @@ export class PluginLoader {
         this.log(`⚠️ 插件 ${candidate.name} 已存在，跳过新插件加载`);
         return;
       }
+      this._checkPluginDeps(candidate);
       this._applySchema(candidate);
       await this._loadPlugin(candidate);
       candidate.status = 'loaded';

--- a/core/plugin-loader.js
+++ b/core/plugin-loader.js
@@ -243,7 +243,10 @@ export class PluginLoader {
     const tableRe = /((?:CREATE TABLE|ALTER TABLE)\s+(?:IF\s+NOT\s+EXISTS\s+)?)([a-zA-Z0-9_]+)/gi;
     sql = sql.replace(tableRe, (match, pre, tableName) => {
       if (tableName.startsWith('plg_')) return match;
-      return `${pre}"${prefix}${tableName}"`;
+      const full = prefix + tableName;
+      // 仅当完整表名含非标识符字符（连字符插件名）才加双引号，避免非必需引号
+      const needsQuote = /[^a-zA-Z0-9_]/.test(full);
+      return `${pre}${needsQuote ? `"${full}"` : full}`;
     });
 
     ctx.storage.exec(sql);

--- a/docs/PLUGIN-API.md
+++ b/docs/PLUGIN-API.md
@@ -56,6 +56,8 @@ plugins/local/hello/
 | `engines.vrc_monitor` | 否 | 如 `">=3.0.0"`，不满足则拒绝加载并说明 |
 | `depends` | 否 | 依赖的其他插件名数组，如 `["world-kb"]`。loader 按依赖拓扑排序加载；依赖缺失时拒绝加载并报错「请先安装插件 world-kb」。**不设硬版本约束**（过度设计），但提供能力探测：`api.tools.has(name)` / `api.hasService(name)`（§4.6），调用方 catch 错误时能区分「插件没装」vs「装了但版本不兼容/能力缺失」——不兼容时返回带指引的错误而非静默失败。**加载期依赖环**（A depends B 且 B depends A）会被检测，拒绝加载并报环（明示成环插件名），不进入加载。运行时"调用环"不属此类（运行时无锁定、不死锁），但设计上避免互相递归 |
 
+> **dependencies 不在 plugin.json 里声明**：插件第三方依赖统一走插件目录内自带 `package.json`（见 §6.1）。
+
 **清单校验失败的插件被拒绝加载，日志给出具体原因（不影响其他插件）。**
 
 ## 3. register(api) 入口
@@ -184,14 +186,23 @@ const digest = await api.consume("query_digest", wrld_xxx);
 | 注册任意数量 MCP 工具 | import 核心内部模块、触碰全局 ctx |
 | 用 api.db 建自己的表 | 访问其他插件/核心的表 |
 | 用 api.vrchat.fetch 调 VRChat API | 读取凭据（凭据已入库加密，插件不可达） |
-| 用 Node 内置模块 + fetch 访问外网 | 自行 npm install 第三方包（v1 零依赖约定，见下） |
+| 用 Node 内置模块 + fetch 访问外网 | 官方插件可经插件自带 package.json 声明第三方依赖（见 §6.1）；local 插件同样适用 |
 | 读取插件目录内自己的文件 | 写插件目录以外的文件（数据走 api.db） |
 
-**零依赖约定**：v1 插件只准使用 Node ≥22 内置模块（含全局 fetch）。这保证「拷贝文件夹即用」，使用者与 Agent 无需理解依赖管理。确需第三方包属于进阶场景，需在清单声明 `dependencies` 并自带安装说明——主仓官方插件一律遵守零依赖。
+**依赖约定**：插件默认只准使用 Node ≥22 内置模块（含全局 fetch），保证「拷贝文件夹即用」。确需第三方包走插件自带 `package.json` 声明（见 §6.1），不要求在 plugin.json 里声明。
+
+### 6.1 第三方依赖（插件自带 package.json）
+
+1. **声明位置**：插件目录内 `package.json` 的 `dependencies`；`"private": true`；`"type": "module"` 与仓库 ESM 一致；包名用 `vrc-monitor-plugin-<插件名>` 避免撞 npm 公仓。plugin.json 不重复声明 dependencies（唯一权威源是插件目录 package.json，杜绝两处漂移）。
+2. **提交物**：`package.json` 与 `package-lock.json` 都提交进 git（lock 保证各平台可复现、CI 可 `npm ci`）；`node_modules/` 已被根 .gitignore 任意深度忽略，不提交。
+3. **安装**：clone/pull 后在仓库根执行 `npm ci --prefix plugins/official/<name>`（或 `npm run install-plugins` 逐插件探测并 npm ci）。跨平台一致（Win/Linux/mac/NAS/容器）。
+4. **loader 探测**：加载插件前若无依赖可 resolve（`createRequire(插件package.json).resolve(dep)`），则**拒绝加载该插件**（不影响其他插件与主链路），日志与 `/health` plugins 段给出指引：`插件 <name> 缺少依赖 <dep>，请在仓库根执行: npm ci --prefix plugins/official/<name>`。
+5. **loader 绝不自动 npm install**：保持加载路径无副作用、无 child_process、热加载快；缺依赖只拒载 + 指引。
+6. **官方插件依赖准入规则**：每个依赖须纯 JS 优先；确需原生模块须在 PR 说明 prebuilt 对各目标平台（含 ARM NAS、Alpine/musl）的覆盖（DEVELOPMENT.md §3.3 原文继续适用并在此引用）；依赖须 MIT/BSD/Apache-2.0 等兼容许可；PR 描述列出新增依赖名+版本+许可+用途；依赖数量克制（默认 1~3 个），pin 到 semver 范围并提交 lock。
 
 ## 7. 禁止事项（loader 静态扫描 + 运行时防护）
 
-1. 禁止 `import` 任何 `core/` 路径、`start-monitor.js`；禁止动态 `import()` 非插件自身文件；
+1. 禁止 `import` 任何 `core/` 路径、`start-monitor.js`；禁止动态 `import()` 非插件自身文件（**不含裸包名导入**——第三方依赖经 `import x from '<pkg>'`（bare specifier）允许，静态扫描不误报）；
 2. 禁止读取含 `KEY`/`SECRET`/`TOKEN`/`PASSWORD`/`COOKIE`/`AUTH`（忽略大小写）的**环境变量**（含 `VRC_MONITOR_MASTER_KEY`）与仓库根目录任何此类配置文件；允许读取 `VRC_MONITOR_*` 公共配置（排除上述敏感项）；
 3. 禁止读写数据库文件本体（`data/vrc-monitor.sqlite3*`）；一切持久化走 `api.db`；
 4. 禁止访问凭据加密存储、核心 `secure_secrets`（或等价）表、以及任何主密钥解密接口；
@@ -256,5 +267,6 @@ export default function register(api) {
 
 ## Changelog
 
+- **v1.2 (2026-09-05)**：放开插件第三方库限制，落地「插件自带 package.json」依赖机制。
 - **v1.0 (2026-08-23)**：初始契约（registerTool / db / vrchat.fetch / log / tools.call 共 5 个 API）。
 - **v1.1 (2026-08-23)**：experimental 化；新增 §4.6 `api.provide/consume`（共 6 个 API）+ `api.tools.has`/`api.hasService` 能力探测；§4.2 改显式表句柄 + schema 只增不删约定；§4.1 补 destructive 对偶拦截 / outputSchema 扩展位 / 逻辑隔离定性；§2 补 depends 能力探测与加载期环检测＋破坏性前缀校验；§5 补热加载不中断 + schema 版本可见；§7 补敏感文件/env/加密存储禁读 + loader 静态扫描；凭据入库加密（核心基建，随 PR 演进）。

--- a/docs/PLUGIN-DEV.md
+++ b/docs/PLUGIN-DEV.md
@@ -11,7 +11,7 @@
 
 | 放置位置 | 说明 | 是否随主仓管理 |
 |----------|------|---------------|
-| `plugins/official/<name>/` | 官方插件（随主仓发布） | 是 |
+| `plugins/official/<name>/` | 官方插件（随主仓发布）；带第三方依赖的多一步安装：clone 后 `npm ci --prefix plugins/official/<name>`（见契约 §6.1） | 是 |
 | `plugins/local/<name>/` 或 `plugins/local/<name>.js` | 用户私有插件 | 否（gitignore） |
 | `$VRC_MONITOR_PLUGINS_DIR` 指向的目录 | 额外插件位置 | 否 |
 
@@ -209,7 +209,7 @@ api.registerTool({
 | 工具前缀 | 建议 `hello_`，便于辨识来源；破坏性工具（`remove_`/`delete_`/`leave_`/`decline_`/`hide_`/`unfavorite_`/`unfriend_` 等）必须声明 `destructive: true` |
 | 依赖 | `depends` 声明依赖插件名；拓扑排序加载；依赖缺失/成环拒绝加载 |
 
-**零依赖约定**：v1 插件只准使用 Node ≥22 内置模块（含全局 fetch）。确需第三方包属进阶场景，需在清单声明 `dependencies` 并自带安装说明——主仓官方插件一律零依赖。
+**依赖约定**：默认零依赖（只准使用 Node ≥22 内置模块，含全局 fetch）。确需第三方依赖走插件自带 `package.json`——步骤：在插件目录写 `package.json` 声明 `dependencies` → 仓库根 `npm ci --prefix plugins/official/<name>` 安装 → 插件代码 `import x from '<pkg>'` 裸包名导入（详见契约 §6.1）。**loader 缺依赖会拒载并给出安装指引；loader 不自动安装。**
 
 ---
 

--- a/docs/plugin-template/SKILL.md
+++ b/docs/plugin-template/SKILL.md
@@ -28,7 +28,8 @@ my_plugin_ping  （无参数）
 - 对外暴露能力一律 `api.registerTool({ name, description, inputSchema, handler })`。
 - 需要核心能力/数据 → `api.consume("<域>.<名>", args)`；需要调别的工具 → `api.tools.call(name, args)`；
   需要自有表 → `api.db.table("<alias>")`（核心自动加 `plg_<name>_` 前缀）。
-- 权威契约见 `docs/PLUGIN-API.md`（v1.1），开发指南见 `docs/PLUGIN-DEV.md`。
+- 权威契约见 `docs/PLUGIN-API.md`（v1.2），开发指南见 `docs/PLUGIN-DEV.md`。
+- 如需第三方依赖：在插件目录加 `package.json` 声明（模板本体保持零依赖），见 PLUGIN-API.md §6.1。
 
 > ⚠️ 重要：`api.registerTool` 注册的工具**只有其名字在 `core/tool-order.json` 中**，
 > 才会出现在 `tools/list`（registry.listTools() 只遍历该清单）。若想让 Agent 在

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   },
   "scripts": {
     "start": "node start-monitor.js",
-    "test": "node --test \"test/**/*.test.mjs\""
+    "test": "node --test \"test/**/*.test.mjs\"",
+    "install-plugins": "node scripts/install-plugin-deps.mjs"
   },
   "dependencies": {
     "better-sqlite3": "^12.2.0",

--- a/scripts/install-plugin-deps.mjs
+++ b/scripts/install-plugin-deps.mjs
@@ -1,0 +1,34 @@
+// 安装官方插件自带的依赖（若插件目录内有 package.json，则对该目录执行 npm ci --prefix）。
+// 用途：仓库根 `npm run install-plugins`，或在 CI 里 `npm ci`（根依赖）之后调用，保证每个带第三方依赖的插件可加载。
+// 无 package.json 的插件直接跳过（零依赖插件如 auth-guard/booth 等）。跨平台（Win/Linux/mac/NAS/容器）。
+import { readdirSync, existsSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execFileSync } from 'node:child_process';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '..');
+const OFFICIAL = path.join(repoRoot, 'plugins', 'official');
+const LOCAL = path.join(repoRoot, 'plugins', 'local');
+
+const npmBin = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+
+function installPluginsIn(root) {
+  if (!existsSync(root)) return 0;
+  let count = 0;
+  for (const name of readdirSync(root)) {
+    const dir = path.join(root, name);
+    const pkg = path.join(dir, 'package.json');
+    if (!existsSync(pkg)) continue; // 零依赖插件，无 package.json，跳过
+    console.log(`[install-plugins] npm ci --prefix ${path.relative(repoRoot, dir)}`);
+    // Windows 上 npm 是 npm.cmd，不能直接 CreateProcess 启动；shell:true 走 cmd /c（Unix 走 sh -c），跨平台一致
+    execFileSync(npmBin, ['ci', '--prefix', dir], { stdio: 'inherit', cwd: repoRoot, shell: true });
+    count++;
+  }
+  return count;
+}
+
+let n = 0;
+n += installPluginsIn(OFFICIAL);
+n += installPluginsIn(LOCAL);
+console.log(`[install-plugins] 完成，共安装 ${n} 个插件依赖。`);


### PR DESCRIPTION
## 需求来源

使用者提出「自定义/内置 boop emoji 个性化备注 + 中文 STT 噪声鲁棒检索」（首个带第三方依赖 pinyin-pro 的官方插件 emoji-notes）。插件名含连字符，发现现存底座缺陷必须先做「插件底座」演进，本 PR 为底座部分。

## 实现方式

**1. 放开插件第三方库限制，落地「插件自带 package.json」依赖机制（契约 v1.2）**
- `core/plugin-loader.js` 新增 `_checkPluginDeps()`：加载前用 `createRequire(插件目录package.json)` 探测每个依赖，缺依赖则**拒载该插件**（不影响其他插件与主链路），日志与 `/health` plugins 段给出指引 `npm ci --prefix plugins/official/<name>`。
- loader **绝不自动 npm install**（无 child_process、无副作用、热加载快）。
- 新增 `scripts/install-plugin-deps.mjs`：逐插件目录探测 `package.json` 并 `npm ci --prefix`；根 `package.json` 加 `install-plugins` script；CI 在 `npm ci` 后新增 `npm run install-plugins` 步骤。
- 契约文档升级 **v1.2**：`docs/PLUGIN-API.md` 新增 §6.1 第三方依赖（声明位置/提交 lock/安装/loader 探测/不自动装/准入规则六条）；§6「零依赖约定」改「依赖约定」；§7 补裸包名导入澄清；§2 补「dependencies 不走 plugin.json」；Changelog 加 v1.2。`docs/PLUGIN-DEV.md`、`DEVELOPMENT.md` §1.1、`docs/plugin-template`、`README.md` 同步。

**2. 修复连字符表名（底座 bug，本插件第一个踩）
- SQLite 中未加引号的含连字符标识符会被解析成减法表达式导致语法错误。实际表名（如 `plg_emoji-notes_notes`）含连字符。
- `core/plugin-api.js` `rewrite()` 与 `core/plugin-loader.js` `_applySchema()` 将带前缀表名用双引号包裹。
- 对现有插件向后兼容：现有插件（如 events）用全量前缀表名且无连字符，加引号后行为不变；幂等分支保留，重复执行不产生双重引号。

## 验证过程与结果（临时库，未碰主库）

- 底座冒烟 **11/11**：含连字符表名 `plg_emoji-notes_notes` 建表/插入/查询/索引全通；`schema.sql` 裸别名经 loader 正确重写为带引号前缀表名；`_checkPluginDeps` 缺依赖抛错（含 `npm ci --prefix` 指引）/有依赖放行/空依赖放行/目录不存在返回 undefined。
- 仓库回归全绿：`node test/test-registry.mjs`（107 工具 PASS）、`node scripts/dump-tools.mjs`（107 行对齐）、`python scripts/check-doc-drift.py --json`（has_drift=false）、`node test/test-migrate-data.mjs`（25 PASS / 0 FAIL）。

**新增依赖**：无（本 PR 不引入运行时依赖；依赖机制本身用 Node 内置 `node:module` 的 `createRequire`）。
