### PR TITLE
fix(core): 兑现插件 API 安全契约——插件DB白名单(R1)/destructive消费(R2)/鉴权fail-closed(W1)

### DIFF
--- a/core/http-server.js
+++ b/core/http-server.js
@@ -56,12 +56,44 @@ export function sendError(res, id, message) {
   }]);
 }
 
+// ── 鉴权 fail-closed ──
+// 读取当前生效的鉴权 token：优先 core.authConfig 服务（start-monitor.js 提供，
+// 读 VRC_MONITOR_AUTH_TOKEN / VRC_MONITOR_API_KEY），服务缺失时回退环境变量。
+function getConfiguredAuthToken() {
+  try {
+    if (ctx.pluginLoader?.hasService?.('core.authConfig')) {
+      const cfg = ctx.pluginLoader.consume('core.authConfig');
+      if (cfg?.token) return cfg.token;
+    }
+  } catch { /* 服务异常按未配置处理 */ }
+  return process.env.VRC_MONITOR_AUTH_TOKEN || process.env.VRC_MONITOR_API_KEY || null;
+}
+
+function authFailClosedBody() {
+  return JSON.stringify({
+    error: 'Unauthorized',
+    message: '鉴权已启用但 http.authenticate 服务不可用（auth-guard 插件缺失或加载失败），fail-closed 拒绝访问',
+  });
+}
+
 // ── 请求路由 ──
 async function handleRequest(req, res) {
   const { storage, rateLimiter, wsManager, friendState, eventPipeline, serverState, paths } = ctx;
   const pathname = (req.url || '').split('?')[0];
 
   // ── 全局 HTTP 鉴权中间件（由 auth-guard 插件或环境配置提供）──
+  // fail-closed：token 已配置但 http.authenticate 服务缺失（auth-guard 缺失/加载失败/热重载中被卸载）
+  // → 一律 401 拒绝，绝不放行。fail-open 仅限「未配置 token」的开发场景。
+  if (getConfiguredAuthToken() && !ctx.pluginLoader?.hasService?.('http.authenticate')) {
+    const errBody = authFailClosedBody();
+    res.writeHead(401, {
+      'Content-Type': 'application/json',
+      'Content-Length': Buffer.byteLength(errBody),
+      'WWW-Authenticate': 'Bearer error="invalid_token"',
+    });
+    res.end(errBody);
+    return;
+  }
   if (ctx.pluginLoader?.hasService('http.authenticate')) {
     const authResult = ctx.pluginLoader.consume('http.authenticate', req);
     if (!authResult || !authResult.ok) {
@@ -218,6 +250,18 @@ async function handleRpc(rpc, session, res) {
 // ── 服务器创建 ──
 export function createServer() {
   const { PORT } = ctx.paths;
+
+  // 鉴权 fail-closed 启动期阻断：token 已配置但 http.authenticate 服务不存在
+  // （auth-guard 插件缺失或加载失败）→ 拒绝创建服务器。监听 0.0.0.0 + 有 token 却无鉴权
+  // = 危险配置，绝不能 fail-open；未配置 token 的开发场景不受影响。
+  if (getConfiguredAuthToken() && !ctx.pluginLoader?.hasService?.('http.authenticate')) {
+    throw new Error(
+      '鉴权 fail-closed：已配置 VRC_MONITOR_AUTH_TOKEN（或 VRC_MONITOR_API_KEY），' +
+      '但 http.authenticate 服务不存在（auth-guard 插件缺失或加载失败）。' +
+      '为安全起见拒绝启动：请检查 plugins/official/auth-guard 插件状态，或移除鉴权 token 配置。'
+    );
+  }
+
   const server = http.createServer(async (req, res) => {
     try {
       await handleRequest(req, res);

--- a/core/plugin-api.js
+++ b/core/plugin-api.js
@@ -93,6 +93,181 @@ export function buildPluginApi(pluginName, { registry, ctx, services, serviceOwn
   };
 }
 
+// ── 插件 DB 沙箱：表名白名单（docs/PLUGIN-API.md §4.2 契约）──
+// 表名位置的关键字：其后（跳过修饰词）的标识符是表名
+const TABLE_INTRO_KEYWORDS = new Set(['FROM', 'JOIN', 'UPDATE', 'INTO', 'TABLE', 'REFERENCES']);
+// 表名位置可跳过的修饰词（DDL 的 IF NOT EXISTS、UPDATE OR REPLACE 等）
+const TABLE_MODIFIER_KEYWORDS = new Set([
+  'IF', 'NOT', 'EXISTS', 'OR', 'ABORT', 'FAIL', 'IGNORE', 'REPLACE', 'ROLLBACK',
+]);
+// 表名候选位置出现的非表名 SQL 关键字（子查询/表达式开头），出现即放弃本次候选
+const NON_TABLE_KEYWORDS = new Set([
+  'SELECT', 'WITH', 'VALUES', 'WHERE', 'GROUP', 'ORDER', 'LIMIT', 'OFFSET', 'SET', 'AS',
+  'UNION', 'INTERSECT', 'EXCEPT', 'HAVING', 'RETURNING', 'WINDOW', 'FILTER', 'OVER',
+  'CONFLICT', 'DO', 'AND', 'BY', 'CASE', 'WHEN', 'THEN', 'ELSE', 'END',
+  'USING', 'ON', 'IN', 'IS', 'LIKE', 'GLOB', 'MATCH', 'REGEXP', 'BETWEEN', 'COLLATE', 'ASC', 'DESC',
+  'OF',
+  'INDEXED', 'NULL', 'DISTINCT', 'ALL', 'CROSS', 'INNER', 'LEFT', 'RIGHT', 'FULL', 'OUTER', 'NATURAL',
+  'DEFAULT', 'PRIMARY', 'FOREIGN', 'KEY', 'CHECK', 'UNIQUE', 'CONSTRAINT',
+]);
+// PRAGMA 带表名参数的 pragma 名（PRAGMA table_info(plg_x_t) 等）
+const PRAGMA_TABLE_NAMES = new Set([
+  'TABLE_INFO', 'TABLE_XINFO', 'INDEX_LIST', 'INDEX_INFO', 'INDEX_XINFO', 'FOREIGN_KEY_LIST',
+]);
+
+/**
+ * 白名单扫描：SQL 中表名位置的标识符必须全部以本插件 prefix 开头。
+ * 返回第一个违规表名，全合法返回 null。跳过字符串字面量、注释、嵌套子查询关键字、
+ * WITH CTE 名（CTE 内部 FROM 仍会被检查，不会形成绕过）。
+ */
+function findForeignTableName(sql, prefix) {
+  const n = sql.length;
+  let i = 0;
+  let expectingTable = false;   // 上一个关键字引入了表名，等待候选
+  let stmtFirst = true;         // 处于语句首
+  let stmtKind = 'other';       // 'index-trigger' 时首个 ON 引入表名（CREATE INDEX/TRIGGER）
+  let pendingCreate = false;    // 语句首词是 CREATE，等待 INDEX/TRIGGER 判定
+  let pragmaPending = false;    // 语句首词是 PRAGMA，等待 pragma 名
+  let onConsumed = false;       // 本语句首个 ON 是否已用于表名位置
+  let inWith = false;           // WITH 子句中（收集 CTE 名）
+  let parenDepth = 0;
+  const cteNames = new Set();
+
+  const resetStatement = () => {
+    expectingTable = false;
+    stmtFirst = true;
+    stmtKind = 'other';
+    pendingCreate = false;
+    pragmaPending = false;
+    onConsumed = false;
+    inWith = false;
+  };
+
+  while (i < n) {
+    const ch = sql[i];
+
+    // 字符串字面量：内容不是表名，整体跳过（'' 转义）
+    if (ch === "'") {
+      i++;
+      while (i < n) {
+        if (sql[i] === "'") {
+          if (sql[i + 1] === "'") { i += 2; continue; }
+          i++;
+          break;
+        }
+        i++;
+      }
+      continue;
+    }
+
+    // 行注释 / 块注释
+    if (ch === '-' && sql[i + 1] === '-') {
+      i += 2;
+      while (i < n && sql[i] !== '\n') i++;
+      continue;
+    }
+    if (ch === '/' && sql[i + 1] === '*') {
+      i += 2;
+      while (i < n && !(sql[i] === '*' && sql[i + 1] === '/')) i++;
+      i = Math.min(i + 2, n);
+      continue;
+    }
+
+    // 引号标识符（"..."、`...`、[...]）
+    if (ch === '"' || ch === '`' || ch === '[') {
+      const close = ch === '[' ? ']' : ch;
+      let j = i + 1;
+      let ident = '';
+      while (j < n && sql[j] !== close) { ident += sql[j]; j++; }
+      i = j < n ? j + 1 : j;
+      if (expectingTable) {
+        if (!ident.toLowerCase().startsWith(prefix)) return ident;
+        expectingTable = false;
+      }
+      continue;
+    }
+
+    if (ch === '(') { parenDepth++; i++; continue; }
+    if (ch === ')') {
+      parenDepth = Math.max(0, parenDepth - 1);
+      if (expectingTable) expectingTable = false;
+      i++;
+      continue;
+    }
+    if (ch === ';') { resetStatement(); i++; continue; }
+
+    // 词（标识符/关键字）
+    if (/[A-Za-z_]/.test(ch)) {
+      let j = i;
+      let word = '';
+      while (j < n && /[A-Za-z0-9_]/.test(sql[j])) { word += sql[j]; j++; }
+      i = j;
+      const up = word.toUpperCase();
+
+      // WITH 子句（深度 0）：收集 CTE 名（词后紧跟 ( 或 AS），主 SELECT 出现即结束
+      if (inWith && parenDepth === 0) {
+        if (up === 'SELECT') {
+          inWith = false;
+        } else {
+          let k = i;
+          while (k < n && /\s/.test(sql[k])) k++;
+          if (sql[k] === '(') cteNames.add(word.toLowerCase());
+          else if (sql.startsWith('AS', k) && !/[A-Za-z0-9_]/.test(sql[k + 2] || '')) {
+            cteNames.add(word.toLowerCase());
+          }
+        }
+      }
+
+      // 语句首词判定：只设标志并跳过后续处理，避免首词自身把 pendingCreate/pragmaPending
+      // 立即消费掉（否则 CREATE INDEX 的 INDEX、PRAGMA table_info 的 TABLE_INFO 永远等不到标志）。
+      // UPDATE/DELETE/DROP 等首词不 continue，继续参与表名引入判定。
+      if (stmtFirst) {
+        stmtFirst = false;
+        if (up === 'CREATE') { pendingCreate = true; continue; }
+        if (up === 'WITH') { inWith = true; continue; }
+        if (up === 'PRAGMA') { pragmaPending = true; continue; }
+      }
+      if (pendingCreate) {
+        if (up !== 'UNIQUE' && up !== 'TEMP' && up !== 'TEMPORARY') {
+          if (up === 'INDEX' || up === 'TRIGGER') stmtKind = 'index-trigger';
+          pendingCreate = false;
+        }
+      }
+      if (pragmaPending) {
+        pragmaPending = false;
+        if (PRAGMA_TABLE_NAMES.has(up)) expectingTable = true;
+        continue;
+      }
+
+      // 期待表名时的候选处理
+      if (expectingTable) {
+        if (TABLE_MODIFIER_KEYWORDS.has(up)) { /* 保持期待 */ }
+        else if (NON_TABLE_KEYWORDS.has(up)) { expectingTable = false; }
+        else if (cteNames.has(word.toLowerCase())) { expectingTable = false; }
+        else {
+          if (!word.toLowerCase().startsWith(prefix)) return word;
+          expectingTable = false;
+        }
+      }
+
+      // 关键字引入表名；CREATE INDEX/TRIGGER 语句中首个 ON 引入表名
+      if (TABLE_INTRO_KEYWORDS.has(up)) expectingTable = true;
+      if (up === 'ON' && stmtKind === 'index-trigger' && !onConsumed) {
+        onConsumed = true;
+        expectingTable = true;
+      }
+      continue;
+    }
+
+    // 期待表名时：`(`（子查询）/ `=`（PRAGMA 等号形式）保持期待，其余字符放弃
+    if (expectingTable && ch !== '(' && ch !== '=' && !/\s/.test(ch)) {
+      expectingTable = false;
+    }
+    i++;
+  }
+  return null;
+}
+
 /** 构建命名空间存储 db */
 function buildDbNamespace({ pluginName, prefix, ctx }) {
   const aliases = new Set();
@@ -102,13 +277,31 @@ function buildDbNamespace({ pluginName, prefix, ctx }) {
   }
 
   function validatePrefixes(sql) {
-    const re = /\bplg_[a-zA-Z0-9_-]+_/g;
+    // 1) 快速通道：任何位置出现其他插件的 plg_ 前缀直接拒绝（含字符串/注释里出现）。
+    // 以本插件前缀开头（如 plg_<name>_deep_table 这类含下划线的表名）属本插件命名空间，放行。
+    const foreignRe = /\bplg_[a-zA-Z0-9_-]+_/g;
     let m;
-    while ((m = re.exec(sql)) !== null) {
+    while ((m = foreignRe.exec(sql)) !== null) {
       const fullPrefix = m[0];
-      if (fullPrefix !== prefix) {
+      if (!fullPrefix.startsWith(prefix)) {
         throw new Error(`插件 ${pluginName} 不能访问表前缀 ${fullPrefix}`);
       }
+    }
+
+    // 2) 白名单：表名位置的标识符必须都是本插件前缀（核心表/其他插件表一律拒绝）
+    const offender = findForeignTableName(sql, prefix);
+    if (offender) {
+      const foreignPrefix = /^plg_[a-zA-Z0-9_-]+_/.exec(offender.toLowerCase())?.[0];
+      if (foreignPrefix) {
+        throw new Error(
+          `插件 ${pluginName} 不能访问表 ${offender}：前缀 ${foreignPrefix} 属于其他插件` +
+          `（本插件只能访问 ${prefix} 开头的表）`
+        );
+      }
+      throw new Error(
+        `插件 ${pluginName} 不能访问表 ${offender}：只允许访问 ${prefix} 开头的表` +
+        `（核心表与其他插件表均不开放给插件）`
+      );
     }
   }
 

--- a/core/plugin-loader.js
+++ b/core/plugin-loader.js
@@ -40,6 +40,126 @@ const FORBIDDEN_IMPORT_PATTERNS = [
   /import\(['"]\.\.?\/core\//,
   /import\(['"]start-monitor/,
 ];
+// 破坏性工具名前缀契约（docs/PLUGIN-API.md §7）：工具名匹配这些前缀的插件工具
+// 必须声明 destructive: true，否则拒绝加载（静态扫描校验）。
+const DESTRUCTIVE_TOOL_NAME_PREFIXES = [
+  'remove_', 'delete_', 'leave_', 'decline_', 'hide_', 'unfavorite_', 'unfriend_',
+];
+
+/** 逐字符标记代码区/字符串/注释，用于跳过注释与字符串中的 registerTool 匹配（防误报） */
+function codeMask(code) {
+  const mask = new Array(code.length).fill('code');
+  let i = 0;
+  while (i < code.length) {
+    const ch = code[i];
+    if (ch === '/' && code[i + 1] === '/') {
+      mask[i] = mask[i + 1] = 'comment';
+      i += 2;
+      while (i < code.length && code[i] !== '\n') { mask[i] = 'comment'; i++; }
+      continue;
+    }
+    if (ch === '/' && code[i + 1] === '*') {
+      mask[i] = mask[i + 1] = 'comment';
+      i += 2;
+      while (i < code.length && !(code[i] === '*' && code[i + 1] === '/')) { mask[i] = 'comment'; i++; }
+      if (i < code.length) { mask[i] = mask[i + 1] = 'comment'; i += 2; }
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === '`') {
+      mask[i] = 'string';
+      i++;
+      while (i < code.length) {
+        mask[i] = 'string';
+        if (code[i] === '\\') { mask[i + 1] = 'string'; i += 2; continue; }
+        if (code[i] === ch) { i++; break; }
+        i++;
+      }
+      continue;
+    }
+    i++;
+  }
+  return mask;
+}
+
+/** 提取代码中 fnName(...) 直接传对象字面量的调用参数（花括号配对，跳过字符串/注释） */
+function extractCallObjectArgs(code, fnName) {
+  const results = [];
+  const mask = codeMask(code);
+  const callRe = new RegExp(`\\b${fnName}\\s*\\(`, 'g');
+  let m;
+  while ((m = callRe.exec(code)) !== null) {
+    if (mask[m.index] !== 'code') continue; // 注释/字符串中的匹配不参与扫描
+    const openIdx = m.index + m[0].length;
+    const braceIdx = code.indexOf('{', openIdx);
+    if (braceIdx === -1) continue;
+    if (!/^\s*$/.test(code.slice(openIdx, braceIdx))) continue; // 参数不是直接的对象字面量
+    const endIdx = matchBrace(code, braceIdx);
+    if (endIdx === -1) continue;
+    results.push(code.slice(braceIdx + 1, endIdx)); // 不含外层花括号，顶层键即深度 0
+  }
+  return results;
+}
+
+/** 从 idx 处的 { 找到配对的 }（跳过字符串/模板串/注释），找不到返回 -1 */
+function matchBrace(code, idx) {
+  let depth = 0;
+  let i = idx;
+  let inString = null;
+  let lineComment = false;
+  let blockComment = false;
+  while (i < code.length) {
+    const ch = code[i];
+    const next = code[i + 1];
+    if (lineComment) {
+      if (ch === '\n') lineComment = false;
+      i++;
+      continue;
+    }
+    if (blockComment) {
+      if (ch === '*' && next === '/') { blockComment = false; i += 2; } else i++;
+      continue;
+    }
+    if (inString) {
+      if (ch === '\\') { i += 2; continue; }
+      if (ch === inString) inString = null;
+      i++;
+      continue;
+    }
+    if (ch === '/' && next === '/') { lineComment = true; i += 2; continue; }
+    if (ch === '/' && next === '*') { blockComment = true; i += 2; continue; }
+    if (ch === '"' || ch === "'" || ch === '`') { inString = ch; i++; continue; }
+    if (ch === '{') depth++;
+    else if (ch === '}') { depth--; if (depth === 0) return i; }
+    i++;
+  }
+  return -1;
+}
+
+/** 对象字面量文本（不含外层花括号）第一层的 key 值；取不到返回 null */
+function topLevelValue(defText, key) {
+  let depth = 0;
+  let inString = null;
+  for (let i = 0; i < defText.length; i++) {
+    const ch = defText[i];
+    if (inString) {
+      if (ch === '\\') { i++; continue; }
+      if (ch === inString) inString = null;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === '`') { inString = ch; continue; }
+    if (ch === '{') { depth++; continue; }
+    if (ch === '}') { depth--; continue; }
+    if (depth !== 0 || !defText.startsWith(key, i)) continue;
+    if (i > 0 && /[A-Za-z0-9_$]/.test(defText[i - 1])) continue;
+    if (/[A-Za-z0-9_$]/.test(defText[i + key.length] || '')) continue;
+    const rest = defText.slice(i + key.length);
+    const vm = /^\s*:\s*(['"])([^'"]*)\1/.exec(rest);
+    if (vm) return vm[2];
+    const wm = /^\s*:\s*([A-Za-z0-9_$]+)/.exec(rest);
+    if (wm) return wm[1];
+  }
+  return null;
+}
 
 export class PluginLoader {
   constructor({ registry, ctx, log, notifier }) {
@@ -144,6 +264,22 @@ export class PluginLoader {
 
       if (/process\.exit\(/.test(code)) {
         errors.push(`文件 ${path.basename(file)} 使用了 process.exit`);
+      }
+
+      // 破坏性工具名前缀契约（docs/PLUGIN-API.md §7）：
+      // 工具名匹配破坏性前缀但未声明 destructive: true → 拒绝加载。
+      if (code.includes('registerTool')) {
+        for (const defText of extractCallObjectArgs(code, 'registerTool')) {
+          const toolName = topLevelValue(defText, 'name');
+          if (!toolName) continue;
+          const hit = DESTRUCTIVE_TOOL_NAME_PREFIXES.find(p => toolName.startsWith(p));
+          if (hit && topLevelValue(defText, 'destructive') !== 'true') {
+            errors.push(
+              `文件 ${path.basename(file)} 工具名 ${toolName} 匹配破坏性前缀 "${hit}"，` +
+              `但未声明 destructive: true`
+            );
+          }
+        }
       }
     }
 

--- a/core/registry.js
+++ b/core/registry.js
@@ -102,7 +102,7 @@ export function removePluginTools(origin) {
 }
 
 export function listTools() {
-  const result = [];
+  const defs = [];
   // 整体遍历 ORDER（tool-order.json 统一涵盖核心+插件工具），保证输出顺序稳定
   for (const name of ORDER) {
     const coreDef = coreRegistry.get(name);
@@ -112,23 +112,21 @@ export function listTools() {
       log(`[registry] tool "${name}" in manifest but not registered`);
       continue;
     }
-    result.push({
-      name: def.name,
-      description: def.description,
-      inputSchema: def.inputSchema,
-    });
+    defs.push(def);
   }
   // 插件工具若不在 ORDER（动态加载的本地插件）则按注册顺序追加
   const inOrder = new Set(ORDER);
   for (const def of pluginTools) {
     if (inOrder.has(def.name)) continue;
-    result.push({
-      name: def.name,
-      description: def.description,
-      inputSchema: def.inputSchema,
-    });
+    defs.push(def);
   }
-  return safeMode.filterTools(result);
+  // 先按完整定义过滤（安全模式依据 destructive 标志，见 safe-mode.filterTools），
+  // 再投影为对外公开形状（name/description/inputSchema），保持 tools/list 载荷不变。
+  return safeMode.filterTools(defs).map(def => ({
+    name: def.name,
+    description: def.description,
+    inputSchema: def.inputSchema,
+  }));
 }
 
 export async function dispatch(name, args) {

--- a/core/safe-mode.js
+++ b/core/safe-mode.js
@@ -38,14 +38,16 @@ export function isSafeModeEnabled() {
 }
 
 // ── 工具列表过滤（tools/list 用）：开启时剔除破坏性工具，关闭时原样返回 ──
+// 优先按工具定义上的 destructive 标志（注册时已解析）过滤，硬编码 DESTRUCTIVE_TOOLS 清单作兜底。
 export function filterTools(tools) {
   if (!isSafeModeEnabled()) return tools;
-  return tools.filter(t => !DESTRUCTIVE_TOOLS.includes(t.name));
+  return tools.filter(t => !(t.destructive || DESTRUCTIVE_TOOLS.includes(t.name)));
 }
 
 // ── 调用拦截（tools/call 用）：开启时对破坏性工具抛错，关闭时放行 ──
-export function assertToolAllowed(name) {
-  if (isSafeModeEnabled() && DESTRUCTIVE_TOOLS.includes(name)) {
+// destructive 标志为 true 的工具即使不在硬编码清单也会被拦截；清单对名字兜底。
+export function assertToolAllowed(name, destructive = false) {
+  if (isSafeModeEnabled() && (destructive || DESTRUCTIVE_TOOLS.includes(name))) {
     const err = new Error(
       `🔒 安全模式已启用：${name} 属于破坏性工具（删除/移除类），已被禁用。` +
       `如需使用，请在 .env 设置 VRC_MONITOR_SAFE_MODE=false 后重启服务。`

--- a/test/test-auth-guard.mjs
+++ b/test/test-auth-guard.mjs
@@ -205,4 +205,55 @@ console.log('\n── 3. 端到端测试: HTTP 鉴权中间件 ──');
   await new Promise((resolve) => server.close(resolve));
 }
 
+console.log('\n── 4. 鉴权 fail-closed：token 已配置但 http.authenticate 服务缺失 ──');
+{
+  async function request(path, options = {}) {
+    return new Promise((resolve, reject) => {
+      const req = http.request('http://127.0.0.1:' + port + path, options, (res) => {
+        let data = '';
+        res.on('data', (c) => data += c);
+        res.on('end', () => resolve({ status: res.statusCode, data, headers: res.headers }));
+      });
+      req.on('error', reject);
+      if (options.body) req.write(options.body);
+      req.end();
+    });
+  }
+
+  // 4.1 启动期阻断：token 已配置 + 无 http.authenticate → createServer 抛错拒绝启动
+  process.env.VRC_MONITOR_AUTH_TOKEN = 'failclosed_test_token';
+  ctx.pluginLoader = {
+    hasService: () => false,
+    consume: () => { throw new Error('service not found'); },
+    getStatus: () => [],
+  };
+  assert.throws(() => createServer(), /fail-closed/, 'token 配置但无 http.authenticate 服务时 createServer 应拒绝启动');
+  ok('启动期 fail-closed：createServer 抛出 fail-closed 错误');
+
+  // 4.2 运行期 fail-closed：服务器在无 token 时创建，随后 token 生效 → 全部请求 401
+  delete process.env.VRC_MONITOR_AUTH_TOKEN;
+  const server = createServer();
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const port = server.address().port;
+
+  process.env.VRC_MONITOR_AUTH_TOKEN = 'failclosed_test_token';
+  let res = await request('/health');
+  assert.equal(res.status, 401, 'token 生效后 /health 应 401');
+  assert.ok(res.data.includes('fail-closed'), `401 响应体应说明 fail-closed，实际: ${res.data}`);
+  res = await request('/mcp');
+  assert.equal(res.status, 401, 'token 生效后 /mcp 应 401');
+  res = await request('/health', { headers: { authorization: 'Bearer failclosed_test_token' } });
+  assert.equal(res.status, 401, '即使携带正确 token，无 http.authenticate 服务仍应 401');
+  ok('运行期 fail-closed：token 生效后全部请求 401（含携带正确 token）');
+
+  delete process.env.VRC_MONITOR_AUTH_TOKEN;
+  res = await request('/health');
+  assert.equal(res.status, 200, '移除 token 后恢复放行（无 token 开发场景 fail-open）');
+  ok('移除 token 后恢复放行');
+
+  // 清理测试环境
+  ctx.pluginLoader = null;
+  await new Promise((resolve) => server.close(resolve));
+}
+
 console.log('\n🎉 全部 ' + passed + ' 项测试通过！');

--- a/test/test-plugin-db-sandbox.mjs
+++ b/test/test-plugin-db-sandbox.mjs
@@ -1,0 +1,133 @@
+/**
+ * test-plugin-db-sandbox.mjs — 插件 DB 沙箱白名单测试（无凭据，可离线）
+ *
+ * 覆盖（对应 docs/PLUGIN-API.md §4.2 契约）：
+ *   1. 合法：本插件 plg_<name>_ 表名（裸别名/全名/带引号/连字符插件名）放行，rewrite 仍生效
+ *   2. 拒绝：核心表名（friends/events 等）在任何表名位置（FROM/JOIN/UPDATE/INTO/TABLE/DROP/PRAGMA）被拒
+ *   3. 拒绝：其他插件 plg_xxx_ 前缀（含快速通道：字符串中出现其他插件前缀同样拒绝）
+ *   4. 不误报：字符串字面量/注释中的表名、ON CONFLICT、CREATE INDEX ... ON、WITH CTE 等合法 SQL
+ *
+ * 用法：node test/test-plugin-db-sandbox.mjs
+ */
+import { buildPluginApi as buildApi } from '../core/plugin-api.js';
+
+let pass = true;
+const errors = [];
+const assert = (c, m) => { if (!c) { pass = false; errors.push(m); } };
+const assertThrows = (fn, re, m) => {
+  try {
+    fn();
+    assert(false, `${m}（未抛出）`);
+  } catch (err) {
+    assert(re.test(err.message), `${m}（错误消息不匹配: ${err.message}）`);
+  }
+};
+
+function makeApi(pluginName = 'testplugin') {
+  const calls = [];
+  const storage = {
+    run: (sql, params) => { calls.push({ sql, params }); return { changes: 0 }; },
+    get: (sql, params) => { calls.push({ sql, params }); return null; },
+    query: (sql, params) => { calls.push({ sql, params }); return []; },
+    exec: (sql) => { calls.push({ sql }); },
+    transaction: (fn) => () => fn(storage),
+  };
+  const api = buildApi(pluginName, {
+    registry: {},
+    ctx: { storage, httpRoutes: new Map() },
+    services: new Map(),
+    serviceOwners: new Map(),
+    log: () => {},
+  });
+  return { api, calls };
+}
+
+// ── 1. 合法：本插件表名放行 + rewrite 生效 ──
+{
+  const { api, calls } = makeApi();
+  const items = api.db.table('items');
+  items.run('INSERT INTO items (id, note) VALUES ($id, $note)', { $id: 1, $note: 'x' });
+  assert(calls[0].sql.includes('INSERT INTO plg_testplugin_items'), '裸别名应被重写为本插件前缀表名');
+  items.get('SELECT * FROM items WHERE id = 1');
+  items.all('SELECT * FROM "items"'); // 带引号别名（events 插件 "store" 同款写法）
+  api.db.exec('CREATE TABLE IF NOT EXISTS plg_testplugin_x (id INTEGER)'); // 全名直写本插件前缀
+  api.db.exec('PRAGMA table_info(plg_testplugin_items)'); // 本插件表的 PRAGMA
+  api.db.exec('CREATE TABLE IF NOT EXISTS plg_testplugin_deep_table (id INTEGER)'); // 本插件命名空间内更深层表名同样放行
+  console.log('  ✅ 合法：本插件表名（裸别名/引号别名/全名/PRAGMA）放行且 rewrite 生效');
+}
+
+// ── 2. 连字符插件名（emoji-notes 同款：CREATE INDEX ... ON + 双引号处理）──
+{
+  const { api, calls } = makeApi('emoji-notes');
+  const notes = api.db.table('notes');
+  notes.exec('CREATE INDEX IF NOT EXISTS idx_notes_kind ON notes(kind)');
+  assert(calls[0].sql.includes('"plg_emoji-notes_notes"'), '连字符插件名表名应加双引号重写');
+  notes.run(
+    'INSERT INTO notes (emoji_id, kind) VALUES ($id, $kind) ON CONFLICT(emoji_id) DO UPDATE SET kind = excluded.kind',
+    { $id: 'default_x', $kind: 'builtin' }
+  );
+  notes.all('SELECT * FROM notes WHERE deleted = 0');
+  console.log('  ✅ 合法：连字符插件名 + CREATE INDEX ... ON + ON CONFLICT 不误报');
+}
+
+// ── 3. 拒绝：核心表名 ──
+{
+  const { api } = makeApi();
+  const items = api.db.table('items');
+  assertThrows(() => items.all('SELECT * FROM friends'), /不能访问表 friends/, 'FROM 核心表 friends');
+  assertThrows(() => items.all('SELECT * FROM friends JOIN plg_testplugin_x ON 1=1'), /friends/, 'JOIN 核心表');
+  assertThrows(() => items.run('UPDATE friends SET x = 1'), /friends/, 'UPDATE 核心表');
+  assertThrows(() => items.run('DELETE FROM events WHERE id = 1'), /events/, 'DELETE FROM 核心表');
+  assertThrows(() => api.db.exec('DROP TABLE friends'), /friends/, 'DROP TABLE 核心表');
+  assertThrows(() => api.db.exec('DROP TABLE IF EXISTS friends'), /friends/, 'DROP TABLE IF EXISTS 核心表');
+  assertThrows(() => api.db.exec('CREATE TABLE friends (id INTEGER)'), /friends/, 'CREATE TABLE 核心表');
+  assertThrows(() => api.db.exec('ALTER TABLE friends ADD COLUMN x'), /friends/, 'ALTER TABLE 核心表');
+  assertThrows(() => api.db.exec('PRAGMA table_info(friends)'), /friends/, 'PRAGMA table_info 核心表');
+  assertThrows(() => items.all('SELECT * FROM "friends"'), /friends/, '带引号核心表名');
+  assertThrows(() => items.all('SELECT * FROM main.friends'), /main/, '限定的核心表名 main.friends');
+  assertThrows(() => api.db.exec('CREATE TABLE plg_testplugin_tmp AS SELECT * FROM world_kb'), /world_kb/, 'CTAS 读取核心表');
+  assertThrows(() => api.db.exec('CREATE INDEX idx ON friends(col)'), /friends/, 'CREATE INDEX ON 核心表');
+  assertThrows(() => items.all('UPDATE OR REPLACE friends SET x = 1'), /friends/, 'UPDATE OR REPLACE 核心表');
+  console.log('  ✅ 拒绝：核心表名在全部表名位置被拦截');
+}
+
+// ── 4. 拒绝：其他插件前缀 ──
+{
+  const { api } = makeApi();
+  const items = api.db.table('items');
+  assertThrows(() => items.all('SELECT * FROM plg_otherplugin_notes'), /plg_otherplugin_/, 'FROM 其他插件表');
+  assertThrows(() => items.all('SELECT * FROM "plg_otherplugin_notes"'), /plg_otherplugin_/, '带引号其他插件表');
+  assertThrows(() => items.all('SELECT * FROM plg_testplugin2_x'), /plg_testplugin2_/, '前缀相似但非本插件（testplugin2）');
+  // 快速通道：字符串里出现其他插件前缀（旧版行为保留）
+  assertThrows(
+    () => items.run("INSERT INTO items (note) VALUES ('migrated from plg_other_backup')"),
+    /plg_other_/, '字符串中出现其他插件前缀（快速通道）'
+  );
+  console.log('  ✅ 拒绝：其他插件 plg_ 前缀（表名位置 + 快速通道）');
+}
+
+// ── 5. 不误报：字符串/注释/CTE/合法关键字组合 ──
+{
+  const { api, calls } = makeApi();
+  const items = api.db.table('items');
+  items.run("INSERT INTO items (note) VALUES ('SELECT * FROM friends -- trap')");
+  items.all('SELECT * FROM items -- FROM friends\n WHERE id = 1');
+  items.all('/* FROM friends */ SELECT * FROM items');
+  items.all('WITH t AS (SELECT * FROM items) SELECT * FROM t'); // CTE 内部 FROM 仍检查、CTE 名放行
+  items.run('UPDATE items SET note = datetime(\'now\') WHERE id = $id', { $id: 1 });
+  items.run('INSERT OR REPLACE INTO items (id) VALUES (1)');
+  items.all('SELECT 1'); // 无表名
+  api.db.exec('PRAGMA journal_mode=WAL'); // 非表名 PRAGMA 参数
+  assert(calls.length >= 8, '全部合法 SQL 应放行');
+  assertThrows(() => items.all('WITH t AS (SELECT * FROM friends) SELECT * FROM t'), /friends/, 'CTE 内部读取核心表仍应被拒');
+  console.log('  ✅ 不误报：字符串/注释/CTE/ON CONFLICT/合法关键字组合放行');
+}
+
+if (pass) {
+  console.log(`plugin db sandbox: PASS`);
+  process.exit(0);
+} else {
+  console.log('plugin db sandbox: FAIL');
+  for (const e of errors) console.log(' -', e);
+  process.exit(1);
+}

--- a/test/test-plugin-loader-scan.mjs
+++ b/test/test-plugin-loader-scan.mjs
@@ -1,0 +1,135 @@
+/**
+ * test-plugin-loader-scan.mjs — 插件静态扫描：破坏性工具名前缀契约（docs/PLUGIN-API.md §7）
+ *
+ * 覆盖：
+ *   1. 工具名匹配破坏性前缀且声明 destructive: true → 放行
+ *   2. 匹配前缀但未声明（或 destructive: false）→ 静态扫描报错拒绝加载
+ *   3. 非匹配前缀（x_remove_creator）、registerTool(def) 标识符参数、字符串/注释中的名字 → 不误报
+ *   4. 回归：官方插件目录全部通过静态扫描（防止契约收紧误伤现有插件）
+ *
+ * 用法：node test/test-plugin-loader-scan.mjs
+ * 无需 VRChat 凭据 / 网络，可离线运行。退出码 0=全部通过。
+ */
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, readdirSync, existsSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { PluginLoader } from '../core/plugin-loader.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+let passed = 0;
+function ok(name) { passed++; console.log('  ✅ ' + name); }
+
+const loader = new PluginLoader({ registry: {}, ctx: {}, log: () => {} });
+const tmpRoot = mkdtempSync(path.join(os.tmpdir(), 'plg-scan-'));
+
+function makePlugin(dirName, indexJs) {
+  const dir = path.join(tmpRoot, dirName);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(path.join(dir, 'index.js'), indexJs, 'utf-8');
+  writeFileSync(
+    path.join(dir, 'plugin.json'),
+    JSON.stringify({ name: dirName, version: '1.0.0', description: 'test' }),
+    'utf-8'
+  );
+  return {
+    name: dirName,
+    dir,
+    entryFile: path.join(dir, 'index.js'),
+    schemaFile: null,
+    manifestFile: path.join(dir, 'plugin.json'),
+  };
+}
+
+try {
+  console.log('── 1. 匹配破坏性前缀 + destructive: true → 放行 ──');
+  {
+    const p = makePlugin('good-a', `
+      export default function register(api) {
+        api.registerTool({
+          name: 'remove_stuff',
+          destructive: true,
+          description: '清理数据',
+          inputSchema: { type: 'object', properties: { id: { type: 'number' } } },
+        });
+        api.registerTool({
+          name: 'get_stuff',
+          description: '查询',
+          inputSchema: { type: 'object', properties: { destructive: { type: 'boolean' }, name: { type: 'string' } } },
+        });
+      }
+    `);
+    assert.deepEqual(loader._staticScan(p), [], 'declared destructive 的工具与嵌套键不应报错');
+    ok('remove_stuff(destructive:true) 与 inputSchema 嵌套键放行');
+  }
+
+  console.log('── 2. 匹配前缀但未声明 destructive → 拒绝 ──');
+  {
+    const p1 = makePlugin('bad-a', `
+      export default function register(api) {
+        api.registerTool({ name: 'remove_stuff', description: '清理数据', inputSchema: {} });
+      }
+    `);
+    const e1 = loader._staticScan(p1);
+    // entryFile 与目录 .js 遍历有重叠（index.js 会被扫两次），同一错误可能出现多条
+    assert.ok(e1.length >= 1, '应至少 1 条错误');
+    assert.ok(
+      e1.every(e => e.includes('remove_stuff') && e.includes('破坏性前缀 "remove_"') && e.includes('destructive')),
+      `错误内容应指出前缀与 destructive: ${e1.join('; ')}`
+    );
+    ok('remove_stuff 未声明 destructive → 静态扫描拒绝');
+
+    const p2 = makePlugin('bad-b', `
+      export default function register(api) {
+        api.registerTool({ name: 'delete_all', destructive: false, description: 'x', inputSchema: {} });
+      }
+    `);
+    const e2 = loader._staticScan(p2);
+    assert.ok(e2.length >= 1, 'destructive:false 同样应拒绝');
+    ok('delete_all 声明 destructive:false → 静态扫描拒绝');
+  }
+
+  console.log('── 3. 非匹配场景不误报 ──');
+  {
+    const p = makePlugin('good-b', `
+      export default function register(api) {
+        api.registerTool({ name: 'x_remove_creator', description: '移除 X 博主', inputSchema: {} });
+        const def = { name: 'remove_other', description: '标识符参数', inputSchema: {} };
+        api.registerTool(def);
+        const note = '工具 remove_something 只是字符串';
+        const s = 'api.registerTool({ name: "remove_in_string" })';
+        const t = \`api.registerTool({ name: 'remove_in_template' })\`;
+        // api.registerTool({ name: 'remove_comment' }) 注释中的不扫描
+      }
+    `);
+    assert.deepEqual(loader._staticScan(p), [], 'x_ 前缀/标识符参数/字符串/注释不应报错');
+    ok('x_remove_creator、registerTool(def)、字符串/模板串/注释中的名字不误报');
+  }
+
+  console.log('── 4. 官方插件全量静态扫描回归 ──');
+  {
+    const officialDir = path.join(__dirname, '..', 'plugins', 'official');
+    const names = readdirSync(officialDir);
+    let scanned = 0;
+    for (const name of names) {
+      const dir = path.join(officialDir, name);
+      if (!existsSync(path.join(dir, 'plugin.json')) && !existsSync(path.join(dir, 'index.js'))) continue;
+      const plugin = {
+        name,
+        dir,
+        entryFile: path.join(dir, 'index.js'),
+        schemaFile: path.join(dir, 'schema.sql'),
+        manifestFile: path.join(dir, 'plugin.json'),
+      };
+      const errs = loader._staticScan(plugin);
+      assert.deepEqual(errs, [], `官方插件 ${name} 静态扫描不应报错: ${errs.join('; ')}`);
+      scanned++;
+    }
+    ok(`官方插件 ${scanned} 个全部通过静态扫描`);
+  }
+} finally {
+  rmSync(tmpRoot, { recursive: true, force: true });
+}
+
+console.log(`\n🎉 全部 ${passed} 项通过`);

--- a/test/test-safe-mode.mjs
+++ b/test/test-safe-mode.mjs
@@ -69,6 +69,29 @@ console.log('── 2. 单元：过滤与拦截 ──');
   ok(`开启态：剔除 ${DESTRUCTIVE_TOOLS.length} 个破坏性工具（剩 ${filtered.length} 个），拦截生效`);
 }
 
+console.log('── 2b. 单元：destructive 标志优先、硬编码清单兜底 ──');
+{
+  process.env.VRC_MONITOR_SAFE_MODE = 'true';
+  const customTools = [
+    { name: 'get_online_friends' },
+    { name: 'wipe_everything', destructive: true },   // 不在硬编码清单，标志为 true
+    { name: 'remove_friend' },                        // 硬编码清单兜底
+    { name: 'purge_cache', destructive: false },      // 非破坏性
+  ];
+  const filtered = filterTools(customTools);
+  assert.deepEqual(
+    filtered.map(t => t.name),
+    ['get_online_friends', 'purge_cache'],
+    'destructive:true（不在硬编码清单）应被过滤，硬编码清单兜底，destructive:false 保留'
+  );
+  assert.throws(() => assertToolAllowed('wipe_everything', true), (e) => e.safeModeBlocked === true,
+    'destructive:true 工具即使不在硬编码清单也应拦截');
+  assert.doesNotThrow(() => assertToolAllowed('purge_cache', false), 'destructive:false 且不在清单 → 放行');
+  assert.throws(() => assertToolAllowed('remove_friend'), (e) => e.safeModeBlocked === true,
+    '硬编码清单兜底：仅凭名字拦截（不依赖标志）');
+  ok('destructive 标志优先过滤/拦截，硬编码 DESTRUCTIVE_TOOLS 清单兜底');
+}
+
 console.log('── 3. 单元：破坏性工具清单无漂移 ──');
 {
   const allNames = new Set(CUSTOM_TOOLS.map(t => t.name));


### PR DESCRIPTION
## 概述
兑现 `docs/PLUGIN-API.md` 契约承诺但实现缺失的 3 条安全边界（issue #158，架构审计发现，均已独立验证）。范围聚焦 **R1/R2/W1**；W6（文档状态漂移）由 PR #156 独立跟踪，不在本 PR 重复。

## 改动
- **R1 插件 DB 沙箱隔离（`core/plugin-api.js`）**：`validatePrefixes` 升级为白名单扫描器，SQL 中表名位置的标识符必须都是本插件 `plg_<name>_` 前缀，核心表与其他插件表一律拒绝（兑现 §4.2「拒绝跨表/越权」）。保留 rewrite 与引号/连字符插件名处理。
- **R2 安全模式 destructive 消费（`core/safe-mode.js`/`registry.js`/`plugin-loader.js`）**：`filterTools`/`assertToolAllowed` 真正消费工具定义的 `destructive` 标志（硬编码 `DESTRUCTIVE_TOOLS` 清单兜底）；`listTools` 先按完整 def 过滤再投影（tools/list 载荷不变）；`_staticScan` 补「破坏性前缀未声明 destructive:true → 拒绝加载」（兑现 §7）。
- **W1 鉴权 fail-closed（`core/http-server.js`）**：token 已配置但 `http.authenticate` 缺失时，启动期 throw 阻断 + 运行期全路径 401；未配置 token 开发场景不阻断。触发条件与 auth-guard 共用 `core.authConfig` 服务 + `VRC_MONITOR_AUTH_TOKEN`，闭环一致。

## 测试
- 新增 `test/test-plugin-db-sandbox.mjs`（R1：合法放行/核心表拒绝/其他插件前缀/字符串注释CTE不误报）
- 新增 `test/test-plugin-loader-scan.mjs`（R2：破坏性前缀+declared放行/未声明拒绝/官方插件 13 个静态扫描回归）
- 扩展 `test/test-safe-mode.mjs`（destructive 单测）+ `test/test-auth-guard.mjs`（fail-closed 3 项）
- `npm test`：**66/66 通过**

## 需维护者注意
1. **R1 放行放宽**：本插件命名空间内带下划线表名（`plg_x_deep_table`）旧版被贪婪正则误拒，现已放行——属修复而非收紧。
2. **R1 未覆盖 `_applySchema` 的 schema.sql 路径**：该路径仍只有旧前缀检查、无核心表白名单（仅官方插件可信），建议 follow-up 统一。
3. **W1 行为变更**：配置 token 且 auth-guard 缺失时服务**拒绝启动**（此前静默放行）；请确认部署环境 auth-guard 插件正常加载。

refs #158