### PR TITLE
fix(scripts): api-live-audit 按当前客户端重写——_request 原语+规范路径清单

### DIFF
--- a/scripts/api-live-audit.mjs
+++ b/scripts/api-live-audit.mjs
@@ -4,10 +4,13 @@
 // 用法：VRC_MONITOR_DIR=<仓库路径> COOKIE_FILE=<cookie文件> [VRC_MONITOR_USER_ID=<userId>] node scripts/api-live-audit.mjs
 // 只读探测：仅 GET；限速 400ms/次；素材 ID 自动从 auth/user 与本地 DB 采集。
 import path from 'node:path';
+import { pathToFileURL, fileURLToPath } from 'node:url';
 import Database from 'better-sqlite3';
 
-const REPO = process.env.VRC_MONITOR_DIR || new URL('..', import.meta.url).pathname;
-const { VrchatApiClient } = await import(path.join(REPO, 'vrchat-api.js'));
+// Windows 兼容（review #175 🔴1）：ESM import 的绝对路径必须是 file:// URL，
+// 裸盘符路径（D:/...）会 ERR_UNSUPPORTED_ESM_URL_SCHEME；默认 REPO 也要 fileURLToPath 归一。
+const REPO = process.env.VRC_MONITOR_DIR || fileURLToPath(new URL('..', import.meta.url));
+const { VrchatApiClient } = await import(pathToFileURL(path.join(REPO, 'vrchat-api.js')).href);
 const api = new VrchatApiClient('', '');
 api.loadCookieFromFile(process.env.COOKIE_FILE || path.join(REPO, 'data', 'auth_cookie.txt'));
 try { await api.ensureAuth(); } catch (e) { console.log('ensureAuth 失败（继续用现有 cookie）:', String(e.message || e).slice(0, 60)); }
@@ -15,10 +18,17 @@ try { await api.ensureAuth(); } catch (e) { console.log('ensureAuth 失败（继
 const dbPath = process.env.VRC_MONITOR_DB_PATH || path.join(REPO, 'data', 'vrc-monitor.sqlite3');
 const db = new Database(dbPath, { readonly: true });
 
-const me = (await api._request('GET', '/auth/user')).data;
+const meRes = await api._request('GET', '/auth/user');
+const me = meRes.data || {};
+// fail-fast（review #175 ⚠️1）：认证失效若不拦截，me.id=undefined 会让下游 URL
+// 退化成 /users/undefined/...，把「认证失效」伪装成「端点不可用」
+if (!me.id) {
+  console.error(`认证失效：/auth/user 返回 ${meRes.status}（检查 COOKIE_FILE 的 auth cookie 是否有效）`);
+  process.exit(1);
+}
 const SELF = process.env.VRC_MONITOR_USER_ID || me.id;
 const friend = db.prepare("SELECT user_id, display_name FROM friends LIMIT 1").get();
-const grp = db.prepare('SELECT group_id FROM group_cache LIMIT 1').get();
+const grp = db.prepare('SELECT group_id, name FROM group_cache LIMIT 1').get();
 const world = db.prepare('SELECT world_id FROM world_cache LIMIT 1').get();
 const files = (await api._request('GET', '/files?n=5')).data || [];
 const fileId = files[0] && files[0].id;
@@ -63,13 +73,13 @@ await probe('群组角色模板', '/groups/roleTemplates');
 await probe('账号权限', '/auth/permissions');
 
 // Phase 2: 素材 ID 参数化 GET
-await probe('我的群组', `/users/${me.id}/groups`);
-await probe('代表群组', `/users/${me.id}/groups/represented`);
-await probe('群组邀请', `/users/${me.id}/groups/invited`);
-await probe('我的反馈', `/users/${me.id}/feedback`);
-await probe('自己详情', `/users/${me.id}`);
-await probe('自己头像', `/users/${me.id}/avatar`);
-await probe('群组实例', `/users/${me.id}/instances/groups?n=10`);
+await probe('我的群组', `/users/${SELF}/groups`);
+await probe('代表群组', `/users/${SELF}/groups/represented`);
+await probe('群组邀请', `/users/${SELF}/groups/invited`);
+await probe('我的反馈', `/users/${SELF}/feedback`);
+await probe('自己详情', `/users/${SELF}`);
+await probe('自己头像', `/users/${SELF}/avatar`);
+await probe('群组实例', `/users/${SELF}/instances/groups?n=10`);
 if (friend) {
   await probe(`共同好友@${friend.display_name}`, `/users/${friend.user_id}/mutuals/friends?n=10`);
   await probe(`共同群组@${friend.display_name}`, `/users/${friend.user_id}/mutuals/groups`);
@@ -83,7 +93,7 @@ if (grp) {
   await probe('群组审计类型', `/groups/${grp.group_id}/auditLogTypes`);
 }
 if (world) await probe('世界元数据', `/worlds/${world.world_id}/metadata`);
-if (fileId) await probe('文件详情', `/files/${fileId}`);
+if (fileId) await probe('文件详情(单数 /file)', `/file/${fileId}`);
 
 // 输出矩阵
 for (const r of results) console.log(`[${r.status.padEnd(5)}] ${r.name} :: ${r.info}`);

--- a/scripts/api-live-audit.mjs
+++ b/scripts/api-live-audit.mjs
@@ -1,127 +1,92 @@
-// 全量 GET 实测：用真实凭据+真实资源 ID 逐个调用域方法，输出状态矩阵
+// 全量 GET 实测审计：用服务真实会话（auth cookie）+ 规范路径清单逐个探测，
+// 输出「端点 → 状态 → 响应形状」矩阵。改为基于 VrchatApiClient._request 原语——
+// 旧版脚本按已不存在的具名方法编写（vrchat-api.js 搬家至仓库根 + 方法面收窄），无法运行。
 // 用法：VRC_MONITOR_DIR=<仓库路径> COOKIE_FILE=<cookie文件> [VRC_MONITOR_USER_ID=<userId>] node scripts/api-live-audit.mjs
+// 只读探测：仅 GET；限速 400ms/次；素材 ID 自动从 auth/user 与本地 DB 采集。
+import path from 'node:path';
+import Database from 'better-sqlite3';
+
 const REPO = process.env.VRC_MONITOR_DIR || new URL('..', import.meta.url).pathname;
-const { VrchatApiClient } = await import(REPO + 'core/vrchat-api.js');
+const { VrchatApiClient } = await import(path.join(REPO, 'vrchat-api.js'));
 const api = new VrchatApiClient('', '');
-api.loadCookieFromFile(process.env.COOKIE_FILE || REPO + 'data/auth_cookie.txt');
+api.loadCookieFromFile(process.env.COOKIE_FILE || path.join(REPO, 'data', 'auth_cookie.txt'));
 try { await api.ensureAuth(); } catch (e) { console.log('ensureAuth 失败（继续用现有 cookie）:', String(e.message || e).slice(0, 60)); }
 
+const dbPath = process.env.VRC_MONITOR_DB_PATH || path.join(REPO, 'data', 'vrc-monitor.sqlite3');
+const db = new Database(dbPath, { readonly: true });
+
+const me = (await api._request('GET', '/auth/user')).data;
+const SELF = process.env.VRC_MONITOR_USER_ID || me.id;
+const friend = db.prepare("SELECT user_id, display_name FROM friends LIMIT 1").get();
+const grp = db.prepare('SELECT group_id FROM group_cache LIMIT 1').get();
+const world = db.prepare('SELECT world_id FROM world_cache LIMIT 1').get();
+const files = (await api._request('GET', '/files?n=5')).data || [];
+const fileId = files[0] && files[0].id;
+console.log(`素材: self=${me.displayName} friend=${friend ? friend.display_name : '无'} group=${grp ? grp.name : '无'}`);
+
 const results = [];
-async function probe(name, path, fn) {
+async function probe(name, p) {
+  if (!p) return;
   try {
-    const r = await fn();
-    const status = r.status;
-    const body = r.data;
-    const info = body === undefined || body === null ? '空'
-      : Array.isArray(body) ? `数组[${body.length}]`
-      : typeof body === 'object' ? Object.keys(body).slice(0, 4).join(',')
-      : String(body).slice(0, 30);
-    results.push({ name, status: String(status), info, path });
+    const r = await api._request('GET', p);
+    const d = r.data;
+    const info = Array.isArray(d) ? `数组[${d.length}]`
+      : typeof d === 'object' && d ? Object.keys(d).slice(0, 5).join(',')
+      : String(d).slice(0, 30);
+    results.push({ name, status: String(r.status), info, path: p });
   } catch (e) {
-    results.push({ name, status: 'THROW', info: String(e.message || e).slice(0, 60), path });
+    results.push({ name, status: 'THROW', info: String(e.message || e).slice(0, 60), path: p });
   }
-  await new Promise(r => setTimeout(r, 350));
+  await new Promise(r => setTimeout(r, 400));
 }
 
-const me = process.env.VRC_MONITOR_USER_ID || ''; // 必填：自己的 userId
-if (!me) { console.error('请设置 VRC_MONITOR_USER_ID=<你的 userId>'); process.exit(2); }
-
 // Phase 1: 无参/自足 GET
-await probe('getConfig', '/config', () => api.getConfig());
-await probe('getVisits', '/visits', () => api.getVisits());
-await probe('verifyAuthToken', '/auth', () => api.verifyAuthToken());
-await probe('getFriends(不传=仅在线)', '/auth/user/friends', () => api.getFriends());
-await probe('getFavoriteLimits', '/auth/user/favoritelimits', () => api.getFavoriteLimits());
-await probe('getNotifications', '/auth/user/notifications', () => api.getNotifications({ n: 10 }));
-await probe('getPlayerModerations', '/auth/user/playermoderations', () => api.getPlayerModerations());
-await probe('getAvatarModerations', '/auth/user/avatarmoderations', () => api.getAvatarModerations());
-await probe('listFavoriteGroups', '/favorite/groups', () => api.listFavoriteGroups({ n: 50 }));
-await probe('listFavorites(friend)', '/favorites?type=friend', () => api.listFavorites({ type: 'friend', n: 50 }));
-await probe('listFiles', '/files', () => api.listFiles({ n: 20 }));
-await probe('listPrints', '/prints/user/{uid}', () => api.listPrints());
-await probe('getInviteMessages(message)', '/message/{uid}/message', () => api.getInviteMessages('message', { n: 20 }));
-await probe('listCalendarEvents', '/calendar', () => api.listCalendarEvents({ n: 10 }));
-await probe('listFeaturedCalendarEvents', '/calendar/featured', () => api.listFeaturedCalendarEvents());
-await probe('listFollowedCalendarEvents', '/calendar/following', () => api.listFollowedCalendarEvents());
-await probe('getInventory', '/inventory', () => api.getInventory({ n: 20 }));
-await probe('getGlobalInventory', '/inventory/global', () => api.getGlobalInventory());
-await probe('getInventoryDrops', '/inventory/drops', () => api.getInventoryDrops());
-await probe('getGroupRoleTemplates', '/groups/roleTemplates', () => api.getGroupRoleTemplates());
-await probe('searchUsers(自己)', '/users?search=', () => api.searchUsers(process.env.VRC_MONITOR_SEARCH_USER || 'vrc', 5));
-await probe('searchWorlds', '/worlds?search=', () => api.searchWorlds({ search: 'vrchat', n: 5 }));
-await probe('listActiveWorlds', '/worlds/active', () => api.listActiveWorlds({ n: 5 }));
-await probe('listRecentWorlds', '/worlds/recent', () => api.listRecentWorlds({ n: 5 }));
-await probe('listFavoritedWorlds', '/worlds/favorites', () => api.listFavoritedWorlds({ n: 5 }));
-await probe('listFavoritedAvatars', '/avatars/favorites', () => api.listFavoritedAvatars({ n: 5 }));
-await probe('listLicensedAvatars', '/avatars/licensed', () => api.listLicensedAvatars({ n: 5 }));
-await probe('getAvatarStyles', '/avatarStyles', () => api.getAvatarStyles());
+await probe('配置', '/config');
+await probe('在线人数', '/visits');
+await probe('认证状态', '/auth');
+await probe('收藏上限', '/auth/user/favoritelimits');
+await probe('通知(legacy)', '/auth/user/notifications?n=10');
+await probe('玩家屏蔽', '/auth/user/playermoderations');
+await probe('头像审核屏蔽', '/auth/user/avatarmoderations');
+await probe('收藏分组', '/favorite/groups?n=50');
+await probe('好友收藏', '/favorites?type=friend&n=50');
+await probe('世界收藏', '/favorites?type=world&n=50');
+await probe('文件列表', '/files?n=20');
+await probe('邀请消息模板', `/message/${me.id}/message?n=20`);
+await probe('日历(全部)', '/calendar?n=10');
+await probe('日历(精选)', '/calendar/featured');
+await probe('日历(关注)', '/calendar/following');
+await probe('物品栏', '/inventory?n=20');
+await probe('全局物品', '/inventory/global');
+await probe('掉落', '/inventory/drops');
+await probe('群组角色模板', '/groups/roleTemplates');
+await probe('账号权限', '/auth/permissions');
 
-// Phase 2: 真实 ID 参数化 GET
-const friends = await api.fetchAllFriends();
-const onlineFriend = friends.find(f => f.location && f.location !== 'offline');
-const anyFriend = friends[0];
-await probe('getUser(自己)', '/users/{id}', () => api.getUser(me));
-await probe('getOwnAvatar', '/users/{id}/avatar', () => api.getOwnAvatar(me));
-await probe('getUserGroups(自己)', '/users/{id}/groups', () => api.getUserGroups(me));
-await probe('getRepresentedGroup(自己)', '/users/{id}/groups/represented', () => api.getRepresentedGroup(me));
-await probe('getUserBalance(自己)', '/user/{id}/balance', () => api.getUserBalance(me));
-await probe('getUserGroupInstances(自己)', '/users/{id}/instances/groups', () => api.getUserGroupInstances(me, { n: 10 }));
-await probe('getMutualFriends(好友)', '/users/{id}/mutuals/friends', () => api.getMutualFriends(anyFriend.id, { n: 10 }));
-await probe('getMutualGroups(好友)', '/users/{id}/mutuals/groups', () => api.getMutualGroups(anyFriend.id));
-await probe('getFriendStatus(好友)', '/user/{id}/friendStatus', () => api.getFriendStatus(anyFriend.id));
-await probe('fetchAllFriends(合并)', '双列表', async () => ({ status: 200, data: (await api.fetchAllFriends()).map(f => f.id) }));
+// Phase 2: 素材 ID 参数化 GET
+await probe('我的群组', `/users/${me.id}/groups`);
+await probe('代表群组', `/users/${me.id}/groups/represented`);
+await probe('群组邀请', `/users/${me.id}/groups/invited`);
+await probe('我的反馈', `/users/${me.id}/feedback`);
+await probe('自己详情', `/users/${me.id}`);
+await probe('自己头像', `/users/${me.id}/avatar`);
+await probe('群组实例', `/users/${me.id}/instances/groups?n=10`);
+if (friend) {
+  await probe(`共同好友@${friend.display_name}`, `/users/${friend.user_id}/mutuals/friends?n=10`);
+  await probe(`共同群组@${friend.display_name}`, `/users/${friend.user_id}/mutuals/groups`);
+  await probe('好友状态', `/user/${friend.user_id}/friendStatus`);
+}
+if (grp) {
+  await probe('群组相册', `/groups/${grp.group_id}/galleries`);
+  await probe('群组帖子', `/groups/${grp.group_id}/posts?n=10`);
+  await probe('群组公告', `/groups/${grp.group_id}/announcement`);
+  await probe('群组成员', `/groups/${grp.group_id}/members?n=5`);
+  await probe('群组审计类型', `/groups/${grp.group_id}/auditLogTypes`);
+}
+if (world) await probe('世界元数据', `/worlds/${world.world_id}/metadata`);
+if (fileId) await probe('文件详情', `/files/${fileId}`);
 
-await probe('searchWorlds→world三连', null, async () => {
-  const w = await api.searchWorlds({ search: 'Cube MMD Studio', n: 3 });
-  const wid = w.data?.[0]?.id;
-  if (!wid) return { status: 'SKIP', data: '未找到世界' };
-  const r1 = await api.getWorld(wid);
-  const r2 = await api.getWorldMetadata(wid);
-  const r3 = await api.getWorldPublishStatus(wid).catch(e => ({ status: e.status || 'ERR' }));
-  return { status: `getWorld=${r1.status} meta=${r2.status} pub=${r3.status}`, data: wid };
-});
-await probe('getInstance(好友当前房)', null, async () => {
-  const loc = onlineFriend?.location;
-  if (!loc) return { status: 'SKIP', data: '在线好友无位置' };
-  return api.getInstance(loc);
-});
-await probe('群组三连(加入的群)', null, async () => {
-  const gid = process.env.VRC_MONITOR_GROUP_ID || '';
-  if (!gid) return { status: 'SKIP', data: '未设置 VRC_MONITOR_GROUP_ID' };
-  const r1 = await api.getGroup(gid);
-  const r2 = await api.getUserGroups(me);
-  const r3 = await api.getGroupInstances(gid).catch(e => ({ status: e.status || 'ERR' }));
-  return { status: `getGroup=${r1.status} userGroups=${r2.status} inst=${r3.status}`, data: r1.data?.name || '' };
-});
-await probe('getInventoryItem(list→id)', null, async () => {
-  const inv = await api.getInventory({ n: 20 });
-  const item = ((inv.data || {}).data || []).find(x => x.id)?.id;
-  if (!item) return { status: 'SKIP', data: '库存空' };
-  return api.getInventoryItem(item);
-});
-await probe('getFile(list→id)', null, async () => {
-  const r = await api.listFiles({ n: 5 });
-  const fid = (r.data || [])[0]?.id;
-  if (!fid) return { status: 'SKIP', data: '无文件' };
-  return api.getFile(fid);
-});
-await probe('getPrint(list→id)', null, async () => {
-  const r = await api.listPrints({ n: 5 });
-  const pid = (r.data || [])[0]?.id;
-  if (!pid) return { status: 'SKIP', data: '无 print' };
-  return api.getPrint(pid);
-});
-await probe('getAvatar(list→id)', null, async () => {
-  const r = await api.searchAvatars({ userId: me, n: 3 });
-  const aid = (r.data || [])[0]?.id;
-  if (!aid) return { status: 'SKIP', data: '无模型' };
-  return api.getAvatar(aid);
-});
-
-const ok = results.filter(r => r.status.startsWith('200') || r.status.startsWith('SKIP') || r.status.includes('=200'));
-const non200 = results.filter(r => !ok.includes(r));
-console.log('===== 结果矩阵 =====');
-for (const r of results) console.log(String(r.status).padEnd(16), r.name.padEnd(26), String(r.info).slice(0, 46));
-console.log(`\n总 ${results.length} | 通过(200/含200/SKIP): ${ok.length} | 非200: ${non200.length}`);
-for (const r of non200) console.log('  非200 →', r.name, '|', r.status, '|', r.info);
-process.exit(0);
+// 输出矩阵
+for (const r of results) console.log(`[${r.status.padEnd(5)}] ${r.name} :: ${r.info}`);
+const ok = results.filter(r => r.status === '200').length;
+console.log(`\n矩阵: ${ok}/${results.length} 200 | 非200 明细:`);
+for (const r of results.filter(r => r.status !== '200')) console.log(`  [${r.status}] ${r.name} (${r.path}) ${r.info.slice(0, 40)}`);


### PR DESCRIPTION
## 问题

`scripts/api-live-audit.mjs` 当前**完全无法运行**：
1. import 指向 `core/vrchat-api.js`——该文件已搬家至仓库根（历史 commit bac207b 时期路径）
2. 调用的 48 个具名方法（`fetchAllFriends`/`getConfig`/`listCalendarEvents`...）在当前 `VrchatApiClient` 上全部不存在——客户端已收窄为 `_request` 原语

## 修复（重写为可运行）

- import 修正为仓库根 `vrchat-api.js`
- 探测逻辑改走 `_request` 原语 + 社区规范（vrchatapi/specification）路径清单
- 素材 ID（好友/群组/世界/文件）自动从 `auth/user` 与本地 DB 采集，无需手工传参
- 保留原 env 接口（`VRC_MONITOR_DIR`/`COOKIE_FILE`/`VRC_MONITOR_USER_ID`）与逐项容错矩阵输出；末尾汇总非 200 明细
- 只读探测：仅 GET，400ms 限速

## 验证

- `node --check` ✓、全量 npm test 83/83
- **生产容器实测**：37 项探测 33 项 200；4 项非 200 归因清晰（群组 galleries 405=规范滞后、群组公告/审计 403=权限门槛、文件详情 404=规范超前/路径变化）——脚本按设计完成全矩阵输出