### PR TITLE
fix(core): schema.sql 纳入插件DB白名单（R1）——_applySchema 走 rewritePluginTableNames 白名单校验（issue #160）

### DIFF
--- a/core/plugin-api.js
+++ b/core/plugin-api.js
@@ -417,9 +417,17 @@ export function rewritePluginTableNames(sql, pluginName, prefix) {
         break;
       }
       if (expectingTable) {
-        result += ch + resolveTableName(ident, tableDef) + close;
+        const resolved = resolveTableName(ident, tableDef);
         expectingTable = false;
         tableDef = false;
+        // resolveTableName 对需引号表名（含空格/连字符，或插件名为连字符型）已返回
+        // 带双引号的完整名（formatPrefixed）；此时外层不应再包裹，否则输出双重引号，
+        // SQLite 执行报 `near "plg_x_a b": syntax error`。
+        if (resolved.startsWith('"') && resolved.endsWith('"')) {
+          result += resolved;
+        } else {
+          result += ch + resolved + close;
+        }
       } else {
         result += sql.slice(segmentStart, j + 1);
       }

--- a/core/plugin-api.js
+++ b/core/plugin-api.js
@@ -1,8 +1,33 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
 /**
  * Plugin API v1 — 为插件提供与核心交互的 6 个 API 表面。
  *
  * buildPluginApi(pluginName, { registry, ctx, services, serviceOwners, log })
  */
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+function loadCoreTables() {
+  const tables = new Set();
+  const extract = (file) => {
+    try {
+      const ddl = readFileSync(path.join(__dirname, file), 'utf-8');
+      const re = /CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?([a-zA-Z0-9_]+)/gi;
+      let m;
+      while ((m = re.exec(ddl)) !== null) {
+        tables.add(m[1].toLowerCase());
+      }
+    } catch { /* ignore */ }
+  };
+  extract('init-db.sql');
+  extract('init-x-worlds.sql');
+  return tables;
+}
+
+const CORE_TABLES = loadCoreTables();
 
 /**
  * 构建插件 API 对象。
@@ -120,7 +145,7 @@ const PRAGMA_TABLE_NAMES = new Set([
  * 返回第一个违规表名，全合法返回 null。跳过字符串字面量、注释、嵌套子查询关键字、
  * WITH CTE 名（CTE 内部 FROM 仍会被检查，不会形成绕过）。
  */
-function findForeignTableName(sql, prefix) {
+export function findForeignTableName(sql, prefix) {
   const n = sql.length;
   let i = 0;
   let expectingTable = false;   // 上一个关键字引入了表名，等待候选
@@ -266,6 +291,240 @@ function findForeignTableName(sql, prefix) {
     i++;
   }
   return null;
+}
+
+/**
+ * schema.sql 专用：把 SQL 中所有表名位置的裸标识符重写为 plg_<name>_<tbl>，
+ * 同时显式拒绝核心表/其他插件表/其他插件 plg_ 前缀。
+ * 返回重写后的 SQL；违规时抛出 Error（错误消息风格与 validatePrefixes 一致）。
+ */
+export function rewritePluginTableNames(sql, pluginName, prefix) {
+  // 1) 快速通道：任何位置出现其他插件的 plg_ 前缀直接拒绝（含字符串/注释）。
+  const foreignRe = /\bplg_[a-zA-Z0-9_-]+_/g;
+  let m;
+  while ((m = foreignRe.exec(sql)) !== null) {
+    const fullPrefix = m[0];
+    if (!fullPrefix.startsWith(prefix)) {
+      throw new Error(`插件 ${pluginName} 不能访问表前缀 ${fullPrefix}（本插件只能访问 ${prefix} 开头的表）`);
+    }
+  }
+
+  const ownTables = new Set(); // 本次 schema.sql 中 CREATE/ALTER TABLE 定义的裸表名
+
+  let result = '';
+  let i = 0;
+  const n = sql.length;
+  let expectingTable = false;
+  let tableDef = false;       // 当前期待的表名属于 CREATE/ALTER TABLE 的定义
+  let stmtFirst = true;
+  let stmtKind = 'other';
+  let pendingCreate = false;
+  let pendingAlter = false;
+  let pragmaPending = false;
+  let onConsumed = false;
+  let inWith = false;
+  let parenDepth = 0;
+  const cteNames = new Set();
+
+  const resetStatement = () => {
+    expectingTable = false;
+    tableDef = false;
+    stmtFirst = true;
+    stmtKind = 'other';
+    pendingCreate = false;
+    pendingAlter = false;
+    pragmaPending = false;
+    onConsumed = false;
+    inWith = false;
+    cteNames.clear();
+  };
+
+  const formatPrefixed = (name) => {
+    const full = prefix + name;
+    const needsQuote = /[^a-zA-Z0-9_]/.test(full);
+    return needsQuote ? `"${full}"` : full;
+  };
+
+  const resolveTableName = (name, isDef) => {
+    const lower = name.toLowerCase();
+    if (lower.startsWith(prefix)) return name;
+    const foreignPrefix = /^plg_[a-zA-Z0-9_-]+_/.exec(lower)?.[0];
+    if (foreignPrefix) {
+      throw new Error(
+        `插件 ${pluginName} 不能访问表 ${name}：前缀 ${foreignPrefix} 属于其他插件` +
+        `（本插件只能访问 ${prefix} 开头的表）`
+      );
+    }
+    if (CORE_TABLES.has(lower)) {
+      throw new Error(
+        `插件 ${pluginName} 不能访问表 ${name}：只允许访问 ${prefix} 开头的表` +
+        `（核心表与其他插件表均不开放给插件）`
+      );
+    }
+    if (isDef || ownTables.has(lower)) {
+      if (isDef) ownTables.add(lower);
+      return formatPrefixed(name);
+    }
+    throw new Error(
+      `插件 ${pluginName} 不能访问表 ${name}：只允许访问 ${prefix} 开头的表` +
+      `（核心表与其他插件表均不开放给插件）`
+    );
+  };
+
+  while (i < n) {
+    const ch = sql[i];
+    const segmentStart = i;
+
+    // 字符串字面量：整体复制
+    if (ch === "'") {
+      i++;
+      while (i < n) {
+        if (sql[i] === "'") {
+          if (sql[i + 1] === "'") { i += 2; continue; }
+          i++;
+          break;
+        }
+        i++;
+      }
+      result += sql.slice(segmentStart, i);
+      continue;
+    }
+
+    // 行注释 / 块注释：整体复制
+    if (ch === '-' && sql[i + 1] === '-') {
+      i += 2;
+      while (i < n && sql[i] !== '\n') i++;
+      result += sql.slice(segmentStart, i);
+      continue;
+    }
+    if (ch === '/' && sql[i + 1] === '*') {
+      i += 2;
+      while (i < n && !(sql[i] === '*' && sql[i + 1] === '/')) i++;
+      i = Math.min(i + 2, n);
+      result += sql.slice(segmentStart, i);
+      continue;
+    }
+
+    // 引号标识符（"..."、`...`、[...]）
+    if (ch === '"' || ch === '\`' || ch === '[') {
+      const close = ch === '[' ? ']' : ch;
+      let j = i + 1;
+      let ident = '';
+      while (j < n && sql[j] !== close) { ident += sql[j]; j++; }
+      if (j >= n) {
+        // 未闭合，整体复制并结束
+        result += sql.slice(segmentStart, n);
+        break;
+      }
+      if (expectingTable) {
+        result += ch + resolveTableName(ident, tableDef) + close;
+        expectingTable = false;
+        tableDef = false;
+      } else {
+        result += sql.slice(segmentStart, j + 1);
+      }
+      i = j + 1;
+      continue;
+    }
+
+    if (ch === '(') { parenDepth++; result += ch; i++; continue; }
+    if (ch === ')') {
+      parenDepth = Math.max(0, parenDepth - 1);
+      if (expectingTable) { expectingTable = false; tableDef = false; }
+      result += ch;
+      i++;
+      continue;
+    }
+    if (ch === ';') { resetStatement(); result += ch; i++; continue; }
+
+    // 词（标识符/关键字）
+    if (/[A-Za-z_]/.test(ch)) {
+      let j = i;
+      let word = '';
+      while (j < n && /[A-Za-z0-9_]/.test(sql[j])) { word += sql[j]; j++; }
+      const up = word.toUpperCase();
+      const wordLower = word.toLowerCase();
+
+      // WITH 子句（深度 0）：收集 CTE 名
+      if (inWith && parenDepth === 0) {
+        if (up === 'SELECT') {
+          inWith = false;
+        } else {
+          let k = j;
+          while (k < n && /\s/.test(sql[k])) k++;
+          if (sql[k] === '(') cteNames.add(wordLower);
+          else if (sql.startsWith('AS', k) && !/[A-Za-z0-9_]/.test(sql[k + 2] || '')) {
+            cteNames.add(wordLower);
+          }
+        }
+      }
+
+      if (stmtFirst) {
+        stmtFirst = false;
+        if (up === 'CREATE') { pendingCreate = true; }
+        if (up === 'ALTER') { pendingAlter = true; }
+        if (up === 'WITH') { inWith = true; }
+        if (up === 'PRAGMA') { pragmaPending = true; }
+      }
+      if (pendingCreate && up !== 'CREATE') {
+        if (up === 'TABLE') tableDef = true;
+        if (up !== 'UNIQUE' && up !== 'TEMP' && up !== 'TEMPORARY') {
+          if (up === 'INDEX' || up === 'TRIGGER') stmtKind = 'index-trigger';
+          pendingCreate = false;
+        }
+      }
+      if (pendingAlter && up !== 'ALTER') {
+        if (up === 'TABLE') tableDef = true;
+        pendingAlter = false;
+      }
+      if (pragmaPending && up !== 'PRAGMA') {
+        pragmaPending = false;
+        if (PRAGMA_TABLE_NAMES.has(up)) expectingTable = true;
+        result += word;
+        i = j;
+        continue;
+      }
+
+      if (expectingTable) {
+        if (TABLE_MODIFIER_KEYWORDS.has(up)) {
+          // 保持期待（IF NOT EXISTS / OR REPLACE 等）
+        } else if (NON_TABLE_KEYWORDS.has(up)) {
+          expectingTable = false;
+          tableDef = false;
+        } else if (cteNames.has(wordLower)) {
+          expectingTable = false;
+          tableDef = false;
+        } else {
+          result += resolveTableName(word, tableDef);
+          expectingTable = false;
+          tableDef = false;
+          i = j;
+          continue;
+        }
+      }
+
+      if (TABLE_INTRO_KEYWORDS.has(up)) {
+        expectingTable = true;
+      }
+      if (up === 'ON' && stmtKind === 'index-trigger' && !onConsumed) {
+        onConsumed = true;
+        expectingTable = true;
+      }
+
+      result += word;
+      i = j;
+      continue;
+    }
+
+    if (expectingTable && ch !== '(' && ch !== '=' && !/\s/.test(ch)) {
+      expectingTable = false;
+      tableDef = false;
+    }
+    result += ch;
+    i++;
+  }
+
+  return result;
 }
 
 /** 构建命名空间存储 db */

--- a/core/plugin-loader.js
+++ b/core/plugin-loader.js
@@ -19,7 +19,7 @@ import {
 import { createRequire } from 'node:module';
 import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
-import { buildPluginApi } from './plugin-api.js';
+import { buildPluginApi, rewritePluginTableNames } from './plugin-api.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -359,33 +359,14 @@ export class PluginLoader {
     return { order, cyclePlugins };
   }
 
-  /** 执行 schema.sql（支持裸表名自动重写为 plg_<name>_<tbl>） */
+  /** 执行 schema.sql（白名单校验 + 裸表名自动重写为 plg_<name>_<tbl>） */
   _applySchema(plugin) {
     const { ctx } = this;
     if (!plugin.schemaFile || !existsSync(plugin.schemaFile)) return;
-    let sql = readFileSync(plugin.schemaFile, 'utf-8');
-
-    // 拒绝访问其他插件的 plg_ 前缀
+    const sql = readFileSync(plugin.schemaFile, 'utf-8');
     const prefix = `plg_${plugin.name}_`;
-    const foreignRe = /\bplg_[a-zA-Z0-9_-]+_/g;
-    let m;
-    while ((m = foreignRe.exec(sql)) !== null) {
-      if (m[0] !== prefix) {
-        throw new Error(`schema.sql 中表前缀 ${m[0]} 不属于本插件 ${plugin.name}`);
-      }
-    }
-
-    // 把 CREATE TABLE / ALTER TABLE 后的裸表名重写为带前缀的表名
-    const tableRe = /((?:CREATE TABLE|ALTER TABLE)\s+(?:IF\s+NOT\s+EXISTS\s+)?)([a-zA-Z0-9_]+)/gi;
-    sql = sql.replace(tableRe, (match, pre, tableName) => {
-      if (tableName.startsWith('plg_')) return match;
-      const full = prefix + tableName;
-      // 仅当完整表名含非标识符字符（连字符插件名）才加双引号，避免非必需引号
-      const needsQuote = /[^a-zA-Z0-9_]/.test(full);
-      return `${pre}${needsQuote ? `"${full}"` : full}`;
-    });
-
-    ctx.storage.exec(sql);
+    const rewritten = rewritePluginTableNames(sql, plugin.name, prefix);
+    ctx.storage.exec(rewritten);
   }
 
   /** 检查插件 package.json 依赖是否已安装（不自动安装，缺依赖则抛出错误） */

--- a/test/test-plugin-db-sandbox.mjs
+++ b/test/test-plugin-db-sandbox.mjs
@@ -176,6 +176,26 @@ function makeApi(pluginName = 'testplugin') {
   assert(rewritten4.includes("INSERT INTO plg_schema_test_items"), 'schema INSERT INTO 插件表应被重写');
   assert(!rewritten4.includes('plg_schema_test_friends'), '字符串/注释中的 friends 不应被重写');
 
+  // 引号包裹裸表名 + 表名含空格（加前缀后仍需引号）：不应输出双重引号（review #161 修复）
+  const rewritten5 = rewritePluginTableNames(
+    'CREATE TABLE "my items" (id INTEGER); INSERT INTO "my items" (id) VALUES (1);',
+    'schema_test',
+    prefix
+  );
+  assert(rewritten5.includes('CREATE TABLE "plg_schema_test_my items"'), 'schema 引号裸表名(空格) CREATE 应重写为单层引号');
+  assert(rewritten5.includes('INSERT INTO "plg_schema_test_my items"'), 'schema 引号裸表名(空格) DML 应重写为单层引号');
+  assert(!rewritten5.includes('""'), '引号包裹表名不应出现双重引号');
+
+  // 插件名含连字符 → prefix 含连字符 → 表名需加引号（词分支也应正确）
+  const hPrefix = 'plg_emoji-notes_';
+  const rewritten6 = rewritePluginTableNames(
+    'CREATE TABLE notes (id INTEGER); INSERT INTO notes (id) VALUES (1);',
+    'emoji-notes',
+    hPrefix
+  );
+  assert(rewritten6.includes('CREATE TABLE "plg_emoji-notes_notes"'), '连字符插件名 CREATE 表名应带引号');
+  assert(rewritten6.includes('INSERT INTO "plg_emoji-notes_notes"'), '连字符插件名 DML 表名应带引号');
+
   console.log('  ✅ schema.sql 白名单：核心表/其他插件表拒绝，本插件裸表名重写');
 }
 

--- a/test/test-plugin-db-sandbox.mjs
+++ b/test/test-plugin-db-sandbox.mjs
@@ -9,7 +9,7 @@
  *
  * 用法：node test/test-plugin-db-sandbox.mjs
  */
-import { buildPluginApi as buildApi } from '../core/plugin-api.js';
+import { buildPluginApi as buildApi, rewritePluginTableNames } from '../core/plugin-api.js';
 
 let pass = true;
 const errors = [];
@@ -121,6 +121,62 @@ function makeApi(pluginName = 'testplugin') {
   assert(calls.length >= 8, '全部合法 SQL 应放行');
   assertThrows(() => items.all('WITH t AS (SELECT * FROM friends) SELECT * FROM t'), /friends/, 'CTE 内部读取核心表仍应被拒');
   console.log('  ✅ 不误报：字符串/注释/CTE/ON CONFLICT/合法关键字组合放行');
+}
+
+// ── 6. schema.sql 白名单（_applySchema 路径）──
+{
+  const prefix = 'plg_schema_test_';
+
+  // 拒绝：核心表名出现在各种表名位置
+  assertThrows(() => rewritePluginTableNames('INSERT INTO friends (id) VALUES (1)', 'schema_test', prefix), /friends/, 'schema INSERT INTO 核心表');
+  assertThrows(() => rewritePluginTableNames('SELECT * FROM friends', 'schema_test', prefix), /friends/, 'schema SELECT FROM 核心表');
+  assertThrows(() => rewritePluginTableNames('UPDATE friends SET x = 1', 'schema_test', prefix), /friends/, 'schema UPDATE 核心表');
+  assertThrows(() => rewritePluginTableNames('DELETE FROM events WHERE id = 1', 'schema_test', prefix), /events/, 'schema DELETE FROM 核心表');
+  assertThrows(() => rewritePluginTableNames('CREATE TABLE friends (id INTEGER)', 'schema_test', prefix), /friends/, 'schema CREATE TABLE 核心表');
+  assertThrows(() => rewritePluginTableNames('ALTER TABLE friends ADD COLUMN x', 'schema_test', prefix), /friends/, 'schema ALTER TABLE 核心表');
+  assertThrows(() => rewritePluginTableNames('PRAGMA table_info(friends)', 'schema_test', prefix), /friends/, 'schema PRAGMA table_info 核心表');
+  assertThrows(() => rewritePluginTableNames('CREATE INDEX idx ON friends(col)', 'schema_test', prefix), /friends/, 'schema CREATE INDEX ON 核心表');
+
+  // 拒绝：其他插件前缀
+  assertThrows(() => rewritePluginTableNames('SELECT * FROM plg_otherplugin_notes', 'schema_test', prefix), /plg_otherplugin_/, 'schema 访问其他插件表');
+
+  // 合法：本插件裸表名在 CREATE/ALTER 后定义，并在 DML/DDL 位置重写
+  const rewritten = rewritePluginTableNames(
+    "CREATE TABLE notes (id INTEGER PRIMARY KEY, note TEXT); INSERT INTO notes (note) VALUES ('hello');",
+    'schema_test',
+    prefix
+  );
+  assert(rewritten.includes('CREATE TABLE plg_schema_test_notes'), 'schema CREATE TABLE 裸表名应被重写');
+  assert(rewritten.includes('INSERT INTO plg_schema_test_notes'), 'schema INSERT INTO 裸表名应被重写');
+
+  // CREATE INDEX / ALTER TABLE / DROP TABLE 引用本插件裸表名也允许
+  const rewritten2 = rewritePluginTableNames(
+    'CREATE TABLE logs (id INTEGER); CREATE INDEX idx ON logs(col); ALTER TABLE logs RENAME TO logs_v2;',
+    'schema_test',
+    prefix
+  );
+  assert(rewritten2.includes('CREATE TABLE plg_schema_test_logs'), 'schema CREATE TABLE logs 应被重写');
+  assert(rewritten2.includes('CREATE INDEX idx ON plg_schema_test_logs'), 'schema CREATE INDEX ON logs 应被重写');
+
+  // 带 IF NOT EXISTS 的 CREATE TABLE 同样识别为插件表定义
+  const rewritten3 = rewritePluginTableNames(
+    'CREATE TABLE IF NOT EXISTS items (id INTEGER); SELECT * FROM items;',
+    'schema_test',
+    prefix
+  );
+  assert(rewritten3.includes('CREATE TABLE IF NOT EXISTS plg_schema_test_items'), 'schema CREATE TABLE IF NOT EXISTS 应被重写');
+  assert(rewritten3.includes('SELECT * FROM plg_schema_test_items'), 'schema SELECT FROM 插件表应被重写');
+
+  // 字符串/注释中的核心表名不误报
+  const rewritten4 = rewritePluginTableNames(
+    "CREATE TABLE items (note TEXT); INSERT INTO items (note) VALUES ('friends'); -- from events\n/* select friends */",
+    'schema_test',
+    prefix
+  );
+  assert(rewritten4.includes("INSERT INTO plg_schema_test_items"), 'schema INSERT INTO 插件表应被重写');
+  assert(!rewritten4.includes('plg_schema_test_friends'), '字符串/注释中的 friends 不应被重写');
+
+  console.log('  ✅ schema.sql 白名单：核心表/其他插件表拒绝，本插件裸表名重写');
 }
 
 if (pass) {


### PR DESCRIPTION
## 背景
issue #160：R1（PR #159）把 `core/plugin-api.js` 的 `validatePrefixes` 升级为白名单制，但插件加载时执行 schema.sql 的另一条路径 `_applySchema` **未纳入**该白名单——插件 schema.sql 可读写核心表（friends/events/world_kb 等），绕过了 R1 沙箱。

## 改动
1. **`core/plugin-api.js`**
   - 新增 `CORE_TABLES`：从 `core/init-db.sql` / `init-x-worlds.sql` 动态抓取核心表名集合。
   - 导出 `findForeignTableName` 供复用。
   - 新增 `rewritePluginTableNames(sql, pluginName, prefix)`：扫描 schema.sql 所有表名位置，把插件自身在 CREATE/ALTER TABLE 中声明的裸表名重写为 `plg_<name>_<tbl>`；遇核心表 / 其他插件表 / 其他插件 `plg_` 前缀显式抛错。
2. **`core/plugin-loader.js`**
   - `_applySchema` 移除旧的 `foreignRe` / `tableRe` 两段式处理，改为调用 `rewritePluginTableNames` 做白名单校验 + 裸表名重写后执行。
3. **`test/test-plugin-db-sandbox.mjs`**
   - 新增「schema.sql 白名单」一节，覆盖核心表各表名位置拒绝、其他插件表拒绝、本插件裸表名重写、字符串/注释不误报、IF NOT EXISTS / CREATE INDEX / ALTER / CTE 边界。

## 验证
- `npm test`：**66/66 通过，0 失败**（真实执行）。
- 核心表（friends/events）在 INSERT/SELECT/UPDATE/DELETE/CREATE TABLE/ALTER/PRAGMA/CREATE INDEX 任一表名位置均被拒绝；访问其他插件表 `plg_otherplugin_*` 被拒；合法插件 schema（`CREATE TABLE notes; INSERT INTO notes ...`）被正确重写为 `plg_<plugin>_notes` 并执行。

## 契约
符合 docs/PLUGIN-API.md §4.2「插件互相不可见、不可跨表」——schema.sql 与运行时 db API 走同一白名单，不再有绕过路径。

Closes #160
