### PR TITLE
fix(dashboard): recentWorlds 补名负缓存占位加 24h TTL——瞬时失败可自愈重试

### DIFF
--- a/core/dashboard-services.js
+++ b/core/dashboard-services.js
@@ -632,16 +632,27 @@ export function registerDashboardServices(loader, ctx) {
     if (cur) { cur.end = cur.lastSeen; addMin(cur); }
     // 补名：world_cache 无记录（事件与缓存皆无名字）的世界，fire-and-forget 走 dashboard.world
     // （自带限流+10s 超时+upsert 缓存）拉取资料落库——本次响应不阻塞，下次查询即有名字。
-    // 触发频率受限：仅 world_cache 无记录且缺名字的世界触发；补名失败（404/私有/不可见）时
-    // upsert 空名占位走 emptyWorldIds 既有冷却机制，避免对同一批不可见世界每次查询重复发起 API 尝试。
+    // 触发频率受限：仅 world_cache 无记录、或空名占位已超 TTL 的世界触发；补名失败（404/私有/
+    // 不可见/瞬时超时）时 upsert 空名占位（负缓存，updated_at 刷新）走 emptyWorldIds 既有冷却
+    // 机制——TTL（24h）内不再对同一世界重复发起 API 尝试，超时自动放行一次重试（瞬时失败可自愈）。
     const worldSvc = loader.services.get('dashboard.world');
+    const EMPTY_PLACEHOLDER_TTL_MS = 24 * 60 * 60 * 1000;
     for (const w of worlds) {
-      if (!w.worldName && String(w.worldId).startsWith('wrld_') && worldSvc && !ctx.storage.getWorldName(w.worldId)) {
-        Promise.resolve(worldSvc({ worldId: w.worldId }))
-          .then((r) => {
-            if (!r || !r.name) ctx.storage.upsertWorld({ worldId: w.worldId, name: '' }); // 不可见/失败 → 空名占位（负缓存）
-          })
-          .catch(() => { /* 补名失败静默 */ });
+      if (!w.worldName && String(w.worldId).startsWith('wrld_') && worldSvc) {
+        const cached = ctx.storage.getWorldName(w.worldId);
+        let placeholderAge = NaN;
+        if (cached && !cached.name) {
+          // updated_at 为 SQLite datetime('now')（UTC 无时区串），补 Z 按 UTC 解析
+          placeholderAge = Date.now() - Date.parse(String(cached.updated_at || '').replace(' ', 'T') + 'Z');
+        }
+        const placeholderExpired = cached && !cached.name && (Number.isNaN(placeholderAge) || placeholderAge >= EMPTY_PLACEHOLDER_TTL_MS);
+        if (!cached || placeholderExpired) {
+          Promise.resolve(worldSvc({ worldId: w.worldId }))
+            .then((r) => {
+              if (!r || !r.name) ctx.storage.upsertWorld({ worldId: w.worldId, name: '' }); // 不可见/失败 → 空名占位（负缓存）
+            })
+            .catch(() => { /* 补名失败静默 */ });
+        }
       }
     }
     return worlds.map((w) => ({ ...w, visits: segCount.get(w.worldId) || 0, minutes: minutes.get(w.worldId) || 0 }));  // 保持数组契约（路由层再包 {worlds: [...]}）；visits 统一为进入段数

--- a/test/test-dashboard-services.test.mjs
+++ b/test/test-dashboard-services.test.mjs
@@ -453,6 +453,67 @@ test('dashboard.notificationEvents 群组通知提取 groupName（ownerName/owne
   assert.equal(boop.groupName, '', '非群组通知 groupName 应为空（title 兜底限定 group.*），实际: ' + JSON.stringify(boop.groupName));
 });
 
+// ── recentWorlds 世界补名负缓存 TTL（审者建议后续优化：占位无 TTL 导致瞬时失败永不自愈）──
+// 语义：无 world_cache 记录 → 触发补名；空名占位在 24h TTL 内 → 抑制（零新增 API 尝试）；
+// 占位超 TTL → 放行一次重试；失败写占位刷新 updated_at（续期冷却）；成功落真名自愈。
+const ttlWorld = (id) => `wrld_ttl-${id}-0000-0000-0000-000000000000`;
+const insertNamelessLocation = (worldId) => ctx.storage.insertEvent({
+  type: 'user-location', userId: 'usr_ttl', displayName: '我',
+  contentJson: { location: worldId + ':1' }, worldId, worldName: '',
+  createdAt: new Date().toISOString(), source: 'ws',
+});
+const upsertPlaceholder = (worldId, ageExpr) => ctx.storage.run(
+  `INSERT OR REPLACE INTO world_cache (world_id, name, updated_at) VALUES ('${worldId}', '', ${ageExpr})`
+);
+const placeholderUpdatedAt = (worldId) => {
+  const r = ctx.storage.query(`SELECT updated_at AS u FROM world_cache WHERE world_id=$w`, { $w: worldId });
+  return r[0] ? r[0].u : null;
+};
+const flushMicrotasks = () => new Promise((r) => setTimeout(r, 0));
+
+test('recentWorlds 补名：无占位触发 / TTL 内抑制 / 超 TTL 重试 / 失败续期 / 成功自愈', async () => {
+  // ① 无记录 → 触发补名 1 次，成功落真名后不再触发
+  const wA = ttlWorld('a');
+  insertNamelessLocation(wA);
+  let callsA = 0;
+  loader.services.set('dashboard.world', (args) => {
+    callsA++;
+    ctx.storage.upsertWorld({ worldId: args.worldId, name: '真名世界A' });
+    return { name: '真名世界A' };
+  });
+  services.get('dashboard.recentWorlds')({ limit: 60 });
+  assert.equal(callsA, 1, '无占位世界应触发补名 1 次');
+  await flushMicrotasks();
+  assert.equal(ctx.storage.getWorldName(wA)?.name, '真名世界A', '补名成功应落真名');
+  services.get('dashboard.recentWorlds')({ limit: 60 });
+  assert.equal(callsA, 1, '落真名后不应再次触发');
+
+  // ② 空名占位在 TTL 内（5 分钟前）→ 抑制，零新增 API 调用
+  const wB = ttlWorld('b');
+  insertNamelessLocation(wB);
+  upsertPlaceholder(wB, `datetime('now','-5 minutes')`);
+  let callsB = 0;
+  loader.services.set('dashboard.world', (args) => { callsB++; return null; });
+  services.get('dashboard.recentWorlds')({ limit: 60 });
+  assert.equal(callsB, 0, 'TTL 内空名占位应抑制补名（负缓存生效）');
+
+  // ③ 占位超 TTL（25 小时前）→ 放行重试 1 次；失败写占位刷新 updated_at（续期冷却）
+  const wC = ttlWorld('c');
+  insertNamelessLocation(wC);
+  upsertPlaceholder(wC, `datetime('now','-25 hours')`);
+  let callsC = 0;
+  loader.services.set('dashboard.world', (args) => { callsC++; return null; }); // 补名失败（API 不可见）
+  services.get('dashboard.recentWorlds')({ limit: 60 });
+  assert.equal(callsC, 1, '超 TTL 占位应放行一次重试');
+  await flushMicrotasks();
+  const refreshed = placeholderUpdatedAt(wC);
+  const oneMinuteAgoUtc = new Date(Date.now() - 60000).toISOString().replace('T', ' ').slice(0, 19);
+  assert.ok(refreshed && refreshed >= oneMinuteAgoUtc,
+    `失败后占位 updated_at 应刷新（续期），实际 ${refreshed}`);
+  services.get('dashboard.recentWorlds')({ limit: 60 });
+  assert.equal(callsC, 1, '刷新后的占位在 TTL 内不应再次触发');
+});
+
 // ── 清理 ──
 after(() => {
   for (const f of [tmpDb, tmpDb + '-wal', tmpDb + '-shm']) { try { rmSync(f, { force: true }); } catch {} }


### PR DESCRIPTION
## 需求来源

#152 复核（CyberNekokoya，00:47Z）💡 后续优化①：补名失败写空名占位后**无 TTL**——当前对一切静默失败（含瞬时网络/超时/限流拒绝）都写永久占位，自动补名不再自愈重试；此前瞬时失败可在下次查询自动补上。建议给占位加时间戳 + TTL（如 24h 后允许重试一次），或仅对「明确 404/私有不可见」写永久占位、其余失败写短 TTL 占位。

## 实现方式

复用 `world_cache.updated_at`（`upsertWorld` ON CONFLICT 时刷新为 `datetime('now')`），**零 schema 变更、零迁移**：

- 触发条件收紧为三态：`world_cache` 无行 → 补名；空名占位行且 **updated_at 距今 < 24h** → 抑制（负缓存生效，零新增 API 调用）；空名占位行且 **超 24h**（或 updated_at 解析异常，NaN 保守放行防永久卡死）→ 放行一次重试。
- 重试失败 → 再次 `upsertWorld({ name: '' })` 刷新占位（updated_at 续期，重新进入 24h 冷却）；成功 → 真名覆盖占位，自愈完成。
- `updated_at` 为 SQLite `datetime('now')` UTC 无时区串，解析时补 `Z` 按 UTC 处理（同 ui/src/utils.js parseTs 口径）。
- 频率上限：每世界每 24h 至多 1 次额外尝试，叠加 dashboard.world 既有 rateLimiter（2.6s 间隔 + maxQueue 50 + 10s 超时），无配额风险；`emptyWorldIds` 显式 forceRefresh 通道不受影响。

## 验证过程与结果

- 新增 4 场景回归测试（test-dashboard-services.test.mjs）：① 无占位触发补名且落真名后不再触发；② 空名占位 5 分钟前（TTL 内）→ **零 API 调用**；③ 占位 25 小时前（超 TTL）→ 放行重试 1 次；④ 补名失败后占位 updated_at 刷新（续期），刷新后不再触发。
- dashboard 专项 **21/21**、全量后端 **67/67**、registry 完整性 **108/108 PASS**、`check-doc-drift` has_drift=false。
- 已部署生产自用（core/ 全量同步，`dashboard-services.js` 含本改动）：health ok / WS connected / 工具注册正常，运行正常。
- 纯后端改动（core/dashboard-services.js + test），无 dist、无文档清单变更（不新增工具）。