### PR TITLE
fix(world-kb): 恢复兜底行元数据回填——add_to_backlog/mark_world_visited/rate_world/set_world_sleep 补 world_name/author/created_at（#76/#77 语义在插件化重构中丢失）

### DIFF
--- a/core/tools/misc.js
+++ b/core/tools/misc.js
@@ -271,7 +271,9 @@ async function ensureWorldKbInfo(worldId) {
   if (!worldId) return null;
   try {
     const cached = storage.getWorldName(worldId);
-    if (cached && (cached.name || cached.author_name || cached.author_id)) {
+    // 判据用 name（主显示诉求）：只有 name 命中才算缓存可用；name 缺失就走 API 补全
+    // （避免 world_cache 里只有 author/note、没有名字的行把回填挡在门外，#183 review 💡1）
+    if (cached && cached.name) {
       const info = storage.backfillWorldKbInfo({
         worldId,
         name: cached.name || '',

--- a/core/tools/misc.js
+++ b/core/tools/misc.js
@@ -253,8 +253,52 @@ export function handleGetNewWorlds({ onlyUnvisited = false, limit = 10, sortBy =
   return { total, worlds };
 }
 
+/**
+ * 兜底行的元数据回填（恢复 issue #76 / PR #77 的修复语义）。
+ *
+ * rate_world / mark_world_visited / set_world_sleep / add_to_backlog 在目标世界不在
+ * world_kb 时只插一条「只有 world_id」的兜底行：world_name / author_name / created_at 恒空
+ * —— get_backlog 的列表读不到名字，推荐侧依赖 created_at 的新图加权对这类行永久失效。
+ *
+ * 回填顺序：本地 world_cache（零成本）→ 缓存缺失才按限流拉一次 /worlds/{id} 并写回缓存。
+ * 幂等：backfillWorldKbInfo 仅在对应列为空时写入，不覆盖已有真实值。
+ * 任何一步失败都只记日志、不阻断主操作（回填属增强，缺元数据不该让写入失败）。
+ */
+async function ensureWorldKbInfo(worldId) {
+  const { storage, api, rateLimiter } = ctx;
+  if (!worldId) return null;
+  try {
+    const cached = storage.getWorldName(worldId);
+    if (cached && (cached.name || cached.author_name || cached.author_id)) {
+      return storage.backfillWorldKbInfo({
+        worldId,
+        name: cached.name || '',
+        authorName: cached.author_name || '',
+        authorId: cached.author_id || '',
+      });
+    }
+    if (!api) return null;
+    const fetchWorld = () => api._request('GET', `/worlds/${worldId}`);
+    const r = rateLimiter ? await rateLimiter.execute(fetchWorld) : await fetchWorld();
+    if (!r || r.status !== 200 || !r.data || !r.data.id) return null;
+    const w = r.data;
+    storage.upsertWorld({
+      worldId: w.id, name: w.name || '', authorId: w.authorId || '', authorName: w.authorName || '',
+      capacity: w.capacity, favorites: w.favorites, releaseStatus: w.releaseStatus || '',
+      tags: w.tags || [], description: w.description || '', imageUrl: w.imageUrl || '',
+    });
+    return storage.backfillWorldKbInfo({
+      worldId, name: w.name || '', authorName: w.authorName || '',
+      authorId: w.authorId || '', createdAt: w.created_at || '',
+    });
+  } catch (e) {
+    log(`[世界KB] 兜底行元数据回填失败（不影响主操作）: ${worldId} ${String(e && e.message || e)}`);
+    return null;
+  }
+}
+
 /** 用户反馈：好图/烂图标记（Issue #19） */
-export function handleRateWorld({ worldId, rating = 0 }) {
+export async function handleRateWorld({ worldId, rating = 0 }) {
   const { storage } = ctx;
   if (!worldId) throw new Error('worldId is required');
   const r = parseInt(rating, 10);
@@ -262,26 +306,32 @@ export function handleRateWorld({ worldId, rating = 0 }) {
     throw new Error('rating must be -1 (junk), 0 (clear), or 1 (good)');
   }
   const result = storage.rateWorld({ worldId, rating: r });
-  log(`[反馈] 用户反馈: ${worldId} → rating=${result.userRating}${result.worldName ? ` (${result.worldName})` : ''}`);
-  return result;
+  await ensureWorldKbInfo(worldId);
+  const worldName = storage.getWorldKbInfo(worldId).worldName || result.worldName;
+  log(`[反馈] 用户反馈: ${worldId} → rating=${result.userRating}${worldName ? ` (${worldName})` : ''}`);
+  return { ...result, worldName };
 }
 
 /** 显式确认逛过某世界（Issue #19 痛点 3） */
-export function handleMarkWorldVisited({ worldId }) {
+export async function handleMarkWorldVisited({ worldId }) {
   const { storage } = ctx;
   if (!worldId) throw new Error('worldId is required');
   const result = storage.markWorldVisited({ worldId });
-  log(`[成功] 手动标记 visited: ${worldId}${result.worldName ? ` (${result.worldName})` : ''}`);
-  return result;
+  await ensureWorldKbInfo(worldId);
+  const worldName = storage.getWorldKbInfo(worldId).worldName || result.worldName;
+  log(`[成功] 手动标记 visited: ${worldId}${worldName ? ` (${worldName})` : ''}`);
+  return { ...result, worldName };
 }
 
 /** 待逛列表：加入/更新（幂等） */
-export function handleAddToBacklog({ worldId, reason = '', priority = 0 }) {
+export async function handleAddToBacklog({ worldId, reason = '', priority = 0 }) {
   const { storage } = ctx;
   if (!worldId) throw new Error('worldId is required');
   const result = storage.addToBacklog({ worldId, reason, priority });
-  log(`[待办] 加入待逛: ${worldId}${result.worldName ? ` (${result.worldName})` : ''} priority=${result.priority}`);
-  return result;
+  await ensureWorldKbInfo(worldId);
+  const worldName = storage.getWorldKbInfo(worldId).worldName || result.worldName;
+  log(`[待办] 加入待逛: ${worldId}${worldName ? ` (${worldName})` : ''} priority=${result.priority}`);
+  return { ...result, worldName };
 }
 
 /** 待逛列表：查询 */
@@ -362,12 +412,14 @@ export async function handleBackupDatabase() {
 }
 
 /** 手动标记某世界为适合睡觉的地图（recommend 用 sleep_ok 强信号） */
-export function handleSetWorldSleep({ worldId, isSleep = true }) {
+export async function handleSetWorldSleep({ worldId, isSleep = true }) {
   const { storage } = ctx;
   if (!worldId) throw new Error('worldId is required');
   const result = storage.setWorldSleep({ worldId, isSleep: !!isSleep });
-  log(`${result.isSleep ? '[睡眠]' : '[取消]'} 标记睡觉图: ${worldId}${result.worldName ? ` (${result.worldName})` : ''} → sleep_ok=${result.isSleep ? 1 : 0}`);
-  return result;
+  await ensureWorldKbInfo(worldId);
+  const worldName = storage.getWorldKbInfo(worldId).worldName || result.worldName;
+  log(`${result.isSleep ? '[睡眠]' : '[取消]'} 标记睡觉图: ${worldId}${worldName ? ` (${worldName})` : ''} → sleep_ok=${result.isSleep ? 1 : 0}`);
+  return { ...result, worldName };
 }
 
 export async function handleSearchWorlds({ query, n }) {

--- a/core/tools/misc.js
+++ b/core/tools/misc.js
@@ -263,6 +263,8 @@ export function handleGetNewWorlds({ onlyUnvisited = false, limit = 10, sortBy =
  * 回填顺序：本地 world_cache（零成本）→ 缓存缺失才按限流拉一次 /worlds/{id} 并写回缓存。
  * 幂等：backfillWorldKbInfo 仅在对应列为空时写入，不覆盖已有真实值。
  * 任何一步失败都只记日志、不阻断主操作（回填属增强，缺元数据不该让写入失败）。
+ * 可观测性：缓存/API 回填成功各记一行 [世界KB] 兜底行回填(<来源>)，API 非 200 记一行"跳过"，
+ * 异常记一行"失败"——即每次触发恰好 1 行日志，成功与降级都不静默。
  */
 async function ensureWorldKbInfo(worldId) {
   const { storage, api, rateLimiter } = ctx;
@@ -270,27 +272,37 @@ async function ensureWorldKbInfo(worldId) {
   try {
     const cached = storage.getWorldName(worldId);
     if (cached && (cached.name || cached.author_name || cached.author_id)) {
-      return storage.backfillWorldKbInfo({
+      const info = storage.backfillWorldKbInfo({
         worldId,
         name: cached.name || '',
         authorName: cached.author_name || '',
         authorId: cached.author_id || '',
       });
+      log(`[世界KB] 兜底行回填(缓存): ${worldId} → ${info.worldName || '(空)'}${info.authorName ? ` / ${info.authorName}` : ''}`);
+      return info;
     }
-    if (!api) return null;
+    if (!api) {
+      log(`[世界KB] 兜底行回填跳过（无 API 客户端，缓存也未命中）: ${worldId}`);
+      return null;
+    }
     const fetchWorld = () => api._request('GET', `/worlds/${worldId}`);
     const r = rateLimiter ? await rateLimiter.execute(fetchWorld) : await fetchWorld();
-    if (!r || r.status !== 200 || !r.data || !r.data.id) return null;
+    if (!r || r.status !== 200 || !r.data || !r.data.id) {
+      log(`[世界KB] 兜底行回填跳过（API ${r ? r.status : '无响应'}）: ${worldId}`);
+      return null;
+    }
     const w = r.data;
     storage.upsertWorld({
       worldId: w.id, name: w.name || '', authorId: w.authorId || '', authorName: w.authorName || '',
       capacity: w.capacity, favorites: w.favorites, releaseStatus: w.releaseStatus || '',
       tags: w.tags || [], description: w.description || '', imageUrl: w.imageUrl || '',
     });
-    return storage.backfillWorldKbInfo({
+    const info = storage.backfillWorldKbInfo({
       worldId, name: w.name || '', authorName: w.authorName || '',
       authorId: w.authorId || '', createdAt: w.created_at || '',
     });
+    log(`[世界KB] 兜底行回填(API): ${worldId} → ${info.worldName || '(空)'}${info.authorName ? ` / ${info.authorName}` : ''}`);
+    return info;
   } catch (e) {
     log(`[世界KB] 兜底行元数据回填失败（不影响主操作）: ${worldId} ${String(e && e.message || e)}`);
     return null;

--- a/skills/vrc-monitor-agent/SKILL.md
+++ b/skills/vrc-monitor-agent/SKILL.md
@@ -57,7 +57,7 @@ metadata:
 | `rate_world` | **用户反馈**：给世界打好评/烂图标记（rating: 1=好图加权 / -1=烂图降权 / 0=清除），写入 world_kb.user_rating，影响 worldScore 推荐排序 |
 | `mark_world_visited` | **显式确认逛过**某世界（事件驱动 visited 会漏记，开图闭环手动确认用） |
 | `set_world_sleep` | **手动标记睡觉图**（worldId 必填，isSleep 默认 true，false=取消），写入 world_kb.sleep_ok=1，recommend_join / recommend_worlds（sleep 主题）的强信号。本地数据，不动云端 |
-| `add_to_backlog` | **加入待逛列表**（本地待办，不动云端收藏）：worldId 必填，reason/priority（0-2，默认 0）可选。幂等：重复加入更新备注/优先级，加入时间保持首次。状态存 world_kb.backlog（合表方案） |
+| `add_to_backlog` | **加入待逛列表**（本地待办，不动云端收藏）：worldId 必填，reason/priority（0-2，默认 0）可选。幂等：重复加入更新备注/优先级，加入时间保持首次。状态存 world_kb.backlog（合表方案）。世界不在 world_kb 时插兜底行并回填 world_name/author/created_at（缓存优先，缺失走 API；`mark_world_visited`/`rate_world`/`set_world_sleep` 同路径） |
 | `get_backlog` | **查看待逛列表**：status（pending 默认=未逛 / visited=逛完历史 / all）、sortBy（added_at 默认 / priority / favorites）、limit（1-50）。**逛完自动从待逛列表移除**（location 事件 / mark_world_visited / 扫描在首次置 visited=1 时同步清 backlog=0），pending 只显示仍待逛的世界 |
 | `remove_from_backlog` | **移出待逛列表**：worldId 必填。只清 backlog 标记（保留行/世界知识），幂等 |
 | `recommend_worlds` | **多源融合世界推荐**：local 新世界池 × PlanetVRC × 官方主题搜索 × 用户反馈，评分（热度+新鲜度+主题+作者画像 30 天窗口熟客）+ 可解释 reasons；theme/excludeTheme/sources/excludeVisited 参数 |

--- a/skills/vrchat-world-queries/SKILL.md
+++ b/skills/vrchat-world-queries/SKILL.md
@@ -35,7 +35,7 @@ metadata:
 
 用户说「把这张图加进待逛/待办」时走 3 工具：
 
-- `add_to_backlog {worldId, reason?, priority?}` — 加入待逛列表（本地待办，不动云端收藏；幂等，priority 0-2；世界不在 world_kb 时插兜底行）
+- `add_to_backlog {worldId, reason?, priority?}` — 加入待逛列表（本地待办，不动云端收藏；幂等，priority 0-2；世界不在 world_kb 时插兜底行，并自动回填元数据：先读本地 world_cache，缺失才走 `GET /worlds/{id}` 写回缓存 + world_kb（含 created_at），失败只记日志不阻断写入）
 - `get_backlog {status? (pending|visited|all 默认 pending), sortBy? (added_at|priority|favorites 默认 added_at), limit?}` — 查看待逛列表；**逛完自动从未逛区消失**（visited 后 pending 不再显示，记录保留在 visited 历史）
 - `remove_from_backlog {worldId}` — 移出待逛列表（只清 backlog 标记，保留行，幂等）
 

--- a/test/world-kb-backfill.test.mjs
+++ b/test/world-kb-backfill.test.mjs
@@ -140,3 +140,73 @@ test('回填后 get_backlog 能读到世界名（回归：此前恒为空串）'
   assert.equal(hit.worldName, '待逛的图');
   assert.equal(hit.authorName, '待逛作者');
 });
+
+
+// ── 可观测性：每次触发恰好一行 [世界KB] 日志（成功/降级都不静默）──
+const { logger } = await import(pathToFileURL(path.join(REPO, 'core', 'logger.js')).href);
+
+async function captureKbLogs(fn) {
+  const seen = [];
+  const orig = logger.info;
+  logger.info = (m) => { seen.push(String(m)); };
+  try { await fn(); } finally { logger.info = orig; }
+  return seen.filter((l) => l.includes('[世界KB]'));
+}
+
+const LOG_CACHE = 'wrld_kbtest-logcache-0000-0000-000000000011';
+const LOG_API = 'wrld_kbtest-logapi-0000-0000-000000000012';
+const LOG_404 = 'wrld_kbtest-log404-0000-0000-000000000013';
+const LOG_THROW = 'wrld_kbtest-logthrow-0000-0000-000000000014';
+const LOG_NOAPI = 'wrld_kbtest-logapi-none-0000-0000-000000000015';
+
+function logStub() {
+  return {
+    api: {
+      _request: async (method, p) => {
+        if (p.endsWith(LOG_API)) {
+          return { status: 200, data: { id: LOG_API, name: '日志图', authorName: '日志作者', tags: [] } };
+        }
+        if (p.endsWith(LOG_404)) return { status: 404, data: {} };
+        if (p.endsWith(LOG_THROW)) throw new Error('boom network');
+        throw new Error(`logStub 未预期: ${p}`);
+      },
+    },
+  };
+}
+
+test('日志：缓存路径恰好一行「回填(缓存)」', async () => {
+  ctx.api = logStub().api;
+  storage.upsertWorld({ worldId: LOG_CACHE, name: '缓存日志图', authorName: '缓存日志作者' });
+  const lines = await captureKbLogs(() => misc.handleAddToBacklog({ worldId: LOG_CACHE, priority: 1 }));
+  assert.equal(lines.length, 1, `应恰好 1 行，实际 ${JSON.stringify(lines)}`);
+  assert.equal(lines[0], `[世界KB] 兜底行回填(缓存): ${LOG_CACHE} → 缓存日志图 / 缓存日志作者`);
+});
+
+test('日志：API 路径恰好一行「回填(API)」', async () => {
+  ctx.api = logStub().api;
+  const lines = await captureKbLogs(() => misc.handleAddToBacklog({ worldId: LOG_API, priority: 1 }));
+  assert.equal(lines.length, 1, `应恰好 1 行，实际 ${JSON.stringify(lines)}`);
+  assert.equal(lines[0], `[世界KB] 兜底行回填(API): ${LOG_API} → 日志图 / 日志作者`);
+});
+
+test('日志：API 非 200 恰好一行「跳过」并带状态码', async () => {
+  ctx.api = logStub().api;
+  const lines = await captureKbLogs(() => misc.handleAddToBacklog({ worldId: LOG_404 }));
+  assert.equal(lines.length, 1, `应恰好 1 行，实际 ${JSON.stringify(lines)}`);
+  assert.equal(lines[0], `[世界KB] 兜底行回填跳过（API 404）: ${LOG_404}`);
+});
+
+test('日志：API 抛异常恰好一行「失败」并带原因', async () => {
+  ctx.api = logStub().api;
+  const lines = await captureKbLogs(() => misc.handleAddToBacklog({ worldId: LOG_THROW }));
+  assert.equal(lines.length, 1, `应恰好 1 行，实际 ${JSON.stringify(lines)}`);
+  assert.match(lines[0], new RegExp(`^\\[世界KB\\] 兜底行元数据回填失败（不影响主操作）: ${LOG_THROW} `));
+  assert.match(lines[0], /boom network/);
+});
+
+test('日志：无 API 客户端时也留一行「跳过」', async () => {
+  ctx.api = null;
+  const lines = await captureKbLogs(() => misc.handleAddToBacklog({ worldId: LOG_NOAPI }));
+  assert.equal(lines.length, 1, `应恰好 1 行，实际 ${JSON.stringify(lines)}`);
+  assert.equal(lines[0], `[世界KB] 兜底行回填跳过（无 API 客户端，缓存也未命中）: ${LOG_NOAPI}`);
+});

--- a/test/world-kb-backfill.test.mjs
+++ b/test/world-kb-backfill.test.mjs
@@ -1,0 +1,142 @@
+/**
+ * test/world-kb-backfill.test.mjs — 兜底行元数据回填（ensureWorldKbInfo）回归测试
+ *
+ * 覆盖：本地 world_cache 命中零 API 回填 / 缓存缺失走 API 并写回缓存 /
+ * API 失败不阻断主操作（仍写入 backlog 标记）/ 幂等不覆盖已有真实值 /
+ * set_world_sleep 同路径 / 回填后 get_backlog 能读到世界名。
+ * 自包含：临时 SQLite + stub api，不依赖真实 VRChat 凭据/网络。
+ */
+import { rmSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { test, after } from 'node:test';
+import assert from 'node:assert/strict';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.join(__dirname, '..');
+
+const { ctx } = await import(pathToFileURL(path.join(REPO, 'core', 'server-context.js')).href);
+const { Storage } = await import(pathToFileURL(path.join(REPO, 'core', 'storage.js')).href);
+const misc = await import(pathToFileURL(path.join(REPO, 'core', 'tools', 'misc.js')).href);
+
+const tmpDb = path.join(__dirname, 'test-world-kb-backfill.sqlite3');
+for (const f of [tmpDb, tmpDb + '-wal', tmpDb + '-shm']) { try { rmSync(f, { force: true }); } catch {} }
+
+const storage = new Storage();
+await storage.init(tmpDb);
+ctx.storage = storage;
+ctx.rateLimiter = { execute: (fn) => fn() };
+
+after(() => { for (const f of [tmpDb, tmpDb + '-wal', tmpDb + '-shm']) { try { rmSync(f, { force: true }); } catch {} } });
+
+const CACHED = 'wrld_kbtest-cached-0000-0000-000000000001';
+const FETCHED = 'wrld_kbtest-fetched-0000-0000-000000000002';
+const FETCHFAIL = 'wrld_kbtest-fetchfail-0000-0000-000000000003';
+const PRESET = 'wrld_kbtest-preset-0000-0000-000000000004';
+const SLEEPY = 'wrld_kbtest-sleepy-0000-0000-000000000005';
+
+// 预置：缓存里有资料的图 / 已被真实值占位的图
+storage.upsertWorld({ worldId: CACHED, name: '缓存里的图', authorId: 'usr_kbtest-author', authorName: '缓存作者', favorites: 42, tags: ['chill'] });
+storage.upsertWorld({ worldId: SLEEPY, name: '睡觉图', authorId: 'usr_kbtest-author', authorName: '缓存作者' });
+
+function apiStub() {
+  const calls = [];
+  return {
+    calls,
+    api: {
+      _request: async (method, p) => {
+        calls.push(`${method} ${p}`);
+        if (p.endsWith(FETCHFAIL)) return { status: 404, data: {} };
+        if (p.endsWith(FETCHED)) {
+          return {
+            status: 200,
+            data: {
+              id: FETCHED, name: '联网拉到的图', authorId: 'usr_kbtest-fetch-author', authorName: '联网作者',
+              capacity: 32, favorites: 123, releaseStatus: 'public', tags: ['riddle'],
+              description: '描述', imageUrl: 'https://example.invalid/x.png', created_at: '2026-09-09T00:00:00.000Z',
+            },
+          };
+        }
+        throw new Error(`stub api 未预期的调用: ${p}`);
+      },
+    },
+  };
+}
+
+test('缓存命中：回填 name/author 且零 API 调用', async () => {
+  const stub = apiStub();
+  ctx.api = stub.api;
+  const res = await misc.handleAddToBacklog({ worldId: CACHED, reason: '氛围图', priority: 1 });
+  assert.equal(res.worldName, '缓存里的图', '返回值应带回填后的世界名');
+  assert.equal(stub.calls.length, 0, '缓存命中不应调 API');
+  const kb = storage.getWorldKbInfo(CACHED);
+  assert.equal(kb.worldName, '缓存里的图');
+  assert.equal(kb.authorName, '缓存作者');
+  const row = storage.query(`SELECT backlog, backlog_reason, backlog_priority FROM world_kb WHERE world_id = $w`, { $w: CACHED })[0];
+  assert.equal(row.backlog, 1);
+  assert.equal(row.backlog_reason, '氛围图');
+  assert.equal(row.backlog_priority, 1);
+});
+
+test('缓存缺失：走 API 一次并写回缓存 + world_kb（含 created_at）', async () => {
+  const stub = apiStub();
+  ctx.api = stub.api;
+  const res = await misc.handleAddToBacklog({ worldId: FETCHED, reason: 'X 上看到', priority: 2 });
+  assert.equal(res.worldName, '联网拉到的图');
+  assert.deepEqual(stub.calls, [`GET /worlds/${FETCHED}`], '应恰好调一次 API');
+  const kb = storage.getWorldKbInfo(FETCHED);
+  assert.equal(kb.worldName, '联网拉到的图');
+  assert.equal(kb.authorName, '联网作者');
+  assert.equal(kb.createdAt, '2026-09-09T00:00:00.000Z', 'created_at 由 API 回填（推荐侧新图加权依赖它）');
+  const cached = storage.getWorldName(FETCHED);
+  assert.ok(cached, 'API 结果应写回 world_cache');
+  assert.equal(cached.name, '联网拉到的图');
+});
+
+test('API 失败：主操作照常成功，不抛错、不产生脏值', async () => {
+  const stub = apiStub();
+  ctx.api = stub.api;
+  const res = await misc.handleAddToBacklog({ worldId: FETCHFAIL, priority: 0 });
+  assert.equal(res.inBacklog, true, '回填失败不应影响加入待逛');
+  assert.equal(res.worldName, '', '拿不到资料时保持空串（不编造）');
+  const kb = storage.getWorldKbInfo(FETCHFAIL);
+  assert.equal(kb.worldName, '');
+  const row = storage.query(`SELECT backlog, world_name FROM world_kb WHERE world_id = $w`, { $w: FETCHFAIL })[0];
+  assert.equal(row.backlog, 1);
+  assert.equal(row.world_name, '');
+});
+
+test('幂等：已有真实世界名不被缓存值覆盖', async () => {
+  const stub = apiStub();
+  ctx.api = stub.api;
+  storage.run(`INSERT INTO world_kb (world_id, world_name, author_name, tags) VALUES ($w, '人工写死的名字', '人工作者', '[]')`, { $w: PRESET });
+  storage.upsertWorld({ worldId: PRESET, name: '缓存里的另一个名字', authorName: '缓存作者' });
+  await misc.handleAddToBacklog({ worldId: PRESET });
+  const kb = storage.getWorldKbInfo(PRESET);
+  assert.equal(kb.worldName, '人工写死的名字', 'world_name 非空时不得覆盖');
+  assert.equal(kb.authorName, '人工作者', 'author_name 非空时不得覆盖');
+});
+
+test('set_world_sleep 走同一回填路径', async () => {
+  const stub = apiStub();
+  ctx.api = stub.api;
+  const res = await misc.handleSetWorldSleep({ worldId: SLEEPY, isSleep: true });
+  assert.equal(res.isSleep, true);
+  assert.equal(res.worldName, '睡觉图');
+  const row = storage.query(`SELECT sleep_ok, world_name FROM world_kb WHERE world_id = $w`, { $w: SLEEPY })[0];
+  assert.equal(row.sleep_ok, 1);
+  assert.equal(row.world_name, '睡觉图');
+});
+
+test('回填后 get_backlog 能读到世界名（回归：此前恒为空串）', async () => {
+  const stub = apiStub();
+  ctx.api = stub.api;
+  const NEWONE = 'wrld_kbtest-backlog-0000-0000-000000000006';
+  storage.upsertWorld({ worldId: NEWONE, name: '待逛的图', authorName: '待逛作者' });
+  await misc.handleAddToBacklog({ worldId: NEWONE, reason: '待逛', priority: 1 });
+  const bl = misc.handleGetBacklog({ status: 'pending', sortBy: 'priority', limit: 20 });
+  const hit = bl.worlds.find((w) => w.worldId === NEWONE);
+  assert.ok(hit, '新加的图应在 pending 列表里');
+  assert.equal(hit.worldName, '待逛的图');
+  assert.equal(hit.authorName, '待逛作者');
+});

--- a/test/world-kb-backfill.test.mjs
+++ b/test/world-kb-backfill.test.mjs
@@ -210,3 +210,25 @@ test('日志：无 API 客户端时也留一行「跳过」', async () => {
   assert.equal(lines.length, 1, `应恰好 1 行，实际 ${JSON.stringify(lines)}`);
   assert.equal(lines[0], `[世界KB] 兜底行回填跳过（无 API 客户端，缓存也未命中）: ${LOG_NOAPI}`);
 });
+
+
+test('缓存行只有 author 没有 name：走 API 补全名字（review 💡1 判据）', async () => {
+  const stub = apiStub();
+  ctx.api = stub.api;
+  const AUTHOR_ONLY = 'wrld_kbtest-authoronly-0000-0000-000000000016';
+  storage.run(
+    `INSERT INTO world_cache (world_id, name, author_name, author_id) VALUES ($w, '', '只有作者', 'usr_kbtest-onlyauthor')`,
+    { $w: AUTHOR_ONLY }
+  );
+  // stub 只认 FETCHED/FETCHFAIL，这里给它一个通用响应
+  stub.api._request = async (method, p) => {
+    stub.calls.push(`${method} ${p}`);
+    return { status: 200, data: { id: AUTHOR_ONLY, name: 'API 补的名字', authorName: '只有作者', tags: [] } };
+  };
+  const lines = await captureKbLogs(() => misc.handleAddToBacklog({ worldId: AUTHOR_ONLY }));
+  assert.equal(stub.calls.length, 1, 'name 为空时应走 API 而不是只吃缓存');
+  const kb = storage.getWorldKbInfo(AUTHOR_ONLY);
+  assert.equal(kb.worldName, 'API 补的名字');
+  assert.equal(lines.length, 1);
+  assert.match(lines[0], /^\[世界KB\] 兜底行回填\(API\): wrld_kbtest-authoronly-0000-0000-000000000016 → API 补的名字 \/ 只有作者$/);
+});


### PR DESCRIPTION
## 需求来源

使用者在 X 上看到一张新解谜图（`謎解きワールド「APEX」`），让本地 agent 用 `add_to_backlog` 加入待逛列表。加完发现这条**没有世界名**：`get_backlog` 返回的 `worldName` 是空串，只有 `worldId` 和 reason 可读；world_kb 里该行的 `world_name` / `author_name` / `created_at` 全空。

溯源：这是 **issue #76 → PR #77 已修过的问题回归**。

- `docs/history/2026-08.md` 记录过同一现象：「兜底插入（rate_world/mark_world_visited/add_to_backlog）的信息字段 100% 恒空——实测 57 行 world_name/author_name/created_at 全空，新图加权（FRESH_DAYS 窗口）对靠手工标记进表的世界永远失效」（issue #76 → PR #77）。
- #77 的修复是 `ensureWorldKbInfo`（优先本地 world_cache → 缺失串行调 `/worlds/{id}` 限流 → 回填 cache 与 kb），并接入三处兜底插入。
- 插件化重构（handler 拆到 `core/domains/world-store.js` + `core/tools/misc.js`、world-kb 服务化）之后，`storage.backfillWorldKbInfo` **保留了下来但没有任何生产调用点**（全仓库仅剩 `test/test-storage-snapshot.mjs` 调用），`ensureWorldKbInfo` 整体消失 —— 即兜底行的回填在重构中被丢掉了。

## 实现方式

`core/tools/misc.js` 新增模块内 `ensureWorldKbInfo(worldId)`，恢复 #77 语义：

- 先读本地 `world_cache`（零成本）→ 命中即 `backfillWorldKbInfo`（name / authorName / authorId）
- 缓存缺失才按 `ctx.rateLimiter` 拉一次 `GET /worlds/{id}`，写回 `world_cache`（upsertWorld）并回填 `world_kb`（含 `created_at`——推荐侧新图加权依赖它）
- 幂等：`backfillWorldKbInfo` 仅在对应列为空时写入，不覆盖已有真实值
- 失败静默降级：任何一步异常只记一条日志，不阻断主操作（缺元数据不该让待逛/标记写入失败）
- 无 api / 无 rateLimiter 时自然跳过（缓存路径仍生效）

接入 4 个兜底插入点（原 #77 三处 + `set_world_sleep`，同一缺陷类）：`handleRateWorld` / `handleMarkWorldVisited` / `handleAddToBacklog` / `handleSetWorldSleep` 改 async，返回值 `worldName` 采用回填后的值。响应其余字段与工具名/参数均不变（`{...result, worldName}`）；调用链（插件 `api.consume` → 服务层 → handler）与 MCP 层均已 await，已实测确认响应体正常。

**可观测性（第二个 commit）**：原实现只在异常分支记日志——缓存/API 回填成功静默、API 非 200 完全静默。已补齐为「每次触发恰好 1 行」：

| 路径 | 日志行 |
|---|---|
| 缓存命中回填 | `[世界KB] 兜底行回填(缓存): <worldId> → <世界名> / <作者>` |
| API 回填成功 | `[世界KB] 兜底行回填(API): <worldId> → <世界名> / <作者>` |
| API 非 200 | `[世界KB] 兜底行回填跳过（API 404）: <worldId>` |
| 抛异常 | `[世界KB] 兜底行元数据回填失败（不影响主操作）: <worldId> <原因>` |
| 无 api 客户端且缓存未命中 | `[世界KB] 兜底行回填跳过（无 API 客户端，缓存也未命中）: <worldId>` |

均为 INFO 单行、只在四个工具命中"世界不在 world_kb"时触发（非热路径），不引入常态噪音。

**文档同步（第三个 commit）**：`skills/vrchat-world-queries/SKILL.md`（backlog 工具清单）+ `skills/vrc-monitor-agent/SKILL.md`（权威工具表）的 `add_to_backlog` 描述补上"插兜底行并回填元数据"。全仓库 `grep 兜底行` 的活文档只有这两处；`docs/history` 的历史条目按惯例不改写。

## 验证过程与结果

**1) 新增回归测试 `test/world-kb-backfill.test.mjs`（12 例，stub api + 临时库，不依赖凭据/网络）**

行为 7 例：缓存命中（**0 次 API**）/ 缓存缺失走 API 并写回缓存（含 `created_at`）/ API 失败不阻断且不编造 / 幂等不覆盖真实值 / `set_world_sleep` 同路径 / 回填后 `get_backlog` 能读到世界名 / 缓存行只有 author 时走 API 补名（review 💡1）。
日志 5 例：逐字比对五种日志行，且断言**恰好 1 行**（成功与降级都不静默）。

```
node --test test/world-kb-backfill.test.mjs
# tests 12 / pass 12 / fail 0
```

**2) 全量测试**

```
node --test "test/**/*.test.mjs"
# tests 98 / pass 98 / fail 0   （改动前 86 例 + 新增 12 例）
```

**3) 隔离实例端到端**（worktree + 全新空库 + 端口 8812 + 复用主服务登录态；未触碰主库/主服务）

| 调用 | 实测结果 |
|---|---|
| `add_to_backlog(APEX)`（缓存缺失 → API 回填路径） | 返回 `worldName: "謎解きワールド「APEX」"`；world_kb 行 name / author(な つ め) / created_at `2026-09-09T21:04:42Z` 全部落地 |
| `add_to_backlog(APEX)` 第二次（缓存命中路径） | 返回同名字，日志来源标记为 `(缓存)` |
| `mark_world_visited(夜とポケット)` | 返回并回填「夜とポケット」/ 作者「仮想える＊」 |
| `set_world_sleep(落陽の帰り道 -The Road Home at Sunset-)` | 返回并回填世界名，`sleep_ok=1` |
| `add_to_backlog(无效 worldId)`（API 404 降级路径） | 仍成功：`backlog=1`、`worldName` 空串、无异常抛错 |
| `get_backlog` 读回 | 待逛项均带世界名（此前恒为空串） |

真实日志（隔离实例，三条路径各一行）：

```
07:53:33.515 INFO [app] [世界KB] 兜底行回填(API): wrld_814c96fe-... → 謎解きワールド「APEX」 / な つ め
07:53:36.142 INFO [app] [世界KB] 兜底行回填跳过（API 404）: wrld_zzz-not-a-real-id
07:53:36.153 INFO [app] [世界KB] 兜底行回填(缓存): wrld_814c96fe-... → 謎解きワールド「APEX」 / な つ め
```

**影响面**：`core/tools/misc.js`（新增内部函数 + 4 个 handler 改 async + 日志）、`test/world-kb-backfill.test.mjs`（新增）、两个 skill 文档各 1 行。不涉及 DB schema 变更、不改工具名/参数、不触碰插件边界。

## 提交序列

| commit | 内容 |
|---|---|
| `da0cf4e` | 恢复兜底行元数据回填（核心修复 + 6 例回归） |
| `17f63ed` | 补日志可观测性（+5 例日志断言） |
| `68eaf32` | 文档同步（两个 skill 各 1 行） |
| `883d98b` | review 💡1：缓存判据收窄为 `name`（+1 例） |

**注**：本 PR 的 base 是 main 的 `68df8aa`（vrc_status/stop 插件修复，已单独合入 main）——该 commit 属 base，不在本 PR 的提交/文件清单内。
