### PR TITLE
fix(legacy-client): 状态译名对齐官方 statusLabels——#171 审查遗留收口

### DIFF
--- a/docs/DASHBOARD-DEV-STATUS.md
+++ b/docs/DASHBOARD-DEV-STATUS.md
@@ -84,7 +84,7 @@
 - **GameLog 游戏日志**：后端 `dashboard.gameSessions` 服务 + `GET /api/dashboard/game-sessions`（user-location 聚合会话）；前端 logs 视图（会话数/总时长/会话时间线）。实测：最近 7 天 72 会话/785 分钟
 - **请求加入（VRCX 邀请对齐）**：后端 `POST /api/dashboard/invite-request`（request_invite 工具）；资料弹窗给在线好友显示「请求加入」按钮（toast 反馈）
 - **快速搜索 Ctrl+K（VRCX Quick Search 对齐）**：任意页面按 Ctrl+K/Cmd+K 弹出快速搜索覆盖层，输入即时匹配本地好友 + VRChat 用户搜索（防抖 300ms），点击打开资料；Esc 关闭
-- **状态预设（VRCX Social Status Presets 对齐）**：右侧栏状态预设（在线/加入我/问我/忙碌）+ 状态描述输入；`POST /api/dashboard/status`（PUT /auth/user/status）
+- **状态预设（VRCX Social Status Presets 对齐）**：右侧栏状态预设（在线/欢迎加入/忙碌/请勿打扰）+ 状态描述输入；`POST /api/dashboard/status`（PUT /auth/user/status）
 - **VRChat 服务器状态指示（受限）**：状态栏 `#vrcs` 显示 VRChat 服务器状态（`GET /api/dashboard/vrc-status`，status.vrchat.com）。**诚实限制**：路由器无法访问 status.vrchat.com（被墙/不可达），VRChat API 无替代公开端点——接口保留，失败时显示 VRC —
 - **好友备注全局显示（VRCX 对齐）**：`GET /api/dashboard/nicknames-all` 加载全部备注到 `state.nicknameMap`，`nameFor` 优先用备注名替换显示名（好友列表/事件流/资料统一显示备注名）
 - **Tools 快捷工具页**：世界/模型/用户/群组 ID → 生成 VRChat 链接（可打开/复制）
@@ -726,7 +726,7 @@ git diff --check
 
 - **非好友追踪 UI 重做**（用户反馈驱动）：卡片化列表 + 添加追踪面板（搜索用户→加入，幂等+立即刷新）+ 移除追踪（removed_at 标记持久化，种子不再复活）+ 打开资料/移除带文字按钮
 - **修复：自己误入追踪列表**——启动早期 /auth/user 失败时 selfId 为空；改为事件表推导（user-location/user-update 只会是自己的事件）+ API 兜底 + 启动清理 + 列表过滤 + 添加拒绝，四层防护
-- **在线状态显示**：刷新循环落库 status/statusDescription/location（迁移加列）；列表绿色圆点+状态徽章（在线/加入我/问我/忙碌/离线，对齐好友页）；在线优先排序
+- **在线状态显示**：刷新循环落库 status/statusDescription/location（迁移加列）；列表绿色圆点+状态徽章（在线/欢迎加入/忙碌/请勿打扰/离线，对齐好友页）；在线优先排序
 - **动态页「只看追踪」筛选**：trackedIds 加载 + 望远镜 chip，与只看关注/只看我并列；空态引导
 - **变化时间线类型筛选**：全部/头像/简介/状态 chips
 - **X 抓取尝试与回退**：chromium+Xvfb+代理基建验证可用，但 2026 X 全匿名通道封锁（Nitter 全灭/GraphQL 404/登录墙）——已回退基建保留 UI，文档注明环境限制

--- a/plugins/official/web-dashboard/client/js/vue-app.js
+++ b/plugins/official/web-dashboard/client/js/vue-app.js
@@ -58,9 +58,9 @@
       return {
         presets: [
           { v: 'active', l: '在线' },
-          { v: 'join me', l: '加入我' },
-          { v: 'ask me', l: '问我' },
-          { v: 'busy', l: '忙碌' },
+          { v: 'join me', l: '欢迎加入' },
+          { v: 'ask me', l: '忙碌' },
+          { v: 'busy', l: '请勿打扰' },
         ],
         desc: '',
       };

--- a/plugins/official/web-dashboard/client/js/vue/core.js
+++ b/plugins/official/web-dashboard/client/js/vue/core.js
@@ -63,9 +63,9 @@
     dbStatus: '—',
     statusPresets: [
       { v: 'active', l: '在线' },
-      { v: 'join me', l: '加入我' },
-      { v: 'ask me', l: '问我' },
-      { v: 'busy', l: '忙碌' },
+      { v: 'join me', l: '欢迎加入' },
+      { v: 'ask me', l: '忙碌' },
+      { v: 'busy', l: '请勿打扰' },
     ],
     statusDesc: '',
     onlineFriends: [],

--- a/plugins/official/web-dashboard/client/js/vue/dialogs.js
+++ b/plugins/official/web-dashboard/client/js/vue/dialogs.js
@@ -197,7 +197,7 @@
                   <div class="status-bar-seg s-active" :style="{ width: (pairData.statusBreakdown.active || 0) + '%' }" :title="'在线 (Active): ' + pairData.statusBreakdown.active + '%'"></div>
                   <div class="status-bar-seg s-joinme" :style="{ width: (pairData.statusBreakdown.joinme || 0) + '%' }" :title="'欢迎加入 (Join Me): ' + pairData.statusBreakdown.joinme + '%'"></div>
                   <div class="status-bar-seg s-askme" :style="{ width: (pairData.statusBreakdown.askme || 0) + '%' }" :title="'忙碌 (Ask Me): ' + pairData.statusBreakdown.askme + '%'"></div>
-                  <div class="status-bar-seg s-busy" :style="{ width: (pairData.statusBreakdown.busy || 0) + '%' }" :title="'忙碌 (Busy): ' + pairData.statusBreakdown.busy + '%'"></div>
+                  <div class="status-bar-seg s-busy" :style="{ width: (pairData.statusBreakdown.busy || 0) + '%' }" :title="'请勿打扰 (Busy): ' + pairData.statusBreakdown.busy + '%'"></div>
                   <div class="status-bar-seg s-offline" :style="{ width: (pairData.statusBreakdown.offline || 0) + '%' }" :title="'离线 (Offline): ' + pairData.statusBreakdown.offline + '%'"></div>
                 </div>
                 <!-- 图例说明 -->
@@ -205,7 +205,7 @@
                   <span class="status-legend-item"><i style="background: var(--s-active)"></i> 在线 {{ pairData.statusBreakdown.active }}%</span>
                   <span class="status-legend-item"><i style="background: var(--s-joinme)"></i> 欢迎加入 {{ pairData.statusBreakdown.joinme }}%</span>
                   <span class="status-legend-item"><i style="background: var(--s-askme)"></i> 忙碌 {{ pairData.statusBreakdown.askme }}%</span>
-                  <span class="status-legend-item"><i style="background: var(--s-busy)"></i> 忙碌 {{ pairData.statusBreakdown.busy }}%</span>
+                  <span class="status-legend-item"><i style="background: var(--s-busy)"></i> 请勿打扰 {{ pairData.statusBreakdown.busy }}%</span>
                   <span class="status-legend-item"><i style="background: var(--s-offline)"></i> 离线 {{ pairData.statusBreakdown.offline }}%</span>
                 </div>
               </div>

--- a/plugins/official/web-dashboard/client/js/vue/dialogs.js
+++ b/plugins/official/web-dashboard/client/js/vue/dialogs.js
@@ -195,16 +195,16 @@
                 <!-- 进度条 -->
                 <div class="status-breakdown-bar">
                   <div class="status-bar-seg s-active" :style="{ width: (pairData.statusBreakdown.active || 0) + '%' }" :title="'在线 (Active): ' + pairData.statusBreakdown.active + '%'"></div>
-                  <div class="status-bar-seg s-joinme" :style="{ width: (pairData.statusBreakdown.joinme || 0) + '%' }" :title="'加入我 (Join Me): ' + pairData.statusBreakdown.joinme + '%'"></div>
-                  <div class="status-bar-seg s-askme" :style="{ width: (pairData.statusBreakdown.askme || 0) + '%' }" :title="'问问我 (Ask Me): ' + pairData.statusBreakdown.askme + '%'"></div>
+                  <div class="status-bar-seg s-joinme" :style="{ width: (pairData.statusBreakdown.joinme || 0) + '%' }" :title="'欢迎加入 (Join Me): ' + pairData.statusBreakdown.joinme + '%'"></div>
+                  <div class="status-bar-seg s-askme" :style="{ width: (pairData.statusBreakdown.askme || 0) + '%' }" :title="'忙碌 (Ask Me): ' + pairData.statusBreakdown.askme + '%'"></div>
                   <div class="status-bar-seg s-busy" :style="{ width: (pairData.statusBreakdown.busy || 0) + '%' }" :title="'忙碌 (Busy): ' + pairData.statusBreakdown.busy + '%'"></div>
                   <div class="status-bar-seg s-offline" :style="{ width: (pairData.statusBreakdown.offline || 0) + '%' }" :title="'离线 (Offline): ' + pairData.statusBreakdown.offline + '%'"></div>
                 </div>
                 <!-- 图例说明 -->
                 <div class="status-breakdown-legend">
                   <span class="status-legend-item"><i style="background: var(--s-active)"></i> 在线 {{ pairData.statusBreakdown.active }}%</span>
-                  <span class="status-legend-item"><i style="background: var(--s-joinme)"></i> 加入我 {{ pairData.statusBreakdown.joinme }}%</span>
-                  <span class="status-legend-item"><i style="background: var(--s-askme)"></i> 问问我 {{ pairData.statusBreakdown.askme }}%</span>
+                  <span class="status-legend-item"><i style="background: var(--s-joinme)"></i> 欢迎加入 {{ pairData.statusBreakdown.joinme }}%</span>
+                  <span class="status-legend-item"><i style="background: var(--s-askme)"></i> 忙碌 {{ pairData.statusBreakdown.askme }}%</span>
                   <span class="status-legend-item"><i style="background: var(--s-busy)"></i> 忙碌 {{ pairData.statusBreakdown.busy }}%</span>
                   <span class="status-legend-item"><i style="background: var(--s-offline)"></i> 离线 {{ pairData.statusBreakdown.offline }}%</span>
                 </div>
@@ -584,9 +584,9 @@
         if (typeof window.isWebOnline === 'function' && window.isWebOnline(u)) return '网页在线';
         if (!u.isOnline || u.status === 'offline') return '离线';
         const s = (u.status || 'active').toLowerCase();
-        if (s === 'join me') return '请加入我 (Join Me)';
-        if (s === 'ask me') return '问问我 (Ask Me)';
-        if (s === 'busy') return '忙碌 (Do Not Disturb)';
+        if (s === 'join me') return '欢迎加入 (Join Me)';
+        if (s === 'ask me') return '忙碌 (Ask Me)';
+        if (s === 'busy') return '请勿打扰 (Do Not Disturb)';
         return '在线 (Online)';
       },
       formatDate: (s) => (s ? new Date(s).toLocaleDateString('zh-CN') : '—'),

--- a/plugins/official/web-dashboard/client/js/vue/rightbar.js
+++ b/plugins/official/web-dashboard/client/js/vue/rightbar.js
@@ -206,7 +206,7 @@
         if (typeof window.isWebOnline === 'function' && window.isWebOnline(f)) return '网页在线';
         if (!f.isOnline) return '离线';
         if (f.statusDescription) return f.statusDescription;
-        const labels = { active: '在线', 'join me': '加入我', 'ask me': '问我', busy: '忙碌' };
+        const labels = { active: '在线', 'join me': '欢迎加入', 'ask me': '忙碌', busy: '请勿打扰' };
         return labels[f.status] || '在线';
       },
       locText(f) {
@@ -225,7 +225,7 @@
         if (me.travelingToLocation) return '传送中';
         if (loc === 'offline') return '离线';
         if (me.statusDescription) return me.statusDescription;
-        const labels = { active: '在线', 'join me': '加入我', 'ask me': '问我', busy: '忙碌' };
+        const labels = { active: '在线', 'join me': '欢迎加入', 'ask me': '忙碌', busy: '请勿打扰' };
         return labels[me.status] || '在线';
       },
       meLocText(me) {


### PR DESCRIPTION
## 问题

`client/js/vue*`（legacy 客户端）的状态中文映射仍是自造译名：join me=加入我、ask me=问我、busy=忙碌——与 #171 确立的官方译名（statusLabels：join me=欢迎加入、ask me=忙碌、busy=请勿打扰）不一致。#171 审查 💡 指出的 follow-up。

## 修复（4 文件，纯展示层）

- `vue-app.js`/`core.js` statusPresets、`rightbar.js` 标签表（×2）、`dialogs.js` 状态分布 title/图例 + 状态文案函数
- 连带修正 busy=忙碌 的连带错误（官方 busy 即请勿打扰）
- CSS 类名（s-joinme 等标识符）不动；残余检查零命中

## 验证

- 全量 `npm test` 83/83
- 生产容器已同步（静态文件，grep 欢迎加入 命中确认）