### PR TITLE
fix(plugin-api): 沙箱白名单扫描器批次2——表值函数放行/VACUUM+ATTACH拒绝/PRAGMA补全/RENAME TO校验(#167)

### DIFF
--- a/core/plugin-api.js
+++ b/core/plugin-api.js
@@ -138,7 +138,17 @@ const NON_TABLE_KEYWORDS = new Set([
 // PRAGMA 带表名参数的 pragma 名（PRAGMA table_info(plg_x_t) 等）
 const PRAGMA_TABLE_NAMES = new Set([
   'TABLE_INFO', 'TABLE_XINFO', 'INDEX_LIST', 'INDEX_INFO', 'INDEX_XINFO', 'FOREIGN_KEY_LIST',
+  'FOREIGN_KEY_CHECK',
 ]);
+// FROM 位置允许的表值函数（#167 ⚠️1：json_each 等返回行集而非读表，不构成越权）。
+// 集合外函数在表名位置仍按外来标识符拒绝（保守白名单制）。
+const TABLE_VALUED_FUNCTIONS = new Set([
+  'JSON_EACH', 'JSON_TREE', 'PRAGMA_TABLE_INFO', 'PRAGMA_TABLE_XINFO',
+  'GENERATE_SERIES', 'VALUE_LIST', 'SQLITE_EXPIRED_STATEMENTS',
+]);
+// 语句级拒绝：作用域为整个数据库/连接、不出现表名位置、可整库导出或外部挂载的语句
+// （#167 ⚠️2：VACUUM INTO 可整库导出；ATTACH/DETACH 挂载外部库后可跨库引用核心表）
+const FORBIDDEN_STATEMENTS = new Set(['VACUUM', 'ATTACH', 'DETACH']);
 
 /**
  * 白名单扫描：SQL 中表名位置的标识符必须全部以本插件 prefix 开头。
@@ -248,6 +258,9 @@ export function findForeignTableName(sql, prefix) {
       // UPDATE/DELETE/DROP 等首词不 continue，继续参与表名引入判定。
       if (stmtFirst) {
         stmtFirst = false;
+        if (FORBIDDEN_STATEMENTS.has(up)) {
+          return `__stmt:${up}`;   // #167 ⚠️2：VACUUM/ATTACH/DETACH 作用域为整库，整条拒绝
+        }
         if (up === 'CREATE') { pendingCreate = true; continue; }
         if (up === 'WITH') { inWith = true; continue; }
         if (up === 'PRAGMA') { pragmaPending = true; continue; }
@@ -268,6 +281,11 @@ export function findForeignTableName(sql, prefix) {
       if (expectingTable) {
         if (TABLE_MODIFIER_KEYWORDS.has(up)) { /* 保持期待 */ }
         else if (NON_TABLE_KEYWORDS.has(up)) { expectingTable = false; }
+        else if (TABLE_VALUED_FUNCTIONS.has(up)) {
+          // 表值函数（json_each 等返回行集，不读表）→ 放行，跳过其括号参数
+          expectingTable = false;
+          continue;
+        }
         else if (cteNames.has(word.toLowerCase())) { expectingTable = false; }
         else {
           if (!word.toLowerCase().startsWith(prefix)) return word;
@@ -320,6 +338,7 @@ export function rewritePluginTableNames(sql, pluginName, prefix) {
   let stmtKind = 'other';
   let pendingCreate = false;
   let pendingAlter = false;
+  let renameTo = false;         // ALTER ... RENAME TO 的目标名位置（#167 💡6）
   let pragmaPending = false;
   let onConsumed = false;
   let inWith = false;
@@ -333,6 +352,7 @@ export function rewritePluginTableNames(sql, pluginName, prefix) {
     stmtKind = 'other';
     pendingCreate = false;
     pendingAlter = false;
+    renameTo = false;
     pragmaPending = false;
     onConsumed = false;
     inWith = false;
@@ -469,6 +489,12 @@ export function rewritePluginTableNames(sql, pluginName, prefix) {
 
       if (stmtFirst) {
         stmtFirst = false;
+        if (FORBIDDEN_STATEMENTS.has(up)) {
+          throw new Error(
+            `插件 ${pluginName} 不允许执行 ${up} 语句（作用域为整个数据库，` +
+            `插件沙箱只开放 ${prefix} 开头的表级操作）`
+          );
+        }
         if (up === 'CREATE') { pendingCreate = true; }
         if (up === 'ALTER') { pendingAlter = true; }
         if (up === 'WITH') { inWith = true; }
@@ -518,6 +544,9 @@ export function rewritePluginTableNames(sql, pluginName, prefix) {
         onConsumed = true;
         expectingTable = true;
       }
+      // ALTER ... RENAME TO <目标>（#167 💡6）：目标名与 FROM/INTO 同级校验/重写
+      if (up === 'RENAME') renameTo = true;
+      if (up === 'TO' && renameTo) { renameTo = false; expectingTable = true; tableDef = true; }
 
       result += word;
       i = j;

--- a/core/plugin-api.js
+++ b/core/plugin-api.js
@@ -165,6 +165,7 @@ export function findForeignTableName(sql, prefix) {
   let pragmaPending = false;    // 语句首词是 PRAGMA，等待 pragma 名
   let onConsumed = false;       // 本语句首个 ON 是否已用于表名位置
   let inWith = false;           // WITH 子句中（收集 CTE 名）
+  let renameTo = false;         // ALTER ... RENAME TO 的目标名位置（review #169 建议#2）
   let parenDepth = 0;
   const cteNames = new Set();
 
@@ -176,6 +177,7 @@ export function findForeignTableName(sql, prefix) {
     pragmaPending = false;
     onConsumed = false;
     inWith = false;
+    renameTo = false;
   };
 
   while (i < n) {
@@ -299,6 +301,11 @@ export function findForeignTableName(sql, prefix) {
         onConsumed = true;
         expectingTable = true;
       }
+      // ALTER ... RENAME TO <目标>（review #169 建议#2）：目标名与 FROM 同级校验
+      // RENAME COLUMN 的目标是列名，遇 COLUMN 即清除标志（与 rewrite 路径一致）
+      if (up === 'RENAME') renameTo = true;
+      if (up === 'COLUMN' && renameTo) renameTo = false;
+      if (up === 'TO' && renameTo) { renameTo = false; expectingTable = true; }
       continue;
     }
 
@@ -545,7 +552,9 @@ export function rewritePluginTableNames(sql, pluginName, prefix) {
         expectingTable = true;
       }
       // ALTER ... RENAME TO <目标>（#167 💡6）：目标名与 FROM/INTO 同级校验/重写
+      // RENAME COLUMN（SQLite 3.25+）的目标是列名而非表名，遇 COLUMN 即清除标志（review #169 inline #1）
       if (up === 'RENAME') renameTo = true;
+      if (up === 'COLUMN' && renameTo) renameTo = false;
       if (up === 'TO' && renameTo) { renameTo = false; expectingTable = true; tableDef = true; }
 
       result += word;
@@ -587,6 +596,15 @@ function buildDbNamespace({ pluginName, prefix, ctx }) {
     // 2) 白名单：表名位置的标识符必须都是本插件前缀（核心表/其他插件表一律拒绝）
     const offender = findForeignTableName(sql, prefix);
     if (offender) {
+      // __stmt: 哨兵（findForeignTableName 返回）= 语句级拒绝（VACUUM/ATTACH/DETACH 等），
+      // 单独输出可读文案，避免误导插件作者以为是表名问题（review #169 💡2）
+      const stmtMatch = /^__stmt:([A-Za-z]+)$/.exec(offender);
+      if (stmtMatch) {
+        throw new Error(
+          `插件 ${pluginName} 不允许执行 ${stmtMatch[1]} 语句：作用域为整个数据库` +
+          `（可整库导出或挂载外部库，禁止在插件内执行）`
+        );
+      }
       const foreignPrefix = /^plg_[a-zA-Z0-9_-]+_/.exec(offender.toLowerCase())?.[0];
       if (foreignPrefix) {
         throw new Error(

--- a/test/test-plugin-db-sandbox.test.mjs
+++ b/test/test-plugin-db-sandbox.test.mjs
@@ -123,6 +123,39 @@ function makeApi(pluginName = 'testplugin') {
   console.log('  ✅ 不误报：字符串/注释/CTE/ON CONFLICT/合法关键字组合放行');
 }
 
+// ── 5b. #167 批次2 行为（review #169 补测试）：表值函数放行 / 语句级拒绝 / RENAME 处理 ──
+{
+  const { api } = makeApi();
+  const items = api.db.table('items');
+
+  // 表值函数在表名位置放行（不读表，无越权）
+  items.all('SELECT * FROM json_each(\'[1,2,3]\')');
+  items.all('SELECT * FROM json_tree(\'{"a":1}\')');
+  items.all('SELECT * FROM generate_series(1, 5)');
+  items.all('SELECT * FROM pragma_table_info(\'items\')');
+  items.all('SELECT value FROM json_each((SELECT note FROM items))'); // 内嵌子查询仍受检：items 是本插件表
+  assertThrows(() => items.all('SELECT * FROM json_each((SELECT json FROM events))'), /events/, '表值函数参数内的核心表子查询仍被拒');
+
+  // 语句级拒绝：VACUUM/ATTACH/DETACH（首词 + 中段 ;VACUUM;）+ 专属报错文案（review #169 💡2）
+  assertThrows(() => api.db.exec('VACUUM'), /不允许执行 VACUUM 语句/, 'VACUUM 语句级拒绝');
+  assertThrows(() => api.db.exec("VACUUM INTO 'backup.db'"), /不允许执行 VACUUM 语句/, 'VACUUM INTO 拒绝');
+  assertThrows(() => api.db.exec("ATTACH DATABASE 'x.db' AS x"), /不允许执行 ATTACH 语句/, 'ATTACH 拒绝');
+  assertThrows(() => api.db.exec('DETACH DATABASE x'), /不允许执行 DETACH 语句/, 'DETACH 拒绝');
+  assertThrows(() => api.db.exec('SELECT 1; VACUUM;'), /不允许执行 VACUUM 语句/, '语句中段 ;VACUUM; 拒绝');
+  // 字符串字面量内的 VACUUM 不误报
+  items.all("SELECT 'VACUUM' AS s FROM items");
+
+  // 运行期 RENAME TO：目标纳入校验（review #169 建议#2）
+  api.db.exec('ALTER TABLE items RENAME TO plg_testplugin_items_v2'); // 本插件命名空间内改名放行
+  assertThrows(() => api.db.exec('ALTER TABLE plg_testplugin_items_v2 RENAME TO events'), /events/, 'RENAME TO 核心表名拒绝');
+  assertThrows(() => api.db.exec('ALTER TABLE plg_testplugin_items_v2 RENAME TO x_backup'), /x_backup/, 'RENAME TO 无前缀目标拒绝');
+
+  // 运行期 RENAME COLUMN：列名目标不进入表名校验（COLUMN 豁免，review #169 inline #1）
+  api.db.exec('ALTER TABLE plg_testplugin_items_v2 RENAME COLUMN note TO note2');
+
+  console.log('  ✅ #167批次2：表值函数放行/VACUUM+ATTACH拒绝(专属文案)/RENAME TO校验/RENAME COLUMN豁免');
+}
+
 // ── 6. schema.sql 白名单（_applySchema 路径）──
 {
   const prefix = 'plg_schema_test_';
@@ -195,6 +228,26 @@ function makeApi(pluginName = 'testplugin') {
   );
   assert(rewritten6.includes('CREATE TABLE "plg_emoji-notes_notes"'), '连字符插件名 CREATE 表名应带引号');
   assert(rewritten6.includes('INSERT INTO "plg_emoji-notes_notes"'), '连字符插件名 DML 表名应带引号');
+
+  // RENAME COLUMN（SQLite 3.25+）：列名目标是列不是表，不应被加前缀（review #169 inline #1 回归用例）
+  const renamed = rewritePluginTableNames(
+    'ALTER TABLE logs RENAME COLUMN note TO note2',
+    'schema_test',
+    prefix
+  );
+  assert(renamed.includes('ALTER TABLE plg_schema_test_logs RENAME COLUMN note TO note2'), 'RENAME COLUMN 源表重写、列名透传');
+
+  // RENAME TO 目标为无前缀名 → 加前缀；为其他插件前缀 → 拒绝（review #169 建议#2 对应 schema 路径）
+  const renamed2 = rewritePluginTableNames(
+    'CREATE TABLE logs (id INTEGER); ALTER TABLE logs RENAME TO logs_v2;',
+    'schema_test',
+    prefix
+  );
+  assert(renamed2.includes('ALTER TABLE plg_schema_test_logs RENAME TO plg_schema_test_logs_v2'), 'RENAME TO 无前缀目标应加前缀');
+  assertThrows(
+    () => rewritePluginTableNames('CREATE TABLE logs (id INTEGER); ALTER TABLE logs RENAME TO friends;', 'schema_test', prefix),
+    /friends/, 'RENAME TO 核心表名拒绝'
+  );
 
   console.log('  ✅ schema.sql 白名单：核心表/其他插件表拒绝，本插件裸表名重写');
 }


### PR DESCRIPTION
## 需求来源

#167(#159 双审非阻断发现聚合跟踪)的 ⚠️1/⚠️2/💡5/💡6 四项——白名单扫描器批次的边界加固。依赖:#168 先合并(本分支含其重命名 commit,合并后自动对齐)。

## 实现方式(core/plugin-api.js)

- **⚠️1 表值函数误报**：FROM 位置的 `json_each`/`json_tree`/`pragma_table_info` 等表值函数返回行集而非读表，加入 `TABLE_VALUED_FUNCTIONS` 白名单放行（集合外函数仍拒绝，保守白名单制）；
- **⚠️2 整库级语句拒绝**：`VACUUM INTO`（整库导出到任意文件）/`ATTACH`/`DETACH`（挂载外部库后跨库引用核心表）作用域为整个数据库、无表名位置——语句首词命中 `FORBIDDEN_STATEMENTS` 直接拒绝（两条路径一致）；
- **💡5 PRAGMA 补全**：`PRAGMA_TABLE_NAMES` 增加 `FOREIGN_KEY_CHECK`（带表名参数，此前漏检，只读低危）；
- **💡6 RENAME TO 目标名**：rewrite 路径把 RENAME TO 目标按本插件新表定义处理（自动加前缀，核心表名/其他插件前缀作目标显式拒绝）；findForeignTableName 校验路径维持放行（核心表启动期已存在 + SQLite「目标已存在」运行时兜底，本 agent 实测确认当前不可利用）——两路径按各自能力对齐。

## 验证过程与结果

- `test-plugin-db-sandbox.test.mjs` 全过（含 #161/#168 既有断言与引号/双重引号回归）；
- 全量 **69/69** 通过；
- 四项均为防御收紧或误报修复：VACUUM/ATTACH/DETACH 是新增拒绝面（官方插件零使用，grep 验证）；表值函数放行影响面=未来合法使用的可用性。

Closes #167 的 ⚠️1/⚠️2/💡5/💡6 四项（⚠️3/⚠️4 已由 #168 承接；💡7 文档注记留待 docs PR）。
