### PR TITLE
fix(pipeline): 网页端在线落库真值——friend-active(platform=web) 清残留世界

### DIFF
--- a/core/event-pipeline.js
+++ b/core/event-pipeline.js
@@ -1,4 +1,10 @@
 import { avatarThumb, avatarOf } from './img-util.js';
+
+// 网页端在线判据（单一来源：WS friend-active 与 start-monitor 快照对账共用，防漂移）。
+// 当前仅 'web'——nativemobile 语义待确认后纳入（见 _handleActive 注释与跟进 issue）。
+export function isWebPresence(platform) {
+  return platform === 'web';
+}
 import { getLogger } from './logger.js';
 
 const log = getLogger('event');
@@ -310,26 +316,17 @@ export class EventPipeline {
   async _handleActive(event) {
     const userId = event.userId;
 
-    if (event.platform === 'web') {
-      // 网页端在线（2026-09-10 用户实测：好友转网页在线时 VRChat 不发 friend-offline，
-      // 只发 platform=web 的 friend-active；REST 快照同口径 location='offline'+platform='web'）。
-      // 不清位置的话 friends 表残留最后进房的世界 → dashboard 仍显示在某世界（假在线位置）。
-      this.storage.upsertFriend({
-        userId,
-        isOnline: true,
-        lastSeen: event.receivedAt,
-        platform: 'web',
-        location: 'offline',
-        worldId: '',
-        worldName: '',
-      });
-    } else {
-      this.storage.upsertFriend({
-        userId,
-        isOnline: true,
-        lastSeen: event.receivedAt,
-      });
-    }
+    // 网页端在线（2026-09-10 用户实测：好友转网页在线时 VRChat 不发 friend-offline，
+    // 只发 platform=web 的 friend-active；REST 快照同口径 location='offline'+platform='web'）。
+    // 不清位置的话 friends 表残留最后进房的世界 → dashboard 仍显示在某世界（假在线位置）。
+    // nativemobile 语义待确认（#181 审查：审查方部署 7 天 592 条/我方 0 样本，盲扩有误清
+    // 真实位置风险）→ 跟进 issue 单独核实后再纳入 isWebPresence。
+    this.storage.upsertFriend({
+      userId,
+      isOnline: true,
+      lastSeen: event.receivedAt,
+      ...(isWebPresence(event.platform) ? { platform: 'web', location: 'offline', worldId: '', worldName: '' } : {}),
+    });
 
     this._storeEvent(event);
   }

--- a/core/event-pipeline.js
+++ b/core/event-pipeline.js
@@ -310,11 +310,26 @@ export class EventPipeline {
   async _handleActive(event) {
     const userId = event.userId;
 
-    this.storage.upsertFriend({
-      userId,
-      isOnline: true,
-      lastSeen: event.receivedAt,
-    });
+    if (event.platform === 'web') {
+      // 网页端在线（2026-09-10 用户实测：好友转网页在线时 VRChat 不发 friend-offline，
+      // 只发 platform=web 的 friend-active；REST 快照同口径 location='offline'+platform='web'）。
+      // 不清位置的话 friends 表残留最后进房的世界 → dashboard 仍显示在某世界（假在线位置）。
+      this.storage.upsertFriend({
+        userId,
+        isOnline: true,
+        lastSeen: event.receivedAt,
+        platform: 'web',
+        location: 'offline',
+        worldId: '',
+        worldName: '',
+      });
+    } else {
+      this.storage.upsertFriend({
+        userId,
+        isOnline: true,
+        lastSeen: event.receivedAt,
+      });
+    }
 
     this._storeEvent(event);
   }

--- a/start-monitor.js
+++ b/start-monitor.js
@@ -12,6 +12,7 @@ import path from 'node:path';
 import net from 'node:net';
 
 import { ctx, log, refreshWatchlistCache } from './core/server-context.js';
+import { isWebPresence } from './core/event-pipeline.js';
 import { initLogger, getLevelName, getLogger } from './core/logger.js';
 import { recordOpsLog, setOpsLogSink } from './core/ops-log.js';
 import * as registry from './core/registry.js';
@@ -145,9 +146,9 @@ async function _refreshOnlineState() {
     // REST 在线列表里 location='offline' 的条目=仅网页在线（VRChat 语义），把 platform/location
     // 真值落 friends 表并清残留世界——与 WS friend-active(platform=web) 修复同口径。
     for (const f of online) {
-      if (f.location === 'offline' && f.platform === 'web') {
+      if (f.location === 'offline' && isWebPresence(f.platform)) {
         try {
-          storage.upsertFriend({ userId: f.id, platform: 'web', location: 'offline', worldId: '', worldName: '', isOnline: true });
+          storage.upsertFriend({ userId: f.id, platform: f.platform || 'web', location: 'offline', worldId: '', worldName: '', isOnline: true, lastSeen: f.last_activity || new Date().toISOString() });
         } catch { /* 单条失败不阻断对账 */ }
       }
     }

--- a/start-monitor.js
+++ b/start-monitor.js
@@ -141,6 +141,16 @@ async function _refreshOnlineState() {
       // active/菜单中用户，location 为空者不算在线——issue #114 ⚠️2 复测遗留修复）
       isOnline: !!(f.location && f.location !== 'offline'),
     })));
+    // 网页端在线自愈（2026-09-10 用户报 bug：转网页在线后 friends 表残留最后进房世界）。
+    // REST 在线列表里 location='offline' 的条目=仅网页在线（VRChat 语义），把 platform/location
+    // 真值落 friends 表并清残留世界——与 WS friend-active(platform=web) 修复同口径。
+    for (const f of online) {
+      if (f.location === 'offline' && f.platform === 'web') {
+        try {
+          storage.upsertFriend({ userId: f.id, platform: 'web', location: 'offline', worldId: '', worldName: '', isOnline: true });
+        } catch { /* 单条失败不阻断对账 */ }
+      }
+    }
 
     // 断线窗口对账：WS 断开期间的好友下线事件会错过（下线不再广播），本地状态会卡在「在线」。
     // 好友表标记在线、但不在真实在线集合中的 → 置离线 + 补记 friend-offline 事件（动态流可见）。

--- a/test/event-pipeline-web-active.test.mjs
+++ b/test/event-pipeline-web-active.test.mjs
@@ -1,0 +1,67 @@
+/**
+ * event-pipeline-web-active.test.mjs — 网页端在线 friend-active 处理回归
+ *
+ * 背景(2026-09-10 用户实测 bug):好友转网页端在线时 VRChat 不发 friend-offline,
+ * 只发 platform=web 的 friend-active——处理器必须把 platform/location 真值落库并清
+ * 残留世界,否则 friends 表保留最后进房世界,dashboard 假显示「在某世界」。
+ * 自包含:mock storage 记录 upsertFriend 调用,不依赖真实 VRChat 凭据。
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { EventPipeline } from '../core/event-pipeline.js';
+
+function makePipeline() {
+  const upserts = [];
+  const events = [];
+  const storage = {
+    upsertFriend(f) { upserts.push(f); },
+    insertEvent(e) { events.push(e); },
+  };
+  const pipeline = new EventPipeline(storage, { get: () => null });
+  return { pipeline, upserts, events };
+}
+
+const WEB_ACTIVE = {
+  type: 'friend-active',
+  userId: 'usr_test',
+  displayName: '测试网页在线好友',
+  platform: 'web',
+  receivedAt: '2026-09-10T13:35:39.557Z',
+  content: { userId: 'usr_test', platform: 'web' },
+};
+
+const GAME_ACTIVE = {
+  type: 'friend-active',
+  userId: 'usr_test2',
+  displayName: '测试游戏在线好友',
+  platform: 'standalonewindows',
+  receivedAt: '2026-09-10T13:35:39.557Z',
+  content: { userId: 'usr_test2', platform: 'standalonewindows' },
+};
+
+test('platform=web → 落 platform/location=offline 并清残留世界', async () => {
+  const { pipeline, upserts } = makePipeline();
+  await pipeline.process({ ...WEB_ACTIVE });
+  assert.strictEqual(upserts.length, 1);
+  assert.strictEqual(upserts[0].platform, 'web');
+  assert.strictEqual(upserts[0].location, 'offline');
+  assert.strictEqual(upserts[0].worldId, '');
+  assert.strictEqual(upserts[0].worldName, '');
+  assert.strictEqual(upserts[0].isOnline, true);
+});
+
+test('platform=游戏端 → 保持原行为(不动 location/platform)', async () => {
+  const { pipeline, upserts } = makePipeline();
+  await pipeline.process({ ...GAME_ACTIVE });
+  assert.strictEqual(upserts.length, 1);
+  assert.strictEqual(upserts[0].platform, undefined);
+  assert.strictEqual(upserts[0].location, undefined);
+  assert.strictEqual(upserts[0].isOnline, true);
+});
+
+test('web-active 事件本身仍落 events 表', async () => {
+  const { pipeline, events } = makePipeline();
+  await pipeline.process({ ...WEB_ACTIVE });
+  assert.strictEqual(events.length, 1);
+  assert.strictEqual(events[0].type, 'friend-active');
+});


### PR DESCRIPTION
## 问题（用户实测报障）

好友转**网页端在线**后，dashboard 仍显示 TA 在最后进房的世界（实测：XIAOFANG小芳 13:35 转网页在线，好友列表仍显示在后海KTV）。

## 根因

好友转网页在线时 VRChat **不发 friend-offline**，只发 `friend-active {platform: web}` 事件；`_handleActive` 只刷 last_seen——friends 表残留 `standalonewindows`+最后进房世界。

VRChat 自身语义（REST `/auth/user/friends` 实测）：网页端用户返回 `platform: web` + `location: offline`。

## 修复（双路径同口径 + UI 零改动）

- **WS 路径** `_handleActive`：`platform === 'web'` 时 upsertFriend 补 `platform: 'web'`/`location: 'offline'`/清 worldId/worldName（与 REST 真值同口径）
- **快照对账路径**：在线列表里 `location === 'offline' && platform === 'web'` 的条目落 friends 表同真值——自愈不依赖稀疏的 web-active 心跳（实测部署后首个刷新周期即纠正）
- **UI 零改动**：platformLabel('web')=网页+pi-globe 图标已内建，数据到位即自动显示

## 验证

- 新增回归测试 ×3（mock storage：web-active 清世界/游戏 active 不动字段/事件仍落表），全量 **86/86**
- 生产容器部署实测：重启后首个刷新周期，小芳行 `platform=web, location=offline, world_name=''`——残留世界已清，13 插件/WS connected