### PR TITLE
fix(dashboard): 非好友追踪列表加权威源兜底——friends 表排除已好友(#164 补漏)

### DIFF
--- a/core/dashboard-services.js
+++ b/core/dashboard-services.js
@@ -762,7 +762,12 @@ export function registerDashboardServices(loader, ctx) {
                 (SELECT e.created_at FROM events e
                   WHERE e.user_id = t.user_id AND e.type = 'friend-update' AND e.source = 'poll'
                   ORDER BY e.id DESC LIMIT 1) AS lastChangeAt
-         FROM tracked_non_friends t WHERE t.removed_at = '' ORDER BY t.last_refresh_at DESC, t.added_at DESC LIMIT $limit`,
+         FROM tracked_non_friends t
+         -- 权威源兜底(#164 补漏):列表只含"当前非好友"。friend-add 联动写 removed_at 是事件驱动,
+         -- 事件丢失(停机/断连窗口内加好友)会残留;LEFT JOIN friends 排除,若日后解除好友自动回列。
+         LEFT JOIN friends f ON f.user_id = t.user_id
+         WHERE t.removed_at = '' AND f.user_id IS NULL
+         ORDER BY t.last_refresh_at DESC, t.added_at DESC LIMIT $limit`,
         { $limit: Math.min(Math.max(Number(limit) || 200, 1), 500) });
       const selfId = getSelfUserId(ctx.storage);
       return { tracked: rows.filter((r) => r.userId !== selfId).map((r) => ({ ...r, avatarUrl: avatarThumb(r.avatarUrl) || '' })) };

--- a/test/test-dashboard-services.test.mjs
+++ b/test/test-dashboard-services.test.mjs
@@ -70,6 +70,22 @@ test('dashboard.trackedNonFriends 返回 tracked 列表形状', () => {
   assert.ok(r.tracked.some((x) => x.userId === UID && x.displayName === '测试用户'));
 });
 
+test('tracked 列表权威源兜底：已是好友必不显示，解除好友自动回列（#164 补漏）', () => {
+  const UID2 = 'usr_test-0000-0000-0000-000000000002';
+  ctx.storage.run(
+    `INSERT OR REPLACE INTO tracked_non_friends (user_id, display_name, avatar_image_url, added_at, last_refresh_at)
+     VALUES ($u, $d, '', datetime('now'), datetime('now'))`,
+    { $u: UID2, $d: '曾追踪现好友' });
+  // 模拟 friend-add 事件丢失（联动未写 removed_at）：直接进 friends 权威表
+  ctx.storage.run(`INSERT OR REPLACE INTO friends (user_id, display_name) VALUES ($u, $d)`, { $u: UID2, $d: '曾追踪现好友' });
+  let r = services.get('dashboard.trackedNonFriends')({ limit: 50 });
+  assert.ok(!r.tracked.some((x) => x.userId === UID2), '已是好友的条目不得出现在追踪列表');
+  // 解除好友（friend-delete 联动删 friends 行）→ 自动回列，无需 removed_at
+  ctx.storage.run(`DELETE FROM friends WHERE user_id = $u`, { $u: UID2 });
+  r = services.get('dashboard.trackedNonFriends')({ limit: 50 });
+  assert.ok(r.tracked.some((x) => x.userId === UID2), '解除好友后应自动回到追踪列表');
+});
+
 test('trackedNonFriends.lastChangeAt 与 trackedChanges 最新变化一致（真实变更时间，非检测时间）', () => {
   const list = services.get('dashboard.trackedNonFriends')({ limit: 10 }).tracked;
   const x = list.find((i) => i.userId === UID);


### PR DESCRIPTION
## 问题（生产实测复现）

#164 的 friend-add 联动是**事件驱动**软删除（写 `removed_at`），存在两个缺口：
1. 事件丢失窗口（服务停机/WS 断连期间加好友，事件不补）→ 已好友残留追踪列表；
2. 联动上线前已加好友的存量条目（生产实测发现 1 例：09-07 加好友的用户 09-09 仍在 tracked 列表）。

列表语义『tracked 恒为非好友』被破坏。

## 修复

`dashboard.trackedNonFriends` 查询加权威源兜底：

```sql
FROM tracked_non_friends t
LEFT JOIN friends f ON f.user_id = t.user_id
WHERE t.removed_at = '' AND f.user_id IS NULL
```

- 当前好友一律不显示（friends 表为权威源，不依赖事件标记完整性）
- **解除好友后自动回列**（`removed_at` 未动，无需任何事件补偿）；与 friend-delete 联动重新激活语义兼容
- 单条查询（trackedChanges 用）不受影响，行为最小变更

## 验证

- 新增回归用例（test-dashboard-services）：friends 表出现即过滤、删除即回列，双向断言
- 全量 `npm test` **82/82**
- 生产部署实测：残留条目（1 例）立即从列表消失（12→11），无需改数据

与「追踪状态行对齐动态页」PR 相互独立。