### PR TITLE
feat(logging): 日志信噪比增强——事件管道分级日志+工具清单降噪+错误带stack

### DIFF
--- a/core/event-pipeline.js
+++ b/core/event-pipeline.js
@@ -3,6 +3,15 @@ import { getLogger } from './logger.js';
 
 const log = getLogger('event');
 
+// 码点安全截断（review #166：UTF-16 slice 会把 emoji 切半成 U+FFFD 替换符）。
+// 仅日志展示层用，不影响落库数据。
+function truncateCodePoints(str, max) {
+  const s = String(str ?? '');
+  const chars = Array.from(s);
+  return chars.length <= max ? s : chars.slice(0, max).join('');
+}
+
+
 /**
  * VRChat 好友监控系统 — 事件处理管道
  * 
@@ -145,7 +154,7 @@ export class EventPipeline {
     if (worldId && worldId !== 'private' && worldId !== prevWorldId) {
       log.info(`${displayName} 换世界 → ${worldName || worldId}`);
     } else {
-      log.debug(`${displayName} 位置更新: ${(worldName || worldId || location).slice(0, 60)}`);
+      log.debug(`${displayName} 位置更新: ${truncateCodePoints(worldName || worldId || location, 60)}`);
     }
   }
 
@@ -158,7 +167,7 @@ export class EventPipeline {
     const worldName = worldId ? await this._resolveWorldName(worldId) : '';
     // 仅存事件（不 upsertFriend——user-location 是自己的位置，不更新好友状态表）
     this._storeEvent({ ...event, worldId }, worldName);
-    log.debug(`我的位置: ${location.slice(0, 60)}`);
+    log.debug(`我的位置: ${truncateCodePoints(location, 60)}`);
     // 逛过的世界同步标记 world_kb.visited（2026-08-12 修复）：
     // 之前 visited 只在 scan_new_worlds 时更新，用户逛过但没再扫描的世界会一直标"未逛"，
     // 导致 get_new_worlds(onlyUnvisited) 把已逛的世界当新世界推荐。此处事件驱动回写，逛完即标记。
@@ -251,14 +260,14 @@ export class EventPipeline {
               break;
             }
             case 'bio': {
-              const prevBio = (c.payload.previousBio || '').slice(0, 40);
-              const newBio = (c.payload.bio || '').slice(0, 40);
+              const prevBio = truncateCodePoints(c.payload.previousBio, 40);
+              const newBio = truncateCodePoints(c.payload.bio, 40);
               log.info(`${displayName} bio变更: ${prevBio} → ${newBio}`);
               break;
             }
             case 'status': {
-              const prevSt = `${c.payload.previousStatus || ''} ${c.payload.previousStatusDescription || ''}`.trim().slice(0, 80);
-              const newSt = `${c.payload.status || ''} ${c.payload.statusDescription || ''}`.trim().slice(0, 80);
+              const prevSt = truncateCodePoints(`${c.payload.previousStatus || ''} ${c.payload.previousStatusDescription || ''}`.trim(), 80);
+              const newSt = truncateCodePoints(`${c.payload.status || ''} ${c.payload.statusDescription || ''}`.trim(), 80);
               log.info(`${displayName} 状态变更: ${prevSt || '(无)'} → ${newSt || '(无)'}`);
               break;
             }

--- a/core/event-pipeline.js
+++ b/core/event-pipeline.js
@@ -1,4 +1,7 @@
 import { avatarThumb, avatarOf } from './img-util.js';
+import { getLogger } from './logger.js';
+
+const log = getLogger('event');
 
 /**
  * VRChat 好友监控系统 — 事件处理管道
@@ -95,6 +98,7 @@ export class EventPipeline {
 
     // 存储事件（带解析到的世界名）
     this._storeEvent(event, worldName);
+    log.info(`${displayName} 上线「${worldName || worldId || location || '未知'}」`);
   }
 
   async _handleOffline(event) {
@@ -109,6 +113,7 @@ export class EventPipeline {
     });
 
     this._storeEvent(event);
+    log.info(`${event.displayName || userId} 下线`);
   }
 
   async _handleLocation(event) {
@@ -117,6 +122,9 @@ export class EventPipeline {
     const location = event.location || '';
     const worldId = event.worldId || '';
     const worldName = await this._resolveWorldName(worldId);
+
+    const prev = this.storage.getFriend(userId);
+    const prevWorldId = prev?.world_id || '';
 
     this.storage.upsertFriend({
       userId,
@@ -133,6 +141,12 @@ export class EventPipeline {
     // 导致 updated_at 永远新鲜、TTL 失效。
 
     this._storeEvent(event, worldName);
+
+    if (worldId && worldId !== 'private' && worldId !== prevWorldId) {
+      log.info(`${displayName} 换世界 → ${worldName || worldId}`);
+    } else {
+      log.debug(`${displayName} 位置更新: ${(worldName || worldId || location).slice(0, 60)}`);
+    }
   }
 
   async _handleUserLocation(event) {
@@ -144,6 +158,7 @@ export class EventPipeline {
     const worldName = worldId ? await this._resolveWorldName(worldId) : '';
     // 仅存事件（不 upsertFriend——user-location 是自己的位置，不更新好友状态表）
     this._storeEvent({ ...event, worldId }, worldName);
+    log.debug(`我的位置: ${location.slice(0, 60)}`);
     // 逛过的世界同步标记 world_kb.visited（2026-08-12 修复）：
     // 之前 visited 只在 scan_new_worlds 时更新，用户逛过但没再扫描的世界会一直标"未逛"，
     // 导致 get_new_worlds(onlyUnvisited) 把已逛的世界当新世界推荐。此处事件驱动回写，逛完即标记。
@@ -229,6 +244,35 @@ export class EventPipeline {
             createdAt: event.receivedAt,
             source: 'websocket',
           });
+
+          switch (c.type) {
+            case 'avatar': {
+              log.info(`${displayName} 头像变更`);
+              break;
+            }
+            case 'bio': {
+              const prevBio = (c.payload.previousBio || '').slice(0, 40);
+              const newBio = (c.payload.bio || '').slice(0, 40);
+              log.info(`${displayName} bio变更: ${prevBio} → ${newBio}`);
+              break;
+            }
+            case 'status': {
+              const prevSt = `${c.payload.previousStatus || ''} ${c.payload.previousStatusDescription || ''}`.trim().slice(0, 80);
+              const newSt = `${c.payload.status || ''} ${c.payload.statusDescription || ''}`.trim().slice(0, 80);
+              log.info(`${displayName} 状态变更: ${prevSt || '(无)'} → ${newSt || '(无)'}`);
+              break;
+            }
+            case 'user_icon': {
+              log.info(`${displayName} 头像框变更`);
+              break;
+            }
+            case 'pronouns': {
+              const prevPr = c.payload.previousPronouns || '';
+              const newPr = c.payload.pronouns || '';
+              log.info(`${displayName} 代词变更: ${prevPr} → ${newPr}`);
+              break;
+            }
+          }
         }
       }
 

--- a/core/http-server.js
+++ b/core/http-server.js
@@ -12,6 +12,7 @@ import * as registry from './registry.js';
 
 // 命名日志：MCP 协议层（JSON-RPC 往返），请求日志默认降为 debug 级避免 ping/keepalive 刷屏
 const logMCP = getLogger('mcp');
+const logApp = getLogger('app');
 
 // ── MCP 会话管理 ──
 const sessions = new Map();
@@ -115,7 +116,7 @@ async function handleRequest(req, res) {
     try {
       await route.handler(req, res);
     } catch (err) {
-      log(`[失败] 插件 HTTP 路由失败 [${route.pluginName} ${pathname}]: ${err.message}`);
+      logApp.error(`插件 HTTP 路由失败 [${route.pluginName} ${pathname}]: ${err.message}`, { stack: err.stack, pathname, pluginName: route.pluginName });
       if (!res.headersSent) {
         const body = JSON.stringify({ error: 'Internal Server Error', message: err.message });
         res.writeHead(500, { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(body) });
@@ -230,7 +231,7 @@ async function handleRpc(rpc, session, res) {
           result: { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] },
         }], session.id);
       } catch (err) {
-        log(`[失败] ${name} failed: ${err.message}`);
+        logApp.error(`工具调用失败 [${name}]: ${err.message}`, { stack: err.stack, name });
         sendError(res, id, err.message);
       }
       break;

--- a/core/ws-manager.js
+++ b/core/ws-manager.js
@@ -255,7 +255,7 @@ export class WsManager {
         this.onEvent(event);
       }
     } catch (err) {
-      log.error(`解析消息失败: ${err.message}`);
+      log.error(`解析消息失败: ${err.message}`, { stack: err.stack, raw: String(raw || '').slice(0, 100) });
     }
   }
 

--- a/start-monitor.js
+++ b/start-monitor.js
@@ -12,7 +12,7 @@ import path from 'node:path';
 import net from 'node:net';
 
 import { ctx, log, refreshWatchlistCache } from './core/server-context.js';
-import { initLogger, getLevelName } from './core/logger.js';
+import { initLogger, getLevelName, getLogger } from './core/logger.js';
 import { recordOpsLog, setOpsLogSink } from './core/ops-log.js';
 import * as registry from './core/registry.js';
 import { isSafeModeEnabled, DESTRUCTIVE_TOOLS } from './core/safe-mode.js';
@@ -47,6 +47,9 @@ import { notifier } from './core/notifier.js';
 import { buildChannels } from './core/notify-channels.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const logApp = getLogger('app');
+const logMCP = getLogger('mcp');
 
 // ── .env 加载（只取 VRC_MONITOR_*）──
 // 注意：无条件覆盖 process.env——服务被插件 spawn 时可能继承旧值，跳过会导致 .env 配置失效
@@ -826,7 +829,7 @@ setOpsLogSink((kind, level, message) => {
           log(`[追踪] [关注] ${event.displayName || event.userId}: ${event.type}`);
         }
       } catch (err) {
-        log(`[警告] 事件处理失败: ${err.message}`);
+        logApp.error(`事件处理失败: ${err.message}`, { stack: err.stack, type: event?.type, userId: event?.userId });
       }
     },
     onStatusChange: (status) => {
@@ -874,9 +877,9 @@ setOpsLogSink((kind, level, message) => {
   const server = createServer();
   server.listen(PORT, HOST, () => {
     log(`\n[启动] MCP 服务运行在 http://${HOST}:${PORT}/mcp\n`);
-    log('可用工具:');
+    log(`可用工具: ${registry.listTools().length} 个（完整清单通过 tools/list 或 /health 查询）`);
     for (const t of registry.listTools()) {
-      log(`  ${t.name} — ${t.description}`);
+      logMCP.debug(`  ${t.name} — ${t.description}`);
     }
     log(`\n健康检查: http://${HOST}:${PORT}/health`);
     log('\n按 Ctrl+C 停止\n');


### PR DESCRIPTION
## 背景
用户反馈日志太简略（调研报告 D:/workspace/hermes/log-research-report.md）。P0 三项落地。

## 改动
### P0-1 事件管道分级日志 (core/event-pipeline.js)
- 引入 getLogger('event'); 上线/下线/换世界/资料变更(头像/bio/状态/头像框/代词) 补 info 级日志（displayName+worldName+新旧摘要，bio/status 截断80字符防敏感）
- 位置更新默认 debug，换世界升 info

### P0-2 工具清单降噪 (start-monitor.js)
- 启动时 111 行 MCP 工具描述循环→一行汇总，完整清单降为 mcp debug 级

### P0-3 错误日志带上下文 (start-monitor/ws-manager/http-server)
- 4 处 error 补 err.stack + 场景变量(event.type/userId/raw/name/pathname)

## 验证
- npm test 82/82 全过
- 4 文件语法全过
- 事件日志格式实测落盘正确([event] 在线/下线/换世界/状态变更)
- 仅加日志不动业务逻辑

## 行为级变更
是（新增/升级日志输出，无功能影响）