### PR TITLE
fix: fix security issue in plugin_api.py

### DIFF
--- a/hermes-plugin/dashboard/plugin_api.py
+++ b/hermes-plugin/dashboard/plugin_api.py
@@ -80,11 +80,11 @@ def get_config() -> Dict[str, Any]:
     try:
         return {
             "ok": True,
-            "monitor_dir": pm._resolve_monitor_dir(),
+            "monitor_dir_configured": pm._resolve_monitor_dir() is not None,
             "node_exe": pm._resolve_node_exe(),
-            "env_monitor_dir": os.environ.get("VRC_MONITOR_DIR"),
+            "env_monitor_dir_set": bool(os.environ.get("VRC_MONITOR_DIR")),
             "env_node_exe": os.environ.get("VRC_MONITOR_NODE"),
-            "config_file": str(pm._config_path()),
+            "config_file_exists": pm._config_path().is_file(),
         }
     except Exception:
         logger.exception("get_config failed")
@@ -105,7 +105,7 @@ def get_doctor() -> Dict[str, Any]:
         checks.append({
             "name": "服务目录",
             "ok": monitor_dir is not None,
-            "detail": monitor_dir if monitor_dir else "未找到服务目录：请设置环境变量 VRC_MONITOR_DIR 指向克隆的仓库目录，或参考仓库 AGENTS.md 配置",
+            "detail": "已解析" if monitor_dir else "未找到服务目录：请设置环境变量 VRC_MONITOR_DIR 指向克隆的仓库目录，或参考仓库 AGENTS.md 配置",
         })
 
         checks.append({
@@ -120,7 +120,7 @@ def get_doctor() -> Dict[str, Any]:
             checks.append({
                 "name": "凭据文件",
                 "ok": cred_ok,
-                "detail": f"credentials.json {'存在' if cred_ok else '不存在'}，位于 {monitor_dir}",
+                "detail": f"credentials.json {'存在' if cred_ok else '不存在'}",
             })
         else:
             checks.append({
@@ -135,7 +135,7 @@ def get_doctor() -> Dict[str, Any]:
             "ok": all_ok,
             "checks": checks,
             "resolved": {
-                "monitor_dir": monitor_dir,
+                "monitor_dir_configured": monitor_dir is not None,
                 "node_exe": node_exe,
             },
         }

--- a/hermes-plugin/dashboard/plugin_api.py
+++ b/hermes-plugin/dashboard/plugin_api.py
@@ -199,8 +199,6 @@ def get_credentials() -> Dict[str, Any]:
             "ok": True,
             "configured": configured,
             "email_masked": email_masked,
-            "monitor_dir": monitor_dir,
-            "config_path": str(cred_path) if cred_path else None,
         }
     except Exception:
         logger.exception("get_credentials failed")


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `hermes-plugin/dashboard/plugin_api.py`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-002 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-002` |
| **File** | `hermes-plugin/dashboard/plugin_api.py:178` |
| **Assessment** | Likely exploitable |
| **Chain Complexity** | 2-step |

**Description**: The GET /credentials endpoint returns credential file existence status, masked email addresses, monitor directory paths, and the full filesystem path to credentials.json without any authentication. This information enables attackers to locate and target credential files for theft.

## Evidence

**Scanner confirmation**: multi_agent_ai rule `V-002` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Threat Model Context

This is a private Node.js application (not published to npm). Vulnerabilities affect this application's own runtime only.

## Changes
- `hermes-plugin/dashboard/plugin_api.py`

## Update (review follow-up)

`nixi-agent`'s review pointed out the first commit only removed `monitor_dir`/`config_path` from `GET /credentials`, but the same router's `GET /config` and `GET /doctor` still returned the identical monitor-dir path and the `credentials.json` location — the disclosure surface wasn't actually closed, just moved. A second commit scrubs the same information from those two endpoints as well (raw paths replaced with boolean `*_configured`/`*_exists` signals), so all three endpoints in this file are now consistent with the V-002 fix. `node_exe`'s path is intentionally left as-is — it isn't part of V-002's threat model (credential file location), and no consumer treats it as sensitive.

The broader point the reviewer raised — that this whole router (`POST /credentials`, `/start`, `/stop`, `/restart`) has no authentication at all — is real but out of scope for this fix: enforcing auth would need to happen in the external Hermes Gateway host that mounts this plugin, which isn't part of this repository. Tracked separately in #144.

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path. No in-repo consumer (`desktop/plugin.js`) reads any of the removed/changed fields — verified by grep.

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*

<!-- orbis-meta: rule=V-002 scanner=multi_agent_ai -->

