### PR TITLE
feat(tracked): 好友关系变化联动非好友追踪——删好友即时入列、加好友自动移出

### DIFF
--- a/core/event-pipeline.js
+++ b/core/event-pipeline.js
@@ -268,6 +268,16 @@ export class EventPipeline {
 
   async _handleAdd(event) {
     this._storeEvent(event);
+    // 加好友联动：该人已是好友 → 从非好友追踪移出（软删除 removed_at 标记）。
+    // 与 _handleDelete 的重新激活成对：加好友移出、删好友激活，tracked 列表始终只含"非好友"。
+    // 不在 tracked 则无操作（好友不需要追踪条目）。
+    try {
+      if (event.userId && String(event.userId).startsWith('usr_')) {
+        this.storage.run(
+          `UPDATE tracked_non_friends SET removed_at = datetime('now') WHERE user_id = $u AND removed_at = ''`,
+          { $u: event.userId });
+      }
+    } catch { /* 联动失败不影响事件记录 */ }
   }
 
   async _handleDelete(event) {
@@ -278,6 +288,17 @@ export class EventPipeline {
     try {
       if (event.userId) this.storage.run('DELETE FROM friends WHERE user_id = $u', { $u: event.userId });
     } catch { /* 移除失败不影响事件记录 */ }
+    // 删好友联动：被删好友即时进入非好友追踪（此前需等重启自动导入，运行期存在追踪空窗）。
+    // ① 从未 tracked → 新增；② 手动移除过（removed_at != ''）→ 重新激活（重新成为"历史非好友"）。
+    // display_name 用事件携带值，后续定时刷新会以 /users/{id} 资料覆盖。
+    try {
+      if (event.userId && String(event.userId).startsWith('usr_')) {
+        this.storage.run(
+          `INSERT INTO tracked_non_friends (user_id, display_name) VALUES ($u, $d)
+           ON CONFLICT(user_id) DO UPDATE SET removed_at = ''`,
+          { $u: event.userId, $d: event.displayName || '' });
+      }
+    } catch { /* 联动失败不影响事件记录 */ }
   }
 
   async _handleNotification(event) {

--- a/test/test-monitor-friend-delete.test.mjs
+++ b/test/test-monitor-friend-delete.test.mjs
@@ -53,6 +53,51 @@ test('friend-delete 移除好友 + 不影响他人 + 事件入 events 表 + 重�
   assert.equal(r.dn, '好友甲(重新加)', '重建后 display_name 应为新值');
 });
 
+// ── 好友关系变化 × 非好友追踪联动（tracked_non_friends）──
+test('friend-delete 即时进入非好友追踪（新行新增 + 已移除行重新激活）', async () => {
+  const D1 = 'usr_test-delf-0000000000000000000000a1';
+  const D2 = 'usr_test-delf-0000000000000000000000a2';
+  // D1 从未 tracked；D2 曾 tracked 且被手动移除（removed_at != ''）
+  storage.upsertFriend({ userId: D1, displayName: '将删好友一', isOnline: 0 });
+  storage.upsertFriend({ userId: D2, displayName: '将删好友二', isOnline: 0 });
+  storage.run(`INSERT OR IGNORE INTO tracked_non_friends (user_id, display_name) VALUES ($u, $d)`,
+    { $u: D2, $d: '将删好友二' });
+  storage.run(`UPDATE tracked_non_friends SET removed_at = datetime('now') WHERE user_id = $u`, { $u: D2 });
+  const d2Before = storage.query(`SELECT removed_at FROM tracked_non_friends WHERE user_id=$u`, { $u: D2 })[0];
+  assert.ok(d2Before.removed_at, '前置:D2 应处于已移除状态');
+
+  await pipe._handleDelete({ userId: D1, type: 'friend-delete', displayName: '将删好友一', receivedAt: new Date().toISOString() });
+  await pipe._handleDelete({ userId: D2, type: 'friend-delete', displayName: '将删好友二', receivedAt: new Date().toISOString() });
+
+  const d1Row = storage.query(`SELECT display_name, removed_at FROM tracked_non_friends WHERE user_id=$u`, { $u: D1 })[0];
+  assert.ok(d1Row, '被删好友 D1 应即时进入 tracked(无需等重启自动导入)');
+  assert.equal(d1Row.removed_at, '', '新进入的 tracked 行应为活跃状态');
+  assert.equal(d1Row.display_name, '将删好友一', 'display_name 取事件携带值');
+  const d2Row = storage.query(`SELECT removed_at FROM tracked_non_friends WHERE user_id=$u`, { $u: D2 })[0];
+  assert.equal(d2Row.removed_at, '', '已移除的 tracked 行应被重新激活(removed_at 清空)');
+});
+
+test('friend-add 从非好友追踪移出(软删除)+ 不在 tracked 的好友无新行', async () => {
+  const A1 = 'usr_test-delf-0000000000000000000000b1';
+  const A2 = 'usr_test-delf-0000000000000000000000b2';
+  // A1 已在 tracked(活跃)；A2 不在 tracked
+  storage.run(`INSERT OR IGNORE INTO tracked_non_friends (user_id, display_name) VALUES ($u, $d)`,
+    { $u: A1, $d: '转正好友' });
+
+  await pipe._handleAdd({ userId: A1, type: 'friend-add', displayName: '转正好友', receivedAt: new Date().toISOString() });
+  await pipe._handleAdd({ userId: A2, type: 'friend-add', displayName: '纯新好友', receivedAt: new Date().toISOString() });
+
+  const a1 = storage.query(`SELECT removed_at FROM tracked_non_friends WHERE user_id=$u`, { $u: A1 })[0];
+  assert.ok(a1.removed_at, '加好友后 tracked 活跃行应被标记移出(已是好友,不再是非好友)');
+  const a2 = storage.query(`SELECT COUNT(*) c FROM tracked_non_friends WHERE user_id=$u`, { $u: A2 })[0];
+  assert.equal(a2.c, 0, '不在 tracked 的好友加好友后不应新增 tracked 行');
+
+  // 成对语义回归:再删好友 → 重新激活(加好友移出 / 删好友激活 闭环)
+  await pipe._handleDelete({ userId: A1, type: 'friend-delete', displayName: '转正好友', receivedAt: new Date().toISOString() });
+  const a1Back = storage.query(`SELECT removed_at FROM tracked_non_friends WHERE user_id=$u`, { $u: A1 })[0];
+  assert.equal(a1Back.removed_at, '', '删好友后应重新激活追踪(成对联动)');
+});
+
 // ── 清理 ──
 after(() => {
   for (const f of [tmpDb, tmpDb + '-wal', tmpDb + '-shm']) { try { rmSync(f, { force: true }); } catch {} }


### PR DESCRIPTION
## 需求来源

自部署实测发现 tracked_non_friends（非好友追踪）与好友关系变化**零联动**，存在两个语义/空窗问题：

1. **删好友运行期不追踪**：friend-delete 只从 friends 表移除（事件历史保留），被删好友要等服务**重启**的自动导入（扫近 30 天 events）才进入追踪——运行期存在追踪空窗；
2. **非好友转正后留守**：非好友加了好友后 tracked 行原地不动，定时刷新继续拉资料（占用刷新配额），且列表语义漂移（「非好友」追踪里出现现役好友）。

## 实现方式

成对联动、零 schema 迁移（core/event-pipeline.js）：

- **friend-delete** → `INSERT ... ON CONFLICT(user_id) DO UPDATE SET removed_at = ''`：从未 tracked 的新增；手动移除过的**重新激活**（重新成为「历史非好友」，与自动导入的 removed_at 排除逻辑自洽——删好友的用户意图通常就是想重新关注此人动向）；
- **friend-add** → `UPDATE removed_at = datetime('now') WHERE removed_at = ''`：已是好友自动移出追踪（与手动移除同通道）。不在 tracked 则无操作（好友不需要条目）。

两者成对闭环：加好友移出 ⇄ 删好友激活，tracked 列表始终只含「非好友」。display_name 取事件携带值，后续定时刷新以 /users/{id} 资料覆盖。

## 验证过程与结果

- 新增 2 测试用例（test-monitor-friend-delete.test.mjs，与 issue #127 回归同文件）：
  ① friend-delete：从未 tracked 新增（removed_at=''）+ 手动移除行重新激活；
  ② friend-add：活跃行标记移出 + 不在 tracked 的好友无新行 + 再删好友重新激活（成对闭环回归）；
- 专项 **3/3**、全量 **69/69** 通过；
- 生产部署验证：healthy、tracked 列表正常返回、无加载失败残留。

## 说明

- 纯 core/event-pipeline.js + 测试，无 UI/dist/文档清单变更（不新增工具/不新增事件类型）。
- 已知交互：手动移除过的人如果与用户互加好友再删除，会重新激活追踪——这与「删好友 = 重新成为历史非好友」的功能定位一致，如需永久排除可后续讨论单独标记字段。
