### PR TITLE
fix(mcp): GET /mcp 返回 405（消除 MCP 客户端每 1s 无限重连刷屏）

### DIFF
--- a/core/http-server.js
+++ b/core/http-server.js
@@ -151,10 +151,18 @@ async function handleRequest(req, res) {
     return;
   }
 
-  // MCP endpoint probe
+  // MCP GET 流：本服务不推送 server→client 消息，按 MCP Streamable HTTP 规范必须
+  // 「返回 text/event-stream」或「返回 405」——**曾经返回 200+空 SSE 并立即 end**，
+  // 导致合规客户端（如 MCP Python SDK / Hermes）判定流断开并**每 1000ms 无限重连**，
+  // 刷屏日志「GET stream disconnected, reconnecting in 1000ms...」（用户实测反馈）。
+  // SDK 行为：405 会计入重连尝试（上限 2 次后停止）；200+立即结束则 attempt 归零 → 死循环。
   if (req.method === 'GET' && pathname === '/mcp') {
-    res.writeHead(200, { 'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache', 'Content-Length': 0 });
-    res.end();
+    res.writeHead(405, { 'Allow': 'POST, DELETE', 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({
+      jsonrpc: '2.0',
+      error: { code: -32000, message: 'This MCP server does not offer a server-initiated SSE stream; use POST for requests (DELETE to end the session).' },
+      id: null,
+    }));
     return;
   }
 

--- a/test/mcp-method-contract.test.mjs
+++ b/test/mcp-method-contract.test.mjs
@@ -1,0 +1,73 @@
+/**
+ * mcp-method-contract.test.mjs — /mcp 的 HTTP 方法契约（用户实测刷屏回归）
+ *
+ * 背景（2026-09-13 群友反馈）：日志被「GET stream disconnected, reconnecting in 1000ms...」刷屏。
+ * 该行来自 MCP Python SDK 客户端（mcp.client.streamable_http）；服务端 GET /mcp 曾返回
+ * 200 + text/event-stream + 立即 end → SDK 的 handle_get_stream 判定流断开后把 attempt 归零
+ * → 每 1000ms 无限重连（合规行为：405 会计入尝试，上限 2 次后停止）。
+ * 本测试锁定：GET /mcp 必须 405（不提供 server→client 流），POST 仍为正常请求通道。
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import { createServer } from '../core/http-server.js';
+import { ctx } from '../core/server-context.js';
+import { RateLimiter } from '../core/rate-limiter.js';
+
+async function withServer(fn) {
+  // 本测试只验证 HTTP 方法契约：清掉 .env 载入的 token，走「未配置 token」的开发态（fail-open），
+  // 否则 #159 的 fail-closed（token 已配置但无 http.authenticate 服务）会把请求拦成 401。
+  delete process.env.VRC_MONITOR_AUTH_TOKEN;
+  delete process.env.VRC_MONITOR_API_KEY;
+  ctx.storage = { getStats: () => ({ events: 1, friends: 1, world_cache: 0 }) };
+  ctx.rateLimiter = new RateLimiter();
+  ctx.serverState = { started: Date.now(), authUser: null, needsOtp: false, needsTotp: false };
+  ctx.paths = { PORT: 0, HOST: '127.0.0.1' };
+  ctx.httpRoutes = new Map();
+  // hasService 恒 false：既不触发 fail-closed（token 已清），也不进入 http.authenticate 分支
+  ctx.pluginLoader = { getStatus: () => [], hasService: () => false, consume: () => ({ token: null }) };
+  const server = createServer();
+  await new Promise((r) => server.listen(0, '127.0.0.1', r));
+  const port = server.address().port;
+  const request = (path, options = {}) => new Promise((resolve, reject) => {
+    const req = http.request(`http://127.0.0.1:${port}${path}`, options, (res) => {
+      let data = '';
+      res.on('data', (c) => (data += c));
+      res.on('end', () => resolve({ status: res.statusCode, data, headers: res.headers }));
+    });
+    req.on('error', reject);
+    if (options.body) req.write(options.body);
+    req.end();
+  });
+  try { return await fn(request); } finally { await new Promise((r) => server.close(r)); }
+}
+
+test('GET /mcp 返回 405（不提供 server→client SSE 流，避免客户端无限重连刷屏）', async () => {
+  await withServer(async (request) => {
+    const res = await request('/mcp', { method: 'GET' });
+    assert.equal(res.status, 405, 'GET /mcp 必须是 405（规范二选一：长连 SSE 或 405）');
+    assert.match(String(res.headers.allow || ''), /POST/, 'Allow 头应声明可用方法');
+    assert.equal(res.headers['content-type'], 'application/json');
+  });
+});
+
+test('DELETE /mcp 返回 204（会话终止，SDK 关闭连接时调用）', async () => {
+  await withServer(async (request) => {
+    const res = await request('/mcp', { method: 'DELETE' });
+    assert.equal(res.status, 204);
+  });
+});
+
+test('POST /mcp 仍正常（initialize → SSE + Mcp-Session-Id，GET 的改动未伤请求通道）', async () => {
+  await withServer(async (request) => {
+    const res = await request('/mcp', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} }),
+    });
+    assert.equal(res.status, 200);
+    assert.match(String(res.headers['content-type'] || ''), /text\/event-stream/);
+    assert.ok(res.headers['mcp-session-id'], '应下发会话 id（客户端据此决定是否开 GET 流）');
+    assert.match(res.data, /"result"/);
+  });
+});

--- a/test/test-auth-guard.mjs
+++ b/test/test-auth-guard.mjs
@@ -148,7 +148,10 @@ console.log('\n── 3. 端到端测试: HTTP 鉴权中间件 ──');
   let res = await request('/health');
   assert.equal(res.status, 200, '未配置 Token 时 /health 正常访问');
   res = await request('/mcp');
-  assert.equal(res.status, 200, '未配置 Token 时 /mcp 正常访问');
+  // GET /mcp 的方法契约是 405（不提供 server→client SSE 流，见 mcp-method-contract 测试）：
+  // 这里断言「未被 401 拦截」即证明鉴权未启用时服务完全放行——405 表示已通过鉴权并抵达方法契约层。
+  assert.equal(res.status, 405, '未配置 Token 时 /mcp 抵达方法契约层（405 而非 401）');
+  assert.match(String(res.headers.allow || ''), /POST/);
   ok('未配置 Token 时服务默认完全放行（向后兼容）');
 
   // 3.2 启用 Token
@@ -178,16 +181,17 @@ console.log('\n── 3. 端到端测试: HTTP 鉴权中间件 ──');
 
   // 3.2.4 正确 Token - X-API-Key Header
   res = await request('/mcp', { headers: { 'x-api-key': TEST_TOKEN } });
-  assert.equal(res.status, 200);
-  ok('携带正确 X-API-Key 成功访问 /mcp');
+  // 鉴权通过 → 抵达 GET /mcp 的方法契约（405，不提供 server→client SSE 流）
+  assert.equal(res.status, 405, '携带正确 X-API-Key 应通过鉴权（405 = 已抵达方法契约层）');
+  ok('携带正确 X-API-Key 成功通过鉴权访问 /mcp');
 
   // 3.2.5 正确 Token - Query Parameter
   res = await request('/health?token=' + TEST_TOKEN);
   assert.equal(res.status, 200);
   assert.equal(JSON.parse(res.data).ok, true);
   res = await request('/mcp?token=' + TEST_TOKEN);
-  assert.equal(res.status, 200);
-  ok('携带正确 URL Query ?token=... 成功访问 /mcp 与 /health');
+  assert.equal(res.status, 405, '携带正确 ?token= 应通过鉴权（405 = 已抵达方法契约层）');
+  ok('携带正确 URL Query ?token=... 成功通过鉴权访问 /mcp 与 /health');
 
   // 3.2.7 根路径豁免（PR #150）：GET/HEAD / → 302 /dashboard（无 token 也不返回 401）
   res = await request('/');


### PR DESCRIPTION
## 问题（用户实测反馈）

日志被下面这一行刷屏（群内反馈，出现在用户的 MCP 客户端日志中）：

```
mcp.client.streamable_http: GET stream disconnected, reconnecting in 1000ms...
```

## 根因

该行来自 **MCP 官方客户端**（Python SDK `mcp/client/streamable_http.py` 的 `handle_get_stream`），不是本服务日志——但**触发条件在服务端**。

MCP Streamable HTTP 规范对 `GET /mcp` 的要求是二选一：

> The server MUST either return `Content-Type: text/event-stream` in response to this HTTP GET, **or else return HTTP 405 Method Not Allowed**.

而本服务此前返回 **200 + `text/event-stream` + `Content-Length: 0` 并立即 `end()`**——客户端解析为「SSE 流已建立但立刻断开」，随即进入 SDK 重连逻辑：

```python
async for sse in event_source:      # 空流 → 立即结束
    ...
attempt = 0                         # ← 正常结束会「重置」尝试计数
...
logger.info(f"GET stream disconnected, reconnecting in {delay_ms}ms...")
await anyio.sleep(delay_ms / 1000.0)  # 默认 1000ms
```

`attempt` 归零 → **每 1000ms 无限重连** → 刷屏。反之若返回 **405**，SDK 走 `raise_for_status()` 异常分支：`attempt += 1`，达到 `MAX_RECONNECTION_ATTEMPTS`（2）后打 debug 并**停止**——即从「无限刷屏」变为「每会话最多 1 行」。

同类现象参考：[modelcontextprotocol/python-sdk#2393](https://github.com/modelcontextprotocol/python-sdk/issues/2393)、[open-webui#23314](https://github.com/open-webui/open-webui/discussions/23314)、[envoy#45900](https://github.com/envoyproxy/envoy/issues/45900)（后者客户端日志与此完全一致）。

## 修复

`core/http-server.js`：`GET /mcp` 由「200 + 空 SSE 立即结束」改为规范允许的 **405**：

```js
res.writeHead(405, { 'Allow': 'POST, DELETE', 'Content-Type': 'application/json' });
res.end(JSON.stringify({ jsonrpc: '2.0', id: null, error: { code: -32000, message: '...does not offer a server-initiated SSE stream; use POST...' } }));
```

- 本服务不推送 server→client 消息，因此「无 GET 流」是诚实声明；POST（请求通道）与 DELETE（会话终止）行为不变
- 客户端刷屏从「无限」降为「每会话最多 1 行 info」，且不再产生每秒一次的无用请求

> 备选是真实的常驻 SSE 流（配 keepalive）：客户端连上后不再重连、可做到零日志；但本服务当前没有 server→client 通知需求，常驻流还需连接保活/清理，405 是规范认可且成本最低的形态。将来若需服务端主动推送（如长任务进度），再改常驻流。

## 验证

- 新增回归 `test/mcp-method-contract.test.mjs` ×3：GET → 405 + `Allow: POST, DELETE`；POST `initialize` → 200 + `text/event-stream` + 下发 `Mcp-Session-Id`；DELETE → 204
- 全量 `npm test` **105/105**（本分支基线）
- 生产容器实测（部署该 commit 后）：`GET /mcp` → **405 + Allow: POST, DELETE**；`POST initialize` → 200 + SSE + 会话 id；`POST tools/call get_online_friends` → 200 且有 result；`/health` → 13/13 插件、`ws: connected`（MCP 请求通道未受影响）
