### PR TITLE
fix(auth): 裸域名访问根路径 401 JSON → 重定向 /dashboard

### DIFF
--- a/plugins/official/auth-guard/index.js
+++ b/plugins/official/auth-guard/index.js
@@ -65,11 +65,16 @@ export default function register(api) {
 
   // ── 1. 提供全局 http.authenticate 服务 ──
   api.provide('http.authenticate', (req) => {
-    // 页面入口豁免：/dashboard 前缀（单文件 HTML + legacy 静态资源 vendor/*，均无敏感数据，
-    // 数据全靠前端 JS 调 API 加载）——无 token 也放行让前端显示登录页（LoginView）；
+    // 页面入口豁免：根路径 /（配合 web-dashboard 的 302 重定向到 /dashboard）与 /dashboard 前缀
+    // （单文件 HTML + legacy 静态资源 vendor/*，均无敏感数据，数据全靠前端 JS 调 API 加载）——
+    // GET/HEAD 无 token 也放行让前端显示登录页（LoginView）；
     // API 路径(/api//health/mcp)仍严格鉴权。图片代理豁免：<img> 无法带 Authorization header，只服务白名单公图。
     try {
       const pathname = new URL(req.url || '', 'http://localhost').pathname;
+      // 根路径豁免（GET/HEAD）：配合 web-dashboard 的 GET / → 302 /dashboard 重定向，裸域名访问不再返回裸 401 JSON
+      if ((req.method === 'GET' || req.method === 'HEAD') && pathname === '/') {
+        return { ok: true, enabled: true };
+      }
       if (req.method === 'GET' && (pathname === '/dashboard' || pathname.startsWith('/dashboard/'))) {
         return { ok: true, enabled: true };
       }

--- a/plugins/official/web-dashboard/index.js
+++ b/plugins/official/web-dashboard/index.js
@@ -74,6 +74,14 @@ export default function register(api) {
   const { homeFavorites: homeFavCache } = dashboardState;
   const HOME_FAV_TTL = CACHE_TTLS.homeFavorites;
 
+  // 根路径 → /dashboard（裸域名访问不再看到 401 JSON；auth-guard 已豁免 GET/HEAD /）
+  const rootRedirect = async (_req, res) => {
+    res.writeHead(302, { Location: '/dashboard' });
+    res.end();
+  };
+  api.http.registerRoute({ method: 'GET', path: '/', handler: rootRedirect });
+  api.http.registerRoute({ method: 'HEAD', path: '/', handler: rootRedirect });
+
   api.http.registerRoute({
     method: 'GET',
     path: '/dashboard',

--- a/test/test-auth-guard.mjs
+++ b/test/test-auth-guard.mjs
@@ -93,6 +93,7 @@ console.log('\n── 3. 端到端测试: HTTP 鉴权中间件 ──');
   ctx.rateLimiter = new RateLimiter();
   ctx.serverState = { started: Date.now(), authUser: { id: 'usr_test', displayName: 'tester' }, needsOtp: false, needsTotp: false };
   ctx.paths = { PORT: 0, HOST: '127.0.0.1' };
+  ctx.httpRoutes = new Map();
 
   // 模拟 pluginLoader
   const services = new Map();
@@ -107,7 +108,14 @@ console.log('\n── 3. 端到端测试: HTTP 鉴权中间件 ──');
     hasService: (name) => services.has(name),
     registerTool: () => {},
     log: () => {},
+    // 模拟 api.http.registerRoute（web-dashboard 等插件注册 HTTP 路由用）
+    http: { registerRoute: (r) => ctx.httpRoutes.set(`${r.method} ${r.path}`, r) },
   };
+  // 模拟 web-dashboard 注册的根路径重定向（GET/HEAD / → 302 /dashboard）与面板页面路由
+  const rootRedirect = (_req, res) => { res.writeHead(302, { Location: '/dashboard' }); res.end(); };
+  mockApi.http.registerRoute({ method: 'GET', path: '/', handler: rootRedirect });
+  mockApi.http.registerRoute({ method: 'HEAD', path: '/', handler: rootRedirect });
+  mockApi.http.registerRoute({ method: 'GET', path: '/dashboard', handler: (_req, res) => { res.writeHead(200, { 'Content-Type': 'text/html' }); res.end('<html>dashboard</html>'); } });
   registerAuthGuard(mockApi);
 
   ctx.pluginLoader = {
@@ -125,7 +133,7 @@ console.log('\n── 3. 端到端测试: HTTP 鉴权中间件 ──');
       const req = http.request('http://127.0.0.1:' + port + path, options, (res) => {
         let data = '';
         res.on('data', (c) => data += c);
-        res.on('end', () => resolve({ status: res.statusCode, data }));
+        res.on('end', () => resolve({ status: res.statusCode, data, headers: res.headers }));
       });
       req.on('error', reject);
       if (options.body) req.write(options.body);
@@ -180,6 +188,17 @@ console.log('\n── 3. 端到端测试: HTTP 鉴权中间件 ──');
   res = await request('/mcp?token=' + TEST_TOKEN);
   assert.equal(res.status, 200);
   ok('携带正确 URL Query ?token=... 成功访问 /mcp 与 /health');
+
+  // 3.2.7 根路径豁免（PR #150）：GET/HEAD / → 302 /dashboard（无 token 也不返回 401）
+  res = await request('/');
+  assert.equal(res.status, 302, '配置 Token 时 GET / 豁免放行（不返回 401）');
+  assert.equal(res.headers.location, '/dashboard', '302 重定向到 /dashboard');
+  res = await request('/', { method: 'HEAD' });
+  assert.equal(res.status, 302, 'HEAD / 同样豁免放行');
+  assert.equal(res.headers.location, '/dashboard', 'HEAD 302 重定向到 /dashboard');
+  res = await request('/dashboard');
+  assert.equal(res.status, 200, '/dashboard 页面豁免回归正常');
+  ok('根路径 GET/HEAD / 豁免 → 302 /dashboard，页面豁免回归正常');
 
   // 清理测试环境
   delete process.env.VRC_MONITOR_AUTH_TOKEN;


### PR DESCRIPTION
## fix(auth): 裸域名访问根路径返回 401 JSON → 重定向到 /dashboard

### 背景
使用者反馈：裸输入域名（如 `https://host/`，不带 `/dashboard` 路径）看到的是
`{"error":"Unauthorized","message":"未提供访问令牌…"}` 裸 JSON，没有任何引导。

### 根因
auth-guard 的页面豁免只放行 `/dashboard` 前缀（GET），根路径 `/` 不在豁免列表，
被 API 鉴权拦截直接返回 401 JSON——而根路径是用户最自然的入口。

### 修复（2 文件，各几行）
- `plugins/official/auth-guard/index.js`：页面豁免增加 **GET /**（精确匹配）——配合重定向放行
- `plugins/official/web-dashboard/index.js`：注册 **GET / → 302 /dashboard**，
  裸域名访问自动进入登录页/面板

### 验证
- 后端测试 65/65、`node --check` 通过
- 实测：`GET /` → 302 Location: /dashboard；`/dashboard` → 200 登录页；
  `GET /api/dashboard/feed`（无 token）→ 401（**API 鉴权不受影响**）
- 已云端部署自用验证
