### PR TITLE
fix(logging): 日志噪音治理——头像变更降 debug、测试进程不写生产日志、stdout 捕获文件加轮转

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,6 +92,7 @@
 - `VRC_MONITOR_DB_PATH`：SQLite 数据库文件路径（默认 `<仓库>/data/vrc-monitor.sqlite3`）。可将数据库迁移到任意位置（如独立数据盘），配合常驻服务使用。
 - `VRC_MONITOR_BACKUP_DIR`：自动备份目录（默认 `<仓库>/data/backups`）。
 - `VRC_MONITOR_LOG_DIR`：常驻服务脚本的日志 / 修复记录目录（默认 `<仓库>/service-logs`，仅 `service-windows/` 脚本使用；Linux systemd 方案日志走 journald，无需设置）。
+- `VRC_MONITOR_CAPTURE_LOG_MAX_SIZE`：Hermes 插件 stdout 捕获文件（`$HERMES_HOME/workspace/vrc-monitor/monitor.log`，node 子进程 stdout/stderr 合并写入）的轮转阈值字节（默认 `10485760`=10MB）。注意：与 `VRC_MONITOR_LOGGER_MAX_SIZE`（logger 模块结构化日志 `<VRC_MONITOR_DIR>/logs/monitor.log` 的轮转阈值）**不同名不同义**，勿混用。
 - `VRC_MONITOR_LOGGER_DIR`：应用日志模块（`core/logger.js`）日志文件目录（默认 `<VRC_MONITOR_DIR>/logs`）。注意：与上面 `VRC_MONITOR_LOG_DIR`（service 脚本用）不同名不同义，勿混用。
 - `VRC_MONITOR_LOGGER_LEVEL`：日志最低输出级别（默认 `info`，取值 `debug|info|warn|error|silent`）。
 - `VRC_MONITOR_LOGGER_FORMAT`：日志格式（默认 `text`，`json`=每行 JSONL 供 agent 解析）。

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -174,6 +174,7 @@ PR 由 AI Agent 编写提交（人类只提出需求、不直接编码）。以�
 - **CI 里的凭据红线**：workflow 文件及其他自动化路径**严禁**出现任何真实凭据、Cookie、token、密码、IMAP 授权码（`credentials.json` 已被 gitignore 排除）。自动化测试账号如需纳入 CI，一律走 GitHub repo secrets 且绝不回显到日志。
 - 新增测试脚本命名沿用 `test-*.mjs` 风格，方便 CI 统一发现。
 - **插件第三方依赖**：`plugins/official/*` 中带 `package.json` 的插件（目前 emoji-notes 依赖 pinyin-pro）需先执行 `npm run install-plugins`（CI 已在 `npm ci` 后运行此步）。本地/审查环境只跑 `npm ci` 会漏装插件依赖，表现为此类插件整体加载失败、`test/test-registry.mjs` 工具数少于 `core/tool-order.json`（如 105/108）——先补装插件依赖再跑测试，勿误判为代码回归。
+- **测试日志隔离（两条路径，绝不写生产日志目录）**：① `npm test`（package.json 的 test script）通过 `--import ./test/setup-log-isolation.mjs` 把 `VRC_MONITOR_LOGGER_DIR` 钉到每次运行唯一的系统临时目录——显式隔离；② 裸 `node --test`（不经 npm script）只有 `core/logger.js` `resolveDir()` 的 `NODE_TEST_CONTEXT` 单点兜底（node --test 子进程会设 `NODE_TEST_CONTEXT`，日志落到 `os.tmpdir()/vrc-monitor-test-logs`）。两条路径都不会写进生产日志目录 `<VRC_MONITOR_DIR>/logs`（曾实测 96 行 `wrld_kbtest-*` 测试夹具污染生产日志，后修复）。
 
 ## 7. AI Agent 提交前自检清单
 

--- a/core/event-pipeline.js
+++ b/core/event-pipeline.js
@@ -265,7 +265,12 @@ export class EventPipeline {
 
           switch (c.type) {
             case 'avatar': {
-              log.info(`${displayName} 头像变更`);
+              // 头像变更是热路径（实测单好友 5 分钟窗口最多 26 条 ≈ 12 秒一条、2 天 683 条，
+              // 占日志 34.5%），逐条 INFO 信噪比过低；且 DB 事件流已完整记录
+              // （get_friend_profile_changes / 看板「Avatar/头像变更」页可查全量含新旧图 URL），
+              // 日志层无需逐条回显。需要排查时用 VRC_MONITOR_LOGGER_LEVEL=debug 打开。
+              // 先例：core/http-server.js:13「MCP 协议层请求日志默认降为 debug 级避免 ping/keepalive 刷屏」。
+              log.debug(`${displayName} 头像变更`);
               break;
             }
             case 'bio': {

--- a/core/event-pipeline.js
+++ b/core/event-pipeline.js
@@ -114,7 +114,10 @@ export class EventPipeline {
 
     // 存储事件（带解析到的世界名）
     this._storeEvent(event, worldName);
-    log.info(`${displayName} 上线「${worldName || worldId || location || '未知'}」`);
+    // 上线是热路径（生产实测「上线+下线」合计占日志 22.3%），逐条 INFO 信噪比过低：
+    // DB 事件流 / SSE / 看板不受影响（events 表照常落库），日志层无需逐条回显。
+    // 排查时用 VRC_MONITOR_LOGGER_LEVEL=debug 恢复。先例：头像变更（34.5%，已降 debug）。
+    log.debug(`${displayName} 上线「${worldName || worldId || location || '未知'}」`);
   }
 
   async _handleOffline(event) {
@@ -129,7 +132,9 @@ export class EventPipeline {
     });
 
     this._storeEvent(event);
-    log.info(`${event.displayName || userId} 下线`);
+    // 下线同属热路径（「上线+下线」合计 22.3%），降 debug 理由同 _handleOnline：
+    // 事件照旧落库，VRC_MONITOR_LOGGER_LEVEL=debug 可恢复。
+    log.debug(`${event.displayName || userId} 下线`);
   }
 
   async _handleLocation(event) {
@@ -161,7 +166,11 @@ export class EventPipeline {
     this._storeEvent(event, worldName);
 
     if (worldId && worldId !== 'private' && worldId !== prevWorldId) {
-      log.info(`${displayName} 换世界 → ${worldName || worldId}`);
+      // 换世界是剩余热路径里最大头（生产实测占日志 26.0%），同样降 debug：
+      // DB 事件流 / SSE / 看板不受影响（events 表照常落库含世界名），
+      // 排查用 VRC_MONITOR_LOGGER_LEVEL=debug 恢复。
+      // 至此 INFO 日志累计压掉：换世界 26.0% + 上线/下线 22.3% + 头像变更 34.5%。
+      log.debug(`${displayName} 换世界 → ${worldName || worldId}`);
     } else {
       log.debug(`${displayName} 位置更新: ${truncateCodePoints(worldName || worldId || location, 60)}`);
     }

--- a/core/logger.js
+++ b/core/logger.js
@@ -1,4 +1,5 @@
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import zlib from 'node:zlib';
 import { fileURLToPath } from 'node:url';
@@ -71,6 +72,15 @@ function resolveDir() {
   // 日志模块专属变量名（VRC_MONITOR_LOGGER_DIR），不与 AGENTS.md 里 service-windows 用的 VRC_MONITOR_LOG_DIR 撞名
   if (process.env.VRC_MONITOR_LOGGER_DIR) {
     return path.resolve(process.env.VRC_MONITOR_LOGGER_DIR);
+  }
+  // node --test 上下文（node --test 子进程 NODE_TEST_CONTEXT=child-v8，已实测）：
+  // 任何继承 VRC_MONITOR_DIR 的测试进程都会把日志写进生产目录（实测 96 行 wrld_kbtest-*
+  // 测试夹具污染主仓库生产日志），单点防御落到系统临时目录与生产日志物理隔离。
+  // 显式 VRC_MONITOR_LOGGER_DIR 永远优先（上方分支），此处只在未显式指定时兜底。
+  if (process.env.NODE_TEST_CONTEXT) {
+    const dir = path.join(os.tmpdir(), 'vrc-monitor-test-logs');
+    console.info(`[logger] 检测到 node --test 上下文，日志落盘改用临时目录: ${dir}（如需显式指定请设 VRC_MONITOR_LOGGER_DIR）`);
+    return dir;
   }
   if (process.env.VRC_MONITOR_DIR) {
     return path.join(process.env.VRC_MONITOR_DIR, 'logs');

--- a/hermes-plugin/README.md
+++ b/hermes-plugin/README.md
@@ -1,0 +1,37 @@
+# hermes-plugin（vrc-monitor 进程托管）
+
+Hermes 插件：托管 vrc-monitor Node.js 服务的启停与状态查询（工具 `vrc_start` / `vrc_stop` / `vrc_restart` / `vrc_status`），并把 node 子进程的 stdout/stderr 合并捕获到日志文件。
+
+## stdout 捕获文件与轮转
+
+- **捕获文件位置**：`$HERMES_HOME/workspace/vrc-monitor/monitor.log`（Hermes home 默认 Windows `%LOCALAPPDATA%\hermes`、Linux/macOS `~/.hermes`）。该文件是子进程 stdout/stderr 的合并重定向，只追加、从不清理——不轮转会无限增长（曾实测 3.7MB）。
+- **轮转时机（双钩子）**：
+  1. `vrc_start` 启动进程前检查一次（低频事件；未达阈值时写一行「跳过」日志，含当前大小）；
+  2. `vrc_status` 每次状态查询时检查一次——常驻服务数周不重启时这是唯一的阈值检查时机（`status()` 的「跳过」分支**不写日志行**，防 Agent 高频调用把捕获文件变成新的刷屏源，结果经返回值的 `log_capture` 字段可见）。
+- **阈值 / 保留份数**：默认 10MB / 5 份（与 `core/logger.js` 的 maxSize/maxFiles 默认一致）。阈值可用环境变量 `VRC_MONITOR_CAPTURE_LOG_MAX_SIZE`（字节）覆盖——注意它只管本插件捕获文件，与 logger 模块结构化日志（`<VRC_MONITOR_DIR>/logs/monitor.log`）的 `VRC_MONITOR_LOGGER_MAX_SIZE` **不同名不同义**。
+- **归档命名**：`monitor-<UTC YYYYMMDD-HHMMSS>-<pid>.log.gz`，对齐 `core/logger.js doRotate()`。清理时 `.gz` 与 gzip 失败遗留的未压缩 `monitor-*.log` 两类归档**共享同一个保留预算**（总数口径，按 mtime 删最旧）；active 文件 `monitor.log` 不带 `monitor-<ts>-` 前缀，两个 glob 都匹配不到，不会被误删。
+- **轮转方式（rename 优先 + copytruncate 兜底）**：先 rename → gzip → 删未压缩件（原子、无损）；Windows 下子进程持有 stdout 句柄时运行中 rename 必失败（`WinError 32` 另一个程序正在使用此文件），自动回退 **copytruncate**（复制成 .gz 归档 → 清空 active 文件，子进程后续写入正常落在新 EOF）。copytruncate 有微秒级竞态：拷贝与清空之间子进程新写入的行会随清空丢失（与 Unix `logrotate copytruncate` 同性质），已用「最多 3 次 stat→读→再 stat，两次 size 一致（期间无新写入）才清空」最小化。
+- **留痕**：轮转成功 / 失败两个分支在两个钩子里都各写一行 `[plugin] 日志轮转: …` / `[plugin] 日志轮转失败（不阻断启动/不影响本次状态查询，继续追加）：…` 进（新的）active 文件（禁静默降级）；任何轮转异常都不阻断启动 / 状态查询。
+- **`vrc_status` 新增 `log_capture` 字段**（只增不改，`log_file` 等既有字段语义不变）：
+
+  ```json
+  {
+    "path": "…/workspace/vrc-monitor/monitor.log",
+    "size": 3670016,
+    "threshold": 10485760,
+    "rotated": false,
+    "method": null,
+    "removed": [],
+    "error": null
+  }
+  ```
+
+  `method` 取值 `rename` | `copytruncate` | `null`（未轮转）；`error` 仅轮转失败时非空。
+
+## 测试
+
+```
+python -m unittest discover -s hermes-plugin/tests -v
+```
+
+`tests/test_log_rotation.py` 自带 `hermes_constants` stub，不依赖 Hermes 运行时；覆盖 rename / copytruncate（mock `PermissionError`）两条路径、竞态缓解重试、未压缩遗留归档清理与共享预算、env 改名（新名生效 / 旧名不生效）、`status()` 双钩子防刷屏与 `log_capture` 字段。

--- a/hermes-plugin/process_manager.py
+++ b/hermes-plugin/process_manager.py
@@ -11,6 +11,7 @@ descriptors open, so the parent agent loop can't block on it.
 
 from __future__ import annotations
 
+import gzip
 import json
 import os
 import shutil
@@ -32,6 +33,14 @@ from hermes_constants import get_hermes_home
 
 MONITOR_SCRIPT = "start-monitor.js"
 HEALTH_URL = "http://127.0.0.1:8799/health"
+
+# stdout capture file (monitor.log) grows unbounded without rotation (3.7MB
+# observed in the wild). Threshold/keep align with core/logger.js defaults
+# (maxSize 10MB / maxFiles 5); archive naming matches logger.js doRotate():
+# monitor-<UTC YYYYMMDD-HHMMSS>-<pid>.log.gz. Threshold overridable via env
+# VRC_MONITOR_LOG_MAX_SIZE (bytes).
+MAX_LOG_SIZE = 10 * 1024 * 1024
+MAX_ARCHIVES = 5
 
 
 def _config_path() -> Path:
@@ -79,6 +88,133 @@ def _state_file() -> Path:
 
 def _log_file() -> Path:
     return _root() / "monitor.log"
+
+
+# ── log rotation ───────────────────────────────────────────────────────
+
+
+def _max_log_size_from_env() -> int:
+    raw = os.environ.get("VRC_MONITOR_LOG_MAX_SIZE")
+    if raw:
+        try:
+            value = int(raw)
+            if value > 0:
+                return value
+        except ValueError:
+            pass
+    return MAX_LOG_SIZE
+
+
+def _prune_archives(directory: Path, keep: int) -> list:
+    """Delete oldest monitor-*.log.gz beyond *keep* (mtime order)."""
+    archives = sorted(
+        directory.glob("monitor-*.log.gz"),
+        key=lambda f: f.stat().st_mtime,
+    )
+    removed = []
+    while len(archives) > keep:
+        oldest = archives.pop(0)
+        oldest.unlink()
+        removed.append(oldest.name)
+    return removed
+
+
+def rotate_log_if_needed(path, max_size=None, keep=None) -> Dict[str, Any]:
+    """Rotate *path* once if it reached the size threshold. Pure function.
+
+    Rotation is checked at process start only (low-frequency event, no
+    runtime watcher). Never raises — failures are reported via the return
+    dict so the caller can degrade to plain append:
+
+      {"ok": True,  "rotated": False, "reason": "missing"|"below_threshold",
+       "size": int, "threshold": int}
+      {"ok": True,  "rotated": True,  "archive": "<name>.gz", "size": int,
+       "kept": int, "removed": [<names>]}
+      {"ok": False, "rotated": False, "error": "<reason>"}
+
+    After a successful rotation the active file is recreated empty, ready
+    for the caller's append-mode open.
+    """
+    p = Path(path)
+    limit = max_size if max_size is not None else _max_log_size_from_env()
+    keep_n = keep if keep is not None else MAX_ARCHIVES
+    try:
+        if not p.is_file():
+            return {
+                "ok": True,
+                "rotated": False,
+                "reason": "missing",
+                "size": 0,
+                "threshold": limit,
+            }
+        size = p.stat().st_size
+        if size < limit:
+            return {
+                "ok": True,
+                "rotated": False,
+                "reason": "below_threshold",
+                "size": size,
+                "threshold": limit,
+            }
+        # UTC YYYYMMDD-HHMMSS + pid, same naming as core/logger.js doRotate()
+        ts = time.strftime("%Y%m%d-%H%M%S", time.gmtime())
+        rotated = p.with_name(f"monitor-{ts}-{os.getpid()}.log")
+        p.rename(rotated)
+        gz_path = Path(str(rotated) + ".gz")
+        with open(rotated, "rb") as f_in, gzip.open(gz_path, "wb") as f_out:
+            shutil.copyfileobj(f_in, f_out)
+        rotated.unlink()
+        try:
+            removed = _prune_archives(p.parent, keep_n)
+        except Exception:
+            # 归档清理失败（占用/权限）不影响本次轮转结果，与 core/logger.js
+            # cleanupOldLogs() 同策略：清理是尽力而为，不降级、不阻断、不误报轮转失败。
+            removed = []
+        p.touch()  # recreate the active file so append-mode open can proceed
+        return {
+            "ok": True,
+            "rotated": True,
+            "archive": gz_path.name,
+            "size": size,
+            "kept": keep_n,
+            "removed": removed,
+        }
+    except Exception as e:
+        return {"ok": False, "rotated": False, "error": str(e)}
+
+
+def _rotate_log_with_notice(log_path: Path) -> None:
+    """Pre-open rotation check with one log line per branch.
+
+    The line goes into the (new) active monitor.log. Any exception —
+    including failure to write the notice itself — is swallowed: rotation
+    problems must never block startup, degrade to plain append.
+    """
+    try:
+        result = rotate_log_if_needed(log_path)
+        if result.get("ok") is False:
+            line = f"[plugin] 日志轮转失败（不阻断启动，继续追加）：{result.get('error')}"
+        elif result.get("rotated"):
+            size_mb = result.get("size", 0) / (1024 * 1024)
+            line = (
+                f"[plugin] 日志轮转: monitor.log ({size_mb:.1f}MB) → "
+                f"{result.get('archive')}（保留 {result.get('kept')} 个归档）"
+            )
+        else:
+            size_mb = result.get("size", 0) / (1024 * 1024)
+            limit_mb = result.get("threshold", MAX_LOG_SIZE) / (1024 * 1024)
+            line = f"[plugin] 日志轮转跳过（未达阈值 {limit_mb:.1f}MB，当前 {size_mb:.1f}MB）"
+    except Exception as e:
+        line = f"[plugin] 日志轮转失败（不阻断启动，继续追加）：{e}"
+    try:
+        with open(str(log_path), "ab", buffering=0) as fh:
+            fh.write(
+                f"[{time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())}] {line}\n".encode(
+                    "utf-8"
+                )
+            )
+    except Exception:
+        pass
 
 
 # ── helpers ────────────────────────────────────────────────────────────
@@ -388,6 +524,9 @@ def start() -> Dict[str, Any]:
         }
 
     log_path = _log_file()
+    # Rotation check BEFORE opening the log — process start is low-frequency,
+    # so a one-shot check suffices (no runtime watcher). Never blocks startup.
+    _rotate_log_with_notice(log_path)
     try:
         log_fh = open(str(log_path), "ab", buffering=0)
     except Exception as e:

--- a/hermes-plugin/process_manager.py
+++ b/hermes-plugin/process_manager.py
@@ -38,7 +38,9 @@ HEALTH_URL = "http://127.0.0.1:8799/health"
 # observed in the wild). Threshold/keep align with core/logger.js defaults
 # (maxSize 10MB / maxFiles 5); archive naming matches logger.js doRotate():
 # monitor-<UTC YYYYMMDD-HHMMSS>-<pid>.log.gz. Threshold overridable via env
-# VRC_MONITOR_LOG_MAX_SIZE (bytes).
+# VRC_MONITOR_CAPTURE_LOG_MAX_SIZE (bytes) — 只管本插件捕获的
+# $HERMES_HOME/workspace/vrc-monitor/monitor.log，与 logger 模块结构化日志的
+# VRC_MONITOR_LOGGER_MAX_SIZE 不同名不同义，勿混用（PR #189 审查 ⚠️2 改名）。
 MAX_LOG_SIZE = 10 * 1024 * 1024
 MAX_ARCHIVES = 5
 
@@ -94,7 +96,12 @@ def _log_file() -> Path:
 
 
 def _max_log_size_from_env() -> int:
-    raw = os.environ.get("VRC_MONITOR_LOG_MAX_SIZE")
+    """VRC_MONITOR_CAPTURE_LOG_MAX_SIZE 覆盖捕获文件轮转阈值（字节）。
+
+    只认新名：旧名 VRC_MONITOR_LOG_MAX_SIZE 是 PR #189 审查前的未发布命名
+    （从未登记进文档），直接废弃不兼容——PR 未合并，无兼容负担。
+    """
+    raw = os.environ.get("VRC_MONITOR_CAPTURE_LOG_MAX_SIZE")
     if raw:
         try:
             value = int(raw)
@@ -106,34 +113,86 @@ def _max_log_size_from_env() -> int:
 
 
 def _prune_archives(directory: Path, keep: int) -> list:
-    """Delete oldest monitor-*.log.gz beyond *keep* (mtime order)."""
-    archives = sorted(
-        directory.glob("monitor-*.log.gz"),
-        key=lambda f: f.stat().st_mtime,
+    """Delete oldest archives beyond *keep* (mtime order, shared budget).
+
+    Matches both ``monitor-*.log.gz`` and uncompressed ``monitor-*.log`` —
+    gzip 失败会遗留未压缩的 monitor-<ts>-<pid>.log，只 glob .gz 会让它永久
+    残留（PR #189 审查 💡1）。两类共享同一个 keep 预算（总数口径），避免
+    各留 N 份。active 文件 monitor.log 不含 "monitor-<ts>-" 前缀，两个
+    glob 都匹配不到它，永远不会被误删。
+    """
+    candidates = list(directory.glob("monitor-*.log.gz")) + list(
+        directory.glob("monitor-*.log")
     )
+    candidates.sort(key=lambda f: f.stat().st_mtime)
     removed = []
-    while len(archives) > keep:
-        oldest = archives.pop(0)
+    while len(candidates) > keep:
+        oldest = candidates.pop(0)
         oldest.unlink()
         removed.append(oldest.name)
     return removed
 
 
+def _copytruncate_rotate(p: Path, keep_n: int, size: int) -> Dict[str, Any]:
+    """rename 被占用时的运行中轮转兜底：copy → gzip 归档 → truncate(0)。
+
+    竞态（微秒级，与 Unix logrotate copytruncate 同性质）：拷贝与清空之间
+    子进程新写入的行会随 truncate 一起消失。缓解：最多 3 次「stat 得 S1 →
+    读内容 → 再 stat 得 S2」，仅当 S2 == S1（期间无新写入）才执行归档与
+    truncate；3 次都稳定不下来说明子进程在持续高频写入，此时仍用最后一次
+    读到的快照执行（否则文件无限增长、轮转失去意义），最多丢失最后一次读
+    与 truncate 之间的窗口行。归档命名与 rename 路径一致（对齐
+    core/logger.js doRotate()）。
+    """
+    ts = time.strftime("%Y%m%d-%H%M%S", time.gmtime())
+    gz_path = p.with_name(f"monitor-{ts}-{os.getpid()}.log.gz")
+    data = b""
+    for _ in range(3):
+        s1 = p.stat().st_size
+        with open(p, "rb") as f_in:
+            data = f_in.read()
+        s2 = p.stat().st_size
+        if s2 == s1:
+            break
+    # 先写归档、后 truncate：gzip 失败时 active 文件保持原样，零损失。
+    with gzip.open(gz_path, "wb") as f_out:
+        f_out.write(data)
+    with open(p, "r+b") as f:
+        f.truncate(0)
+    try:
+        removed = _prune_archives(p.parent, keep_n)
+    except Exception:
+        # 归档清理失败不影响本次轮转结果（与 rename 路径同策略）。
+        removed = []
+    return {
+        "ok": True,
+        "rotated": True,
+        "archive": gz_path.name,
+        "size": size,
+        "kept": keep_n,
+        "removed": removed,
+        "method": "copytruncate",
+    }
+
+
 def rotate_log_if_needed(path, max_size=None, keep=None) -> Dict[str, Any]:
     """Rotate *path* once if it reached the size threshold. Pure function.
 
-    Rotation is checked at process start only (low-frequency event, no
-    runtime watcher). Never raises — failures are reported via the return
-    dict so the caller can degrade to plain append:
+    Checked at process start AND on every ``status()`` call (long-running
+    service without restart would otherwise never cross the threshold again).
+    Rotation tries ``rename`` first (atomic, lossless) and falls back to
+    ``copytruncate`` when the file is held open by the child (Windows:
+    rename fails with WinError 32). Never raises — failures are reported via
+    the return dict so the caller can degrade to plain append:
 
       {"ok": True,  "rotated": False, "reason": "missing"|"below_threshold",
        "size": int, "threshold": int}
       {"ok": True,  "rotated": True,  "archive": "<name>.gz", "size": int,
-       "kept": int, "removed": [<names>]}
+       "kept": int, "removed": [<names>], "method": "rename"|"copytruncate"}
       {"ok": False, "rotated": False, "error": "<reason>"}
 
-    After a successful rotation the active file is recreated empty, ready
-    for the caller's append-mode open.
+    After a successful rotation the active file is empty (rename: recreated;
+    copytruncate: truncated in place), ready for continued append-mode writes.
     """
     p = Path(path)
     limit = max_size if max_size is not None else _max_log_size_from_env()
@@ -159,7 +218,13 @@ def rotate_log_if_needed(path, max_size=None, keep=None) -> Dict[str, Any]:
         # UTC YYYYMMDD-HHMMSS + pid, same naming as core/logger.js doRotate()
         ts = time.strftime("%Y%m%d-%H%M%S", time.gmtime())
         rotated = p.with_name(f"monitor-{ts}-{os.getpid()}.log")
-        p.rename(rotated)
+        try:
+            p.rename(rotated)
+        except OSError:
+            # Windows 下子进程持有 stdout 句柄时运行中 rename 必失败
+            # （WinError 32「另一个程序正在使用此文件」，已实测）；启动时
+            # （无句柄）才会走到上面这条 rename 原子路径。回退 copytruncate。
+            return _copytruncate_rotate(p, keep_n, size)
         gz_path = Path(str(rotated) + ".gz")
         with open(rotated, "rb") as f_in, gzip.open(gz_path, "wb") as f_out:
             shutil.copyfileobj(f_in, f_out)
@@ -178,34 +243,51 @@ def rotate_log_if_needed(path, max_size=None, keep=None) -> Dict[str, Any]:
             "size": size,
             "kept": keep_n,
             "removed": removed,
+            "method": "rename",
         }
     except Exception as e:
         return {"ok": False, "rotated": False, "error": str(e)}
 
 
-def _rotate_log_with_notice(log_path: Path) -> None:
-    """Pre-open rotation check with one log line per branch.
+def _rotate_log_with_notice(
+    log_path: Path, write_skip: bool = True
+) -> Dict[str, Any]:
+    """One rotation check, one log line per non-skip branch (into the active
+    capture file), result dict always returned.
 
-    The line goes into the (new) active monitor.log. Any exception —
-    including failure to write the notice itself — is swallowed: rotation
-    problems must never block startup, degrade to plain append.
+    ``write_skip=True``（start() 钩子）：低频事件，允许写「跳过（未达阈值）」
+    行。``write_skip=False``（status() 钩子）：vrc_status 是 Agent 高频调用，
+    若每次都写一行「跳过」，捕获文件会变成新的刷屏源——该分支静默，结果改由
+    status() 返回的 ``log_capture`` 字段可见。轮转成功 / 失败两个分支在两个
+    钩子里都各写一行（禁静默降级）。任何异常——包括写 notice 行本身失败——
+    都被吞掉：轮转问题必须永不阻断启动或状态查询，降级为纯追加。
     """
     try:
         result = rotate_log_if_needed(log_path)
-        if result.get("ok") is False:
-            line = f"[plugin] 日志轮转失败（不阻断启动，继续追加）：{result.get('error')}"
-        elif result.get("rotated"):
-            size_mb = result.get("size", 0) / (1024 * 1024)
+    except Exception as e:
+        result = {"ok": False, "rotated": False, "error": str(e)}
+    if result.get("ok") is False:
+        line = f"[plugin] 日志轮转失败（不阻断启动/不影响本次状态查询，继续追加）：{result.get('error')}"
+    elif result.get("rotated"):
+        size_mb = result.get("size", 0) / (1024 * 1024)
+        method = result.get("method", "rename")
+        if method == "copytruncate":
             line = (
                 f"[plugin] 日志轮转: monitor.log ({size_mb:.1f}MB) → "
-                f"{result.get('archive')}（保留 {result.get('kept')} 个归档）"
+                f"{result.get('archive')}（方式 copytruncate，运行中无法 rename，"
+                f"保留 {result.get('kept')} 个归档）"
             )
         else:
-            size_mb = result.get("size", 0) / (1024 * 1024)
-            limit_mb = result.get("threshold", MAX_LOG_SIZE) / (1024 * 1024)
-            line = f"[plugin] 日志轮转跳过（未达阈值 {limit_mb:.1f}MB，当前 {size_mb:.1f}MB）"
-    except Exception as e:
-        line = f"[plugin] 日志轮转失败（不阻断启动，继续追加）：{e}"
+            line = (
+                f"[plugin] 日志轮转: monitor.log ({size_mb:.1f}MB) → "
+                f"{result.get('archive')}（方式 rename，保留 {result.get('kept')} 个归档）"
+            )
+    elif write_skip:
+        size_mb = result.get("size", 0) / (1024 * 1024)
+        limit_mb = result.get("threshold", MAX_LOG_SIZE) / (1024 * 1024)
+        line = f"[plugin] 日志轮转跳过（未达阈值 {limit_mb:.1f}MB，当前 {size_mb:.1f}MB）"
+    else:
+        return result
     try:
         with open(str(log_path), "ab", buffering=0) as fh:
             fh.write(
@@ -215,6 +297,7 @@ def _rotate_log_with_notice(log_path: Path) -> None:
             )
     except Exception:
         pass
+    return result
 
 
 # ── helpers ────────────────────────────────────────────────────────────
@@ -396,7 +479,7 @@ def _find_monitor_pid() -> Optional[int]:
 # ── public API ─────────────────────────────────────────────────────────
 
 
-def status() -> Dict[str, Any]:
+def status(check_log_rotation: bool = True) -> Dict[str, Any]:
     """Return the current process state and health.
 
     Returns a dict::
@@ -409,7 +492,19 @@ def status() -> Dict[str, Any]:
             "started_at": float|None,
             "log_file": str|None,
             "inferred": true|false,  # running detected via health probe, no known pid
+            "log_capture": {
+                "path": str, "size": int, "threshold": int,
+                "rotated": bool, "method": "rename"|"copytruncate"|None,
+                "removed": [...], "error": str|None
+            },
         }
+
+    ``log_capture`` 是 PR #189 审查后新增的字段（只增不改，既有字段语义
+    不动）：每次 status() 顺路做一次捕获文件轮转检查（常驻服务数周不重启
+    时这是唯一的阈值检查时机）。「跳过（未达阈值）」分支不写日志行（防
+    高频调用刷屏），结果经本字段可见；轮转成功/失败各写一行进 active
+    文件。``check_log_rotation=False`` 仅供 start() 内部使用（start() 有
+    自己的显式检查，避免同一进程启动时双检双行）。
 
     All exceptions are caught — this function never raises.
     """
@@ -458,6 +553,38 @@ def status() -> Dict[str, Any]:
             inferred = True
             pid = None
 
+    # 运行中轮转检查（PR #189 审查 ⚠️1）：常驻服务数周不重启时仅靠 start()
+    # 的一次性检查，阈值永远不再被检查、捕获文件无界增长。vrc_status 是
+    # Agent 高频调用，这里顺路做一次检查（内部只读一次 stat，不引入额外
+    # I/O 抖动）。「跳过」分支不写日志行（防刷屏），结果经 log_capture
+    # 字段返回；轮转成功/失败各写一行（禁静默降级）。轮转异常绝不污染
+    # status 主流程。
+    capture_path = Path(log_file) if log_file else _log_file()
+    log_capture: Dict[str, Any] = {
+        "path": str(capture_path),
+        "size": 0,
+        "threshold": _max_log_size_from_env(),
+        "rotated": False,
+        "method": None,
+        "removed": [],
+        "error": None,
+    }
+    if check_log_rotation:
+        try:
+            result = _rotate_log_with_notice(capture_path, write_skip=False)
+            log_capture = {
+                "path": str(capture_path),
+                "size": result.get("size", 0),
+                "threshold": result.get("threshold", log_capture["threshold"]),
+                "rotated": bool(result.get("rotated")),
+                "method": result.get("method"),
+                "removed": result.get("removed", []),
+                "error": result.get("error") if result.get("ok") is False else None,
+            }
+        except Exception as e:
+            # _rotate_log_with_notice 自身已吞异常，此处是最后的保险。
+            log_capture["error"] = str(e)
+
     return {
         "ok": True,
         "running": alive or inferred,
@@ -466,6 +593,7 @@ def status() -> Dict[str, Any]:
         "started_at": started_at,
         "log_file": log_file,
         "inferred": inferred,
+        "log_capture": log_capture,
         "resolved": {
             "monitor_dir": _resolve_monitor_dir(),
             "node_exe": _resolve_node_exe(),
@@ -480,7 +608,9 @@ def start() -> Dict[str, Any]:
     All exceptions are caught — this function never raises.
     """
     try:
-        current = status()
+        # check_log_rotation=False：start() 下方有自己的一次性显式检查
+        # （open 日志之前），这里再查会双检双行（轮转成功行 + 跳过行）。
+        current = status(check_log_rotation=False)
         if current.get("running"):
             # Already running (pid alive or health probe) — refresh the
             # state record so later calls can find it; when inferred there
@@ -524,8 +654,10 @@ def start() -> Dict[str, Any]:
         }
 
     log_path = _log_file()
-    # Rotation check BEFORE opening the log — process start is low-frequency,
-    # so a one-shot check suffices (no runtime watcher). Never blocks startup.
+    # Rotation check BEFORE opening the log. 双钩子之一（start()，低频）：
+    # 允许写「跳过」行；另一处是 status()（高频，跳过分支静默、经
+    # log_capture 字段可见）——常驻服务不重启时靠 status() 触发阈值检查。
+    # Never blocks startup.
     _rotate_log_with_notice(log_path)
     try:
         log_fh = open(str(log_path), "ab", buffering=0)

--- a/hermes-plugin/tests/test_log_rotation.py
+++ b/hermes-plugin/tests/test_log_rotation.py
@@ -1,12 +1,19 @@
-"""stdlib unittest coverage for hermes-plugin log rotation (delivery C).
+"""stdlib unittest coverage for hermes-plugin log rotation (delivery C, round 2).
 
 Covers ``process_manager.rotate_log_if_needed``:
   * below threshold → file untouched, no rotation
   * at/above threshold → rotation, .log.gz created (content preserved),
-    active file recreated empty
-  * prune: archives beyond ``keep`` deleted oldest-first (mtime order)
+    active file empty; ``method == "rename"``
+  * rename 被占用（Windows WinError 32 等）→ 回退 copytruncate：
+    .log.gz 内容与原文一致、active 被 truncate 为 0、``method == "copytruncate"``
+  * copytruncate 竞态缓解：S2 != S1（期间有新写入）时重读，稳定后才截断
+  * prune: .gz 与未压缩遗留 .log 共享 keep 预算（总数口径），按 mtime 删最旧；
+    active monitor.log 不被 glob 命中、绝不被误删
   * failures (locked file etc.) never raise, reported via return dict
-  * env override ``VRC_MONITOR_LOG_MAX_SIZE``
+  * env override ``VRC_MONITOR_CAPTURE_LOG_MAX_SIZE``；旧名
+    ``VRC_MONITOR_LOG_MAX_SIZE`` 不再生效
+  * status() 钩子：跳过分支静默（连续两次调用不产生「日志轮转跳过」行）且
+    返回 ``log_capture`` 字段；轮转成功/失败各写一行
 
 Run from the repo root:
   python -m unittest discover -s hermes-plugin/tests -v
@@ -15,6 +22,7 @@ Self-contained: ``hermes_constants`` (Hermes runtime dep) is stubbed before
 import so the tests do not require a Hermes installation.
 """
 
+import contextlib
 import gzip
 import os
 import re
@@ -69,6 +77,7 @@ class RotateLogIfNeededTest(unittest.TestCase):
         res = process_manager.rotate_log_if_needed(self.log, max_size=10 * 1024)
         self.assertTrue(res["ok"])
         self.assertTrue(res["rotated"])
+        self.assertEqual(res["method"], "rename", "无占用句柄时正常路径必须走 rename")
         archives = list(self.dir.glob("monitor-*.log.gz"))
         self.assertEqual(len(archives), 1)
         self.assertRegex(
@@ -79,6 +88,65 @@ class RotateLogIfNeededTest(unittest.TestCase):
             self.assertEqual(f.read(), payload, "gz content must equal original")
         self.assertEqual(self.log.stat().st_size, 0, "active file must be recreated empty")
         self.assertEqual(res["archive"], archives[0].name)
+
+    def test_copytruncate_fallback_on_rename_permission_error(self):
+        """Windows 运行中 rename 必失败（WinError 32）→ copytruncate 兜底。
+
+        mock Path.rename 抛 PermissionError（等价实测的「另一个程序正在使用
+        此文件」），断言：走 copytruncate、归档 .gz 内容与原文一致、active
+        文件被清空为 0 字节、返回 method == "copytruncate"。
+        """
+        payload = b"z" * (10 * 1024)
+        self.log.write_bytes(payload)
+        with mock.patch.object(Path, "rename", side_effect=PermissionError("file in use")):
+            res = process_manager.rotate_log_if_needed(self.log, max_size=10 * 1024)
+        self.assertTrue(res["ok"])
+        self.assertTrue(res["rotated"])
+        self.assertEqual(res["method"], "copytruncate", "rename 被占用必须回退 copytruncate")
+        archives = list(self.dir.glob("monitor-*.log.gz"))
+        self.assertEqual(len(archives), 1)
+        with gzip.open(archives[0], "rb") as f:
+            self.assertEqual(f.read(), payload, "copytruncate 归档内容必须与原文一致")
+        self.assertEqual(self.log.stat().st_size, 0, "active 文件必须被 truncate 为 0 字节")
+        self.assertEqual(res["archive"], archives[0].name)
+
+    def test_copytruncate_retries_until_stable_size(self):
+        """竞态缓解：S2 != S1（拷贝期间有新写入）时重读，稳定后才截断。
+
+        前两次读（S1=10240→S2=10250、S1=10250→S2=10260）模拟期间有新写入，
+        第三次稳定（S1==S2==10260）才执行归档 + truncate——共 7 次 stat。
+        """
+        payload = b"x" * (10 * 1024)
+        self.log.write_bytes(payload)
+        real_stat = Path.stat
+        active_log = self.log
+        calls = {"n": 0}
+        sizes = {1: 10240, 2: 10240, 3: 10250, 4: 10250, 5: 10260, 6: 10260, 7: 10260}
+
+        def fake_stat(inst):
+            real = real_stat(inst)
+            if inst == active_log:
+                calls["n"] += 1
+                st = mock.Mock()
+                st.st_size = sizes.get(calls["n"], 10260)
+                st.st_mode = real.st_mode
+                return st
+            return real
+
+        # is_file 一并 mock：pathlib 3.13+ 的 is_file() 内部也调 self.stat()，
+        # 钉死后 stat 调用序列在各 Python 版本下确定（call1=阈值检查，call2-7=循环）。
+        # stat 用 autospec=True：patch.object 默认不绑定实例参数（fake 收不到 self）。
+        with mock.patch.object(Path, "is_file", return_value=True), \
+                mock.patch.object(Path, "rename", side_effect=PermissionError("in use")), \
+                mock.patch.object(Path, "stat", autospec=True, side_effect=fake_stat):
+            res = process_manager.rotate_log_if_needed(self.log, max_size=10 * 1024)
+        self.assertEqual(calls["n"], 7, "前两次不稳定（S2>S1）应重读，第三次稳定才截断")
+        self.assertEqual(res["method"], "copytruncate")
+        archives = list(self.dir.glob("monitor-*.log.gz"))
+        self.assertEqual(len(archives), 1)
+        with gzip.open(archives[0], "rb") as f:
+            self.assertEqual(f.read(), payload, "归档必须是最新一次读到的稳定快照")
+        self.assertEqual(self.log.stat().st_size, 0)
 
     def test_prune_deletes_oldest_beyond_keep(self):
         for i in range(5):
@@ -93,6 +161,30 @@ class RotateLogIfNeededTest(unittest.TestCase):
         self.assertEqual(len(remaining), 5, "must keep exactly 5 archives")
         self.assertNotIn("monitor-20260100-000000-100.log.gz", remaining)
 
+    def test_prune_covers_uncompressed_leftovers_with_shared_budget(self):
+        """gzip 失败遗留的未压缩 monitor-*.log 也纳入清理预算（两类合计）。"""
+        self.make_archive("monitor-20260101-000000-101.log.gz", age_days=5)
+        self.make_archive("monitor-20260102-000000-102.log.gz", age_days=3)
+        self.make_archive("monitor-20260103-000000-201.log", age_days=4)
+        self.make_archive("monitor-20260104-000000-202.log", age_days=2)
+        self.make_archive("monitor-20260105-000000-203.log", age_days=1)
+        self.write_active(10 * 1024)
+        res = process_manager.rotate_log_if_needed(self.log, max_size=10 * 1024, keep=3)
+        self.assertTrue(res["ok"])
+        self.assertTrue(res["rotated"])
+        gz_left = sorted(p.name for p in self.dir.glob("monitor-*.log.gz"))
+        plain_left = sorted(p.name for p in self.dir.glob("monitor-*.log"))
+        self.assertEqual(
+            len(gz_left) + len(plain_left), 3,
+            f"两类归档共享 keep 预算（总数口径），合计应恰好 3 份: gz={gz_left} plain={plain_left}",
+        )
+        # 最旧的 .gz（age 5）与最旧的未压缩件（age 4）必须被删除——未压缩件
+        # 只 glob .gz 的话会永久残留
+        self.assertIn("monitor-20260101-000000-101.log.gz", res["removed"])
+        self.assertIn("monitor-20260103-000000-201.log", res["removed"])
+        # active 文件 monitor.log 无 "monitor-<ts>-" 前缀，两个 glob 都不命中，绝不能被误删
+        self.assertTrue(self.log.exists(), "active monitor.log 绝不能被误删")
+
     def test_failure_returns_error_and_never_raises(self):
         self.write_active(10 * 1024)
         with mock.patch.object(Path, "stat", side_effect=PermissionError("file locked")):
@@ -103,16 +195,37 @@ class RotateLogIfNeededTest(unittest.TestCase):
 
     def test_env_override_threshold(self):
         self.write_active(32)
-        old = os.environ.get("VRC_MONITOR_LOG_MAX_SIZE")
-        os.environ["VRC_MONITOR_LOG_MAX_SIZE"] = "16"
+        old = os.environ.get("VRC_MONITOR_CAPTURE_LOG_MAX_SIZE")
+        os.environ["VRC_MONITOR_CAPTURE_LOG_MAX_SIZE"] = "16"
         try:
             res = process_manager.rotate_log_if_needed(self.log)
         finally:
             if old is None:
+                os.environ.pop("VRC_MONITOR_CAPTURE_LOG_MAX_SIZE", None)
+            else:
+                os.environ["VRC_MONITOR_CAPTURE_LOG_MAX_SIZE"] = old
+        self.assertTrue(res["rotated"], "新名 env 阈值 16B 必须能轮转 32B 文件")
+
+    def test_old_env_name_no_longer_takes_effect(self):
+        """R2 干净改名：旧名 VRC_MONITOR_LOG_MAX_SIZE 不再识别（PR 未合并，无兼容负担）。"""
+        self.write_active(32)
+        old_new = os.environ.get("VRC_MONITOR_CAPTURE_LOG_MAX_SIZE")
+        old_old = os.environ.get("VRC_MONITOR_LOG_MAX_SIZE")
+        os.environ.pop("VRC_MONITOR_CAPTURE_LOG_MAX_SIZE", None)
+        os.environ["VRC_MONITOR_LOG_MAX_SIZE"] = "16"
+        try:
+            res = process_manager.rotate_log_if_needed(self.log)
+        finally:
+            if old_new is None:
+                os.environ.pop("VRC_MONITOR_CAPTURE_LOG_MAX_SIZE", None)
+            else:
+                os.environ["VRC_MONITOR_CAPTURE_LOG_MAX_SIZE"] = old_new
+            if old_old is None:
                 os.environ.pop("VRC_MONITOR_LOG_MAX_SIZE", None)
             else:
-                os.environ["VRC_MONITOR_LOG_MAX_SIZE"] = old
-        self.assertTrue(res["rotated"], "env threshold 16B must rotate a 32B file")
+                os.environ["VRC_MONITOR_LOG_MAX_SIZE"] = old_old
+        self.assertFalse(res["rotated"], "旧名 VRC_MONITOR_LOG_MAX_SIZE 必须不再生效")
+        self.assertEqual(res["reason"], "below_threshold")
 
 
 class RotateNoticeTest(unittest.TestCase):
@@ -126,7 +239,8 @@ class RotateNoticeTest(unittest.TestCase):
 
     def test_skip_branch_writes_notice_into_active_log(self):
         self.log.write_bytes(b"abc")
-        process_manager._rotate_log_with_notice(self.log)
+        result = process_manager._rotate_log_with_notice(self.log)
+        self.assertEqual(result.get("reason"), "below_threshold")
         content = self.log.read_text(encoding="utf-8")
         self.assertIn("[plugin] 日志轮转跳过（未达阈值", content)
         self.assertIn("abc", content, "original content must be preserved (append)")
@@ -138,7 +252,82 @@ class RotateNoticeTest(unittest.TestCase):
         content = self.log.read_text(encoding="utf-8")
         self.assertIn("[plugin] 日志轮转: monitor.log", content)
         self.assertIn("→ monitor-", content)
+        self.assertIn("方式 rename", content, "无占用句柄时 notice 应标注方式 rename")
         self.assertEqual(len(list(self.dir.glob("monitor-*.log.gz"))), 1)
+
+
+class StatusLogCaptureTest(unittest.TestCase):
+    """status() 新增的运行中轮转钩子与 log_capture 字段（PR #189 ⚠️1）。"""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.dir = Path(self.tmp.name)
+        self.log = self.dir / "monitor.log"
+
+    def status_patches(self):
+        """让 status() 脱离 Hermes 运行时/网络可跑通。"""
+        stack = contextlib.ExitStack()
+        stack.enter_context(mock.patch.object(process_manager, "_read_state", return_value=None))
+        stack.enter_context(mock.patch.object(
+            process_manager, "_health_check", return_value={"error": "probe down"}))
+        stack.enter_context(mock.patch.object(process_manager, "_log_file", return_value=self.log))
+        stack.enter_context(mock.patch.object(process_manager, "_resolve_monitor_dir", return_value=None))
+        stack.enter_context(mock.patch.object(process_manager, "_resolve_node_exe", return_value=None))
+        stack.enter_context(mock.patch.object(
+            process_manager, "_max_log_size_from_env", return_value=10 * 1024))
+        return stack
+
+    def test_status_below_threshold_silent_twice_and_reports_log_capture(self):
+        """连续两次 status()：active 文件不得出现「日志轮转跳过」行（防高频刷屏），
+        且返回值含 log_capture 字段。"""
+        self.log.write_bytes(b"abc")
+        with self.status_patches():
+            res1 = process_manager.status()
+            res2 = process_manager.status()
+        content = self.log.read_text(encoding="utf-8")
+        self.assertEqual(content, "abc", "跳过分支必须完全静默，文件内容不得变化")
+        self.assertNotIn("[plugin]", content)
+        for res in (res1, res2):
+            self.assertIn("log_capture", res, "status() 返回值必须含 log_capture 字段")
+            lc = res["log_capture"]
+            self.assertEqual(lc["path"], str(self.log))
+            self.assertEqual(lc["size"], 3)
+            self.assertEqual(lc["threshold"], 10 * 1024)
+            self.assertFalse(lc["rotated"])
+            self.assertIsNone(lc["method"])
+            self.assertEqual(lc["removed"], [])
+            self.assertIsNone(lc["error"])
+
+    def test_status_rotation_writes_one_line_and_reports_rename(self):
+        self.log.write_bytes(b"z" * (10 * 1024))
+        with self.status_patches():
+            res = process_manager.status()
+        content = self.log.read_text(encoding="utf-8")
+        self.assertEqual(content.count("[plugin] 日志轮转:"), 1,
+                         "status() 钩子轮转成功必须恰好写一行（禁静默降级，也不重复）")
+        self.assertIn("方式 rename", content)
+        lc = res["log_capture"]
+        self.assertTrue(lc["rotated"])
+        self.assertEqual(lc["method"], "rename")
+        self.assertIsNone(lc["error"])
+        self.assertEqual(lc["size"], 10 * 1024)
+        self.assertEqual(len(list(self.dir.glob("monitor-*.log.gz"))), 1)
+
+    def test_status_rotation_failure_writes_one_line_and_reports_error(self):
+        self.log.write_bytes(b"z" * (10 * 1024))
+        with self.status_patches(), \
+                mock.patch.object(Path, "stat", side_effect=PermissionError("file locked")):
+            res = process_manager.status()
+        self.assertTrue(res["ok"], "轮转失败绝不影响 status 主流程")
+        content = self.log.read_text(encoding="utf-8")
+        self.assertIn("[plugin] 日志轮转失败（不阻断启动/不影响本次状态查询", content)
+        self.assertEqual(content.count("[plugin] 日志轮转失败"), 1)
+        lc = res["log_capture"]
+        self.assertFalse(lc["rotated"])
+        self.assertIsNone(lc["method"])
+        self.assertIsNotNone(lc["error"])
+        self.assertIn("locked", lc["error"])
 
 
 if __name__ == "__main__":

--- a/hermes-plugin/tests/test_log_rotation.py
+++ b/hermes-plugin/tests/test_log_rotation.py
@@ -1,0 +1,145 @@
+"""stdlib unittest coverage for hermes-plugin log rotation (delivery C).
+
+Covers ``process_manager.rotate_log_if_needed``:
+  * below threshold → file untouched, no rotation
+  * at/above threshold → rotation, .log.gz created (content preserved),
+    active file recreated empty
+  * prune: archives beyond ``keep`` deleted oldest-first (mtime order)
+  * failures (locked file etc.) never raise, reported via return dict
+  * env override ``VRC_MONITOR_LOG_MAX_SIZE``
+
+Run from the repo root:
+  python -m unittest discover -s hermes-plugin/tests -v
+
+Self-contained: ``hermes_constants`` (Hermes runtime dep) is stubbed before
+import so the tests do not require a Hermes installation.
+"""
+
+import gzip
+import os
+import re
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+# Stub the Hermes runtime dependency BEFORE importing process_manager
+# (module-level ``from hermes_constants import get_hermes_home``).
+hermes_constants_stub = types.ModuleType("hermes_constants")
+hermes_constants_stub.get_hermes_home = lambda: tempfile.gettempdir()
+sys.modules["hermes_constants"] = hermes_constants_stub
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+import process_manager  # noqa: E402
+
+
+class RotateLogIfNeededTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.dir = Path(self.tmp.name)
+        self.log = self.dir / "monitor.log"
+
+    def write_active(self, size):
+        self.log.write_bytes(b"x" * size)
+        return size
+
+    def make_archive(self, name, age_days=0):
+        p = self.dir / name
+        p.write_bytes(b"old archive")
+        ts = 1600000000 - age_days * 86400
+        os.utime(p, (ts, ts))
+        return p
+
+    def test_below_threshold_leaves_file_untouched(self):
+        self.write_active(1024)
+        before = self.log.read_bytes()
+        res = process_manager.rotate_log_if_needed(self.log, max_size=10 * 1024)
+        self.assertTrue(res["ok"])
+        self.assertFalse(res["rotated"])
+        self.assertEqual(res["reason"], "below_threshold")
+        self.assertEqual(self.log.read_bytes(), before, "file must be untouched")
+        self.assertEqual(list(self.dir.glob("monitor-*.log.gz")), [], "no archives expected")
+
+    def test_at_threshold_rotates_gzips_and_recreates_active(self):
+        payload = b"y" * (10 * 1024)
+        self.log.write_bytes(payload)
+        res = process_manager.rotate_log_if_needed(self.log, max_size=10 * 1024)
+        self.assertTrue(res["ok"])
+        self.assertTrue(res["rotated"])
+        archives = list(self.dir.glob("monitor-*.log.gz"))
+        self.assertEqual(len(archives), 1)
+        self.assertRegex(
+            archives[0].name, r"^monitor-\d{8}-\d{6}-\d+\.log\.gz$",
+            "name must be monitor-<UTC YYYYMMDD-HHMMSS>-<pid>.log.gz",
+        )
+        with gzip.open(archives[0], "rb") as f:
+            self.assertEqual(f.read(), payload, "gz content must equal original")
+        self.assertEqual(self.log.stat().st_size, 0, "active file must be recreated empty")
+        self.assertEqual(res["archive"], archives[0].name)
+
+    def test_prune_deletes_oldest_beyond_keep(self):
+        for i in range(5):
+            self.make_archive(f"monitor-2026010{i}-000000-{100 + i}.log.gz", age_days=5 - i)
+        self.write_active(10 * 1024)
+        res = process_manager.rotate_log_if_needed(self.log, max_size=10 * 1024, keep=5)
+        self.assertTrue(res["ok"])
+        self.assertTrue(res["rotated"])
+        self.assertIn("monitor-20260100-000000-100.log.gz", res["removed"],
+                      "oldest archive (mtime) must be removed")
+        remaining = sorted(p.name for p in self.dir.glob("monitor-*.log.gz"))
+        self.assertEqual(len(remaining), 5, "must keep exactly 5 archives")
+        self.assertNotIn("monitor-20260100-000000-100.log.gz", remaining)
+
+    def test_failure_returns_error_and_never_raises(self):
+        self.write_active(10 * 1024)
+        with mock.patch.object(Path, "stat", side_effect=PermissionError("file locked")):
+            res = process_manager.rotate_log_if_needed(self.log, max_size=10 * 1024)
+        self.assertFalse(res["ok"])
+        self.assertFalse(res["rotated"])
+        self.assertIn("locked", res["error"])
+
+    def test_env_override_threshold(self):
+        self.write_active(32)
+        old = os.environ.get("VRC_MONITOR_LOG_MAX_SIZE")
+        os.environ["VRC_MONITOR_LOG_MAX_SIZE"] = "16"
+        try:
+            res = process_manager.rotate_log_if_needed(self.log)
+        finally:
+            if old is None:
+                os.environ.pop("VRC_MONITOR_LOG_MAX_SIZE", None)
+            else:
+                os.environ["VRC_MONITOR_LOG_MAX_SIZE"] = old
+        self.assertTrue(res["rotated"], "env threshold 16B must rotate a 32B file")
+
+
+class RotateNoticeTest(unittest.TestCase):
+    """One log line per branch, written into the active monitor.log."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.dir = Path(self.tmp.name)
+        self.log = self.dir / "monitor.log"
+
+    def test_skip_branch_writes_notice_into_active_log(self):
+        self.log.write_bytes(b"abc")
+        process_manager._rotate_log_with_notice(self.log)
+        content = self.log.read_text(encoding="utf-8")
+        self.assertIn("[plugin] 日志轮转跳过（未达阈值", content)
+        self.assertIn("abc", content, "original content must be preserved (append)")
+
+    def test_rotate_branch_writes_notice_into_new_active_log(self):
+        self.log.write_bytes(b"z" * (10 * 1024))
+        with mock.patch.object(process_manager, "_max_log_size_from_env", return_value=10 * 1024):
+            process_manager._rotate_log_with_notice(self.log)
+        content = self.log.read_text(encoding="utf-8")
+        self.assertIn("[plugin] 日志轮转: monitor.log", content)
+        self.assertIn("→ monitor-", content)
+        self.assertEqual(len(list(self.dir.glob("monitor-*.log.gz"))), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "start": "node start-monitor.js",
-    "test": "node --test \"test/**/*.test.mjs\"",
+    "test": "node --test --import ./test/setup-log-isolation.mjs \"test/**/*.test.mjs\"",
     "install-plugins": "node scripts/install-plugin-deps.mjs"
   },
   "dependencies": {

--- a/test/event-pipeline-avatar-log-level.test.mjs
+++ b/test/event-pipeline-avatar-log-level.test.mjs
@@ -1,0 +1,143 @@
+/**
+ * test/event-pipeline-avatar-log-level.test.mjs — 头像变更日志降级回归（交付 A）
+ *
+ * 背景（生产实测）：头像变更是热路径（单好友 5 分钟窗口最多 26 条 ≈ 12 秒一条、2 天 683 条），
+ * 逐条 INFO 占日志 34.5%，信噪比过低 → case 'avatar' 降为 debug（DB 事件流仍完整落库）。
+ * 覆盖：avatar 变更不再走 info、仍走 debug；事件照旧落库（含新旧图 URL）；
+ *       bio/status 变更不受误伤（仍走 info）；级别穿透（debug 落盘 / info 不落盘）。
+ * 自包含：临时 SQLite + stub worldCache，不依赖网络/凭据。
+ *
+ * 说明：event-pipeline 的 logger 是 getLogger('event') 的闭包实例，无法替换导出 logger 方法拦截；
+ * 按 world-kb-backfill.test.mjs:146-152 同款思路（临时替换收集行 + try/finally 还原），
+ * 改在日志写盘出口 console.info/console.debug 处收集。
+ */
+import { test, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { rmSync, readFileSync, existsSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.join(__dirname, '..');
+
+const { initLogger } = await import(pathToFileURL(path.join(REPO, 'core', 'logger.js')).href);
+const { EventPipeline } = await import(pathToFileURL(path.join(REPO, 'core', 'event-pipeline.js')).href);
+const { Storage } = await import(pathToFileURL(path.join(REPO, 'core', 'storage.js')).href);
+
+const USER_ID = 'usr_avlogtest-0000-0000-000000000001';
+const OLD_AVATAR = 'https://api.vrchat.example/avatars/avtr_old/image.png';
+const NEW_AVATAR = 'https://api.vrchat.example/avatars/avtr_new/image.png';
+
+const tmpDb = path.join(__dirname, 'test-avatar-log-level.sqlite3');
+const logRoot = path.join(__dirname, 'avatar-log-level-rundir');
+
+for (const f of [tmpDb, tmpDb + '-wal', tmpDb + '-shm']) { try { rmSync(f, { force: true }); } catch {} }
+rmSync(logRoot, { recursive: true, force: true });
+
+const storage = new Storage();
+await storage.init(tmpDb);
+// 预置好友基线行：avatar/bio/status 有值才能触发 diff（与 _handleUpdate 判据一致）
+storage.upsertFriend({
+  userId: USER_ID,
+  displayName: '头像日志测试好友',
+  avatarImageUrl: OLD_AVATAR,
+  bio: '旧简介',
+  status: 'active',
+  statusDescription: '旧状态',
+  userIcon: 'https://assets.vrchat.example/icons/old.png',
+  pronouns: 'they/them',
+});
+
+const pipeline = new EventPipeline(storage, { get: () => null });
+
+after(() => {
+  for (const f of [tmpDb, tmpDb + '-wal', tmpDb + '-shm']) { try { rmSync(f, { force: true }); } catch {} }
+  rmSync(logRoot, { recursive: true, force: true });
+});
+
+function makeUpdate({ avatar, bio, status, statusDescription }) {
+  return {
+    type: 'friend-update',
+    userId: USER_ID,
+    displayName: '头像日志测试好友',
+    receivedAt: '2026-09-13T09:00:00.000Z',
+    content: {
+      user: {
+        currentAvatarImageUrl: avatar ?? NEW_AVATAR,
+        currentAvatarName: '新模型',
+        currentAvatarThumbnailImageUrl: 'https://api.vrchat.example/avatars/avtr_new/thumb.png',
+        bio: bio ?? '旧简介',
+        status: status ?? 'active',
+        statusDescription: statusDescription ?? '旧状态',
+        userIcon: 'https://assets.vrchat.example/icons/old.png',
+        pronouns: 'they/them',
+      },
+    },
+  };
+}
+
+// 临时替换 console.info/console.debug 收集日志行（照抄 world-kb-backfill 的 try/finally 还原模式）
+async function captureConsole(fn) {
+  const infoLines = [];
+  const debugLines = [];
+  const origInfo = console.info;
+  const origDebug = console.debug;
+  console.info = (m) => { infoLines.push(String(m)); };
+  console.debug = (m) => { debugLines.push(String(m)); };
+  try { await fn(); } finally { console.info = origInfo; console.debug = origDebug; }
+  return { infoLines, debugLines };
+}
+
+test('avatar 变更：info 收不到、debug 收到，且事件照旧落库（含新旧图 URL）', async () => {
+  initLogger({ dir: path.join(logRoot, 'av-debug'), format: 'text', level: 'debug' });
+  const { infoLines, debugLines } = await captureConsole(
+    () => pipeline.process(makeUpdate({ avatar: NEW_AVATAR }))
+  );
+  assert.ok(!infoLines.some((l) => l.includes('头像变更')),
+    `info 不得收到头像变更行，实际 ${JSON.stringify(infoLines)}`);
+  assert.ok(debugLines.some((l) => l.includes('头像变更')),
+    `debug 应收到头像变更行，实际 ${JSON.stringify(debugLines)}`);
+  // 落库不变：events 表有 type=friend-update + content_json.type=avatar 记录，含新旧图 URL
+  const rows = storage.getFriendProfileChanges(USER_ID, { types: 'avatar' });
+  assert.equal(rows.length, 1, `应恰好 1 条 avatar 变更记录，实际 ${rows.length}`);
+  const content = JSON.parse(rows[0].content_json);
+  assert.equal(content.type, 'avatar');
+  assert.equal(content.avatarImageUrl, NEW_AVATAR, '新图 URL 应落库');
+  assert.equal(content.previousAvatarImageUrl, OLD_AVATAR, '旧图 URL 应落库');
+});
+
+test('防误伤：bio/status 变更仍走 info', async () => {
+  initLogger({ dir: path.join(logRoot, 'av-bio-status'), format: 'text', level: 'info' });
+  const { infoLines, debugLines } = await captureConsole(
+    () => pipeline.process(makeUpdate({ bio: '新简介', status: 'join me', statusDescription: '新状态' }))
+  );
+  assert.ok(infoLines.some((l) => l.includes('bio变更')), `bio 变更应走 info，实际 ${JSON.stringify(infoLines)}`);
+  assert.ok(infoLines.some((l) => l.includes('状态变更')), `status 变更应走 info，实际 ${JSON.stringify(infoLines)}`);
+  assert.ok(!infoLines.some((l) => l.includes('头像变更')), 'avatar 未变不应产生头像变更行');
+  assert.equal(debugLines.length, 0, `info 级别下不应有 debug 行，实际 ${JSON.stringify(debugLines)}`);
+});
+
+test('级别穿透：level=debug 落盘含该行，默认 info 落盘不含', async () => {
+  const dirDebug = path.join(logRoot, 'level-debug');
+  initLogger({ dir: dirDebug, format: 'text', level: 'debug' });
+  await pipeline.process(makeUpdate({ avatar: 'https://api.vrchat.example/avatars/avtr_b2/image.png' }));
+  const debugContent = readFileSync(path.join(dirDebug, 'monitor.log'), 'utf8');
+  assert.ok(debugContent.includes('头像变更'), 'debug 级别下文件应含头像变更行');
+  assert.ok(/DEBUG\s+\[event\].*头像变更/.test(debugContent), `应带 DEBUG [event] 前缀，实际：${debugContent}`);
+
+  const dirInfo = path.join(logRoot, 'level-info');
+  initLogger({ dir: dirInfo, format: 'text', level: 'info' });
+  // 吞掉 console 输出避免污染测试报告；断言只依赖文件
+  const origInfo = console.info;
+  const origDebug = console.debug;
+  console.info = () => {}; console.debug = () => {};
+  try {
+    // 同一文件内混入 bio 变更（info 会写行）证明文件活跃，头像行必须缺席
+    await pipeline.process(makeUpdate({ avatar: 'https://api.vrchat.example/avatars/avtr_b3/image.png' }));
+    await pipeline.process(makeUpdate({ bio: '又换简介' }));
+  } finally { console.info = origInfo; console.debug = origDebug; }
+  assert.ok(existsSync(path.join(dirInfo, 'monitor.log')), 'info 级别应已创建日志文件（bio 变更写行）');
+  const infoContent = readFileSync(path.join(dirInfo, 'monitor.log'), 'utf8');
+  assert.ok(infoContent.includes('bio变更'), `同文件应含 info 级 bio 行，实际：${infoContent}`);
+  assert.ok(!infoContent.includes('头像变更'), `默认 info 级别文件不得含头像变更行，实际：${infoContent}`);
+});

--- a/test/event-pipeline-presence-log-level.test.mjs
+++ b/test/event-pipeline-presence-log-level.test.mjs
@@ -1,0 +1,179 @@
+/**
+ * test/event-pipeline-presence-log-level.test.mjs — 上线/下线/换世界日志降级回归（交付 R4）
+ *
+ * 背景（PR #189 审查 💡2 + 生产实测）：剩余热路径里「换世界」占日志 26.0%、
+ * 「上线+下线」合计 22.3%（此前头像变更 34.5% 已降 debug）——逐条 INFO 信噪比
+ * 过低，三处统一降为 debug。DB 事件流 / SSE / 看板不受影响（events 表照常落库），
+ * VRC_MONITOR_LOGGER_LEVEL=debug 可恢复。
+ * 覆盖：三行 info 不收、debug 收；事件照旧落库；级别穿透（info 落盘不含、
+ * debug 落盘含）；防误伤：bio/status 变更仍走 info。
+ * 自包含：临时 SQLite + stub worldCache，不依赖网络/凭据。
+ *
+ * 说明：event-pipeline 的 logger 是 getLogger('event') 的闭包实例，无法替换导出
+ * logger 方法拦截；按 event-pipeline-avatar-log-level.test.mjs 同款思路（临时
+ * 替换 console.info/console.debug 收集行 + try/finally 还原）。
+ */
+import { test, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { rmSync, readFileSync, existsSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.join(__dirname, '..');
+
+const { initLogger } = await import(pathToFileURL(path.join(REPO, 'core', 'logger.js')).href);
+const { EventPipeline } = await import(pathToFileURL(path.join(REPO, 'core', 'event-pipeline.js')).href);
+const { Storage } = await import(pathToFileURL(path.join(REPO, 'core', 'storage.js')).href);
+
+const USER_ID = 'usr_preslogtest-0000-0000-000000000001';
+const NAME = '在线日志测试好友';
+
+const tmpDb = path.join(__dirname, 'test-presence-log-level.sqlite3');
+const logRoot = path.join(__dirname, 'presence-log-level-rundir');
+
+for (const f of [tmpDb, tmpDb + '-wal', tmpDb + '-shm']) { try { rmSync(f, { force: true }); } catch {} }
+rmSync(logRoot, { recursive: true, force: true });
+
+const storage = new Storage();
+await storage.init(tmpDb);
+// 预置好友基线行（bio/status 有值才能触发 diff，供「防误伤」用例）
+storage.upsertFriend({
+  userId: USER_ID,
+  displayName: NAME,
+  bio: '旧简介',
+  status: 'active',
+  statusDescription: '旧状态',
+});
+
+const pipeline = new EventPipeline(storage, { get: () => null });
+
+after(() => {
+  for (const f of [tmpDb, tmpDb + '-wal', tmpDb + '-shm']) { try { rmSync(f, { force: true }); } catch {} }
+  rmSync(logRoot, { recursive: true, force: true });
+});
+
+const makeOnline = () => ({
+  type: 'friend-online',
+  userId: USER_ID,
+  displayName: NAME,
+  location: 'private',
+  worldId: '',
+  receivedAt: '2026-09-13T09:00:00.000Z',
+  platform: 'standalonewindows',
+});
+
+const makeOffline = () => ({
+  type: 'friend-offline',
+  userId: USER_ID,
+  displayName: NAME,
+  receivedAt: '2026-09-13T09:01:00.000Z',
+});
+
+const makeLocation = (worldId) => ({
+  type: 'friend-location',
+  userId: USER_ID,
+  displayName: NAME,
+  location: `${worldId}:123`,
+  worldId,
+  receivedAt: '2026-09-13T09:02:00.000Z',
+});
+
+const makeUpdate = ({ bio, status, statusDescription }) => ({
+  type: 'friend-update',
+  userId: USER_ID,
+  displayName: NAME,
+  receivedAt: '2026-09-13T09:03:00.000Z',
+  content: {
+    user: {
+      currentAvatarImageUrl: '',
+      bio: bio ?? '旧简介',
+      status: status ?? 'active',
+      statusDescription: statusDescription ?? '旧状态',
+      userIcon: '',
+      pronouns: 'they/them',
+    },
+  },
+});
+
+// 临时替换 console.info/console.debug 收集日志行（同 avatar 测试的 try/finally 还原模式）
+async function captureConsole(fn) {
+  const infoLines = [];
+  const debugLines = [];
+  const origInfo = console.info;
+  const origDebug = console.debug;
+  console.info = (m) => { infoLines.push(String(m)); };
+  console.debug = (m) => { debugLines.push(String(m)); };
+  try { await fn(); } finally { console.info = origInfo; console.debug = origDebug; }
+  return { infoLines, debugLines };
+}
+
+test('上线/下线/换世界：info 收不到、debug 收到，且事件照旧落库', async () => {
+  initLogger({ dir: path.join(logRoot, 'pres-debug'), format: 'text', level: 'debug' });
+  const { infoLines, debugLines } = await captureConsole(async () => {
+    await pipeline.process(makeOnline());
+    await pipeline.process(makeOffline());
+    await pipeline.process(makeLocation('wrld_ptest1'));
+  });
+  assert.ok(!infoLines.some((l) => l.includes('上线')),
+    `info 不得收到上线行，实际 ${JSON.stringify(infoLines)}`);
+  assert.ok(!infoLines.some((l) => l.includes('下线')),
+    `info 不得收到下线行，实际 ${JSON.stringify(infoLines)}`);
+  assert.ok(!infoLines.some((l) => l.includes('换世界')),
+    `info 不得收到换世界行，实际 ${JSON.stringify(infoLines)}`);
+  assert.ok(debugLines.some((l) => l.includes('上线')),
+    `debug 应收到上线行，实际 ${JSON.stringify(debugLines)}`);
+  assert.ok(debugLines.some((l) => l.includes('下线')),
+    `debug 应收到下线行，实际 ${JSON.stringify(debugLines)}`);
+  assert.ok(debugLines.some((l) => l.includes('换世界')),
+    `debug 应收到换世界行，实际 ${JSON.stringify(debugLines)}`);
+  // DB 事件流不受降级影响：三类事件照旧落库
+  const rows = storage.getEventsByUser(USER_ID, { limit: 20 });
+  assert.equal(rows.filter((r) => r.type === 'friend-online').length, 1, 'friend-online 应落库 1 条');
+  assert.equal(rows.filter((r) => r.type === 'friend-offline').length, 1, 'friend-offline 应落库 1 条');
+  assert.equal(rows.filter((r) => r.type === 'friend-location').length, 1, 'friend-location 应落库 1 条');
+});
+
+test('级别穿透：level=debug 落盘含三行，默认 info 落盘不含', async () => {
+  const dirDebug = path.join(logRoot, 'level-debug');
+  initLogger({ dir: dirDebug, format: 'text', level: 'debug' });
+  await pipeline.process(makeOnline());
+  await pipeline.process(makeOffline());
+  await pipeline.process(makeLocation('wrld_ptest2'));
+  const debugContent = readFileSync(path.join(dirDebug, 'monitor.log'), 'utf8');
+  assert.ok(debugContent.includes('上线'), `debug 文件应含上线行，实际：${debugContent}`);
+  assert.ok(debugContent.includes('下线'), `debug 文件应含下线行，实际：${debugContent}`);
+  assert.ok(debugContent.includes('换世界'), `debug 文件应含换世界行，实际：${debugContent}`);
+  assert.ok(/DEBUG\s+\[event\]/.test(debugContent), `应带 DEBUG [event] 前缀，实际：${debugContent}`);
+
+  const dirInfo = path.join(logRoot, 'level-info');
+  initLogger({ dir: dirInfo, format: 'text', level: 'info' });
+  // 吞掉 console 输出避免污染测试报告；断言只依赖文件
+  const origInfo = console.info;
+  const origDebug = console.debug;
+  console.info = () => {};
+  console.debug = () => {};
+  try {
+    await pipeline.process(makeOnline());
+    await pipeline.process(makeOffline());
+    await pipeline.process(makeLocation('wrld_ptest3'));
+    // 同一文件内混入 bio 变更（info 会写行）证明文件活跃，三行必须缺席
+    await pipeline.process(makeUpdate({ bio: '又换简介' }));
+  } finally { console.info = origInfo; console.debug = origDebug; }
+  assert.ok(existsSync(path.join(dirInfo, 'monitor.log')), 'info 级别应已创建日志文件（bio 变更写行）');
+  const infoContent = readFileSync(path.join(dirInfo, 'monitor.log'), 'utf8');
+  assert.ok(infoContent.includes('bio变更'), `同文件应含 info 级 bio 行，实际：${infoContent}`);
+  assert.ok(!infoContent.includes('上线'), `默认 info 级别文件不得含上线行，实际：${infoContent}`);
+  assert.ok(!infoContent.includes('下线'), `默认 info 级别文件不得含下线行，实际：${infoContent}`);
+  assert.ok(!infoContent.includes('换世界'), `默认 info 级别文件不得含换世界行，实际：${infoContent}`);
+});
+
+test('防误伤：bio/status 变更仍走 info（低频且有内容，不在降级范围）', async () => {
+  initLogger({ dir: path.join(logRoot, 'pres-bio-status'), format: 'text', level: 'info' });
+  const { infoLines, debugLines } = await captureConsole(
+    () => pipeline.process(makeUpdate({ bio: '新简介', status: 'join me', statusDescription: '新状态' }))
+  );
+  assert.ok(infoLines.some((l) => l.includes('bio变更')), `bio 变更应走 info，实际 ${JSON.stringify(infoLines)}`);
+  assert.ok(infoLines.some((l) => l.includes('状态变更')), `status 变更应走 info，实际 ${JSON.stringify(infoLines)}`);
+  assert.equal(debugLines.length, 0, `info 级别下不应有 debug 行，实际 ${JSON.stringify(debugLines)}`);
+});

--- a/test/logger.test.mjs
+++ b/test/logger.test.mjs
@@ -8,6 +8,7 @@
 import { test, before, after } from 'node:test';
 import assert from 'node:assert/strict';
 import { rmSync, readdirSync, readFileSync } from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import zlib from 'node:zlib';
 import { fileURLToPath, pathToFileURL } from 'node:url';
@@ -224,8 +225,12 @@ test('脱敏：中文键「授权码」宽松值也替换', () => {
 test('默认目录：无任何 env 时落到仓库根/logs（非 cwd 父目录）', () => {
   const savedD = process.env.VRC_MONITOR_LOGGER_DIR;
   const savedM = process.env.VRC_MONITOR_DIR;
+  const savedCtx = process.env.NODE_TEST_CONTEXT;
   delete process.env.VRC_MONITOR_LOGGER_DIR;
   delete process.env.VRC_MONITOR_DIR;
+  // 本测试进程自带 NODE_TEST_CONTEXT=child-v8（node --test 子进程）——删除它模拟生产进程，
+  // 否则 resolveDir 会按「测试上下文兜底」落到系统临时目录（B1 防御，见下方用例）。
+  delete process.env.NODE_TEST_CONTEXT;
   try {
     const s = initLogger({});
     const expected = path.join(REPO, 'logs');
@@ -234,8 +239,55 @@ test('默认目录：无任何 env 时落到仓库根/logs（非 cwd 父目录�
     // 复位后用隔离目录重建，避免向 <仓库>/logs 写日志
     if (savedD !== undefined) process.env.VRC_MONITOR_LOGGER_DIR = savedD;
     if (savedM !== undefined) process.env.VRC_MONITOR_DIR = savedM;
+    if (savedCtx !== undefined) process.env.NODE_TEST_CONTEXT = savedCtx;
     initLogger({ dir: path.join(dir, 'reset') });
     rmSync(path.join(REPO, 'logs'), { recursive: true, force: true }); // 清掉断言时创建的目录
+  }
+});
+
+// ===== 交付 B1 回归：node --test 上下文未显式设 LOGGER_DIR 时，日志必须落到系统临时目录 =====
+test('B1：NODE_TEST_CONTEXT 下 initLogger({}) 落到系统临时目录（不写继承的 VRC_MONITOR_DIR/logs）', () => {
+  const savedD = process.env.VRC_MONITOR_LOGGER_DIR;
+  const savedM = process.env.VRC_MONITOR_DIR;
+  const savedCtx = process.env.NODE_TEST_CONTEXT;
+  const noticeLines = [];
+  const origInfo = console.info;
+  delete process.env.VRC_MONITOR_LOGGER_DIR;
+  // 模拟继承的生产 VRC_MONITOR_DIR（虚构路径，勿写真实环境路径）与 NODE_TEST_CONTEXT：
+  // 正是「测试子进程继承生产 env」的真实条件
+  process.env.VRC_MONITOR_DIR = 'D:\\somewhere\\production-checkout';
+  process.env.NODE_TEST_CONTEXT = 'child-v8';
+  console.info = (m) => { noticeLines.push(String(m)); };
+  try {
+    const s = initLogger({});
+    const expected = path.join(os.tmpdir(), 'vrc-monitor-test-logs');
+    assert.equal(s.dir, expected, `测试上下文应落到系统临时目录 ${expected}`);
+    assert.ok(!s.dir.includes('production-checkout'), '不得落到继承的 VRC_MONITOR_DIR/logs');
+    assert.ok(noticeLines.some((l) => l.includes('检测到 node --test 上下文')), '必须打一行非静默提示（禁静默降级）');
+    // 隔离目录真实可写（与生产日志目录物理隔离）
+    assert.ok(readdirSync(expected).length >= 0, '临时日志目录应可创建');
+  } finally {
+    console.info = origInfo;
+    if (savedD !== undefined) process.env.VRC_MONITOR_LOGGER_DIR = savedD;
+    if (savedM !== undefined) process.env.VRC_MONITOR_DIR = savedM;
+    if (savedCtx !== undefined) process.env.NODE_TEST_CONTEXT = savedCtx;
+    initLogger({ dir: path.join(dir, 'reset-b1') });
+  }
+});
+
+test('B1：显式 VRC_MONITOR_LOGGER_DIR 永远优先（压过 NODE_TEST_CONTEXT）', () => {
+  const savedD = process.env.VRC_MONITOR_LOGGER_DIR;
+  const savedCtx = process.env.NODE_TEST_CONTEXT;
+  const d = path.join(dir, 'b1-explicit');
+  process.env.VRC_MONITOR_LOGGER_DIR = d;
+  process.env.NODE_TEST_CONTEXT = 'child-v8';
+  try {
+    const s = initLogger({});
+    assert.equal(s.dir, path.resolve(d), '显式 LOGGER_DIR 必须压过测试上下文兜底');
+  } finally {
+    if (savedD !== undefined) process.env.VRC_MONITOR_LOGGER_DIR = savedD;
+    if (savedCtx !== undefined) process.env.NODE_TEST_CONTEXT = savedCtx;
+    initLogger({ dir: path.join(dir, 'reset-b1b') });
   }
 });
 

--- a/test/setup-log-isolation.mjs
+++ b/test/setup-log-isolation.mjs
@@ -1,0 +1,13 @@
+// 测试日志隔离（交付 B2）——经 `node --test --import` 以第一条 import 的语义生效。
+// 把 VRC_MONITOR_LOGGER_DIR 钉到每次运行唯一的系统临时目录，防止任何测试进程（含子进程）
+// 把日志写进继承自 shell 的 VRC_MONITOR_DIR/logs（生产日志目录）。
+// 污染实测：主仓库生产日志累计 96 行 wrld_kbtest-* 测试夹具（生产 DB 查无此 world）。
+// 若 --import 未透传到某子进程，core/logger.js resolveDir 的 NODE_TEST_CONTEXT 兜底（B1）
+// 仍会把日志落到 os.tmpdir()/vrc-monitor-test-logs，双层防御都保证不碰生产目录。
+import os from 'node:os';
+import path from 'node:path';
+
+process.env.VRC_MONITOR_LOGGER_DIR = path.join(
+  os.tmpdir(),
+  `vrc-monitor-test-logs-${process.pid}-${Date.now()}`
+);


### PR DESCRIPTION
## 一、需求来源（生产日志实测）

用户排查「日志是否有刷屏」，实测三处噪音：

**1. `头像变更` 逐条 INFO 是最大噪音源**（主仓库 `logs/monitor.log`，6794 行 / 2.2 天）：

| 类别 | 行数 | 占比 |
|------|------|------|
| `头像变更` | 2343 | **34.5%** |
| `换世界` | 1768 | 26.0% |
| `上线` + `下线` | 814 + 698 | 22.3% |
| `状态` | 333 | 4.9% |
| 其余（插件/app/ws） | ~800 | 11.8% |

单好友 `Are you Mr COLA` 独占 **683 行**，5 分钟窗口内最多 **26 条**（≈12 秒一条）。
**先确认不是 bug**：核对该好友 DB 事件链，每条 `previousAvatarImageUrl` 精确等于上一条 `avatarImageUrl`（环状循环同一组模型）→ 真实变更，非 diff 误报、非重复写，**判定逻辑无需改动**，问题只在日志层逐条回显。

**2. stdout 捕获文件从不轮转**：`$HERMES_HOME/workspace/vrc-monitor/monitor.log` 实测 **3.7MB**、跨 09-02 至今无限追加（内容与结构化日志重复——console 重定向），比结构化日志本身还大。

**3. 生产日志被测试进程写入**（顺带查出）：生产日志里有 **96 行 `wrld_kbtest-*` 测试夹具**。
根因（已实测复现）：Hermes 环境导出全局 `VRC_MONITOR_DIR=<主仓库>`，而 `core/logger.js resolveDir()` 第二优先级正是 `VRC_MONITOR_DIR/logs` → **任何继承该 env 的 node 进程（包括在 worktree 里跑的单测）都把日志写进生产日志文件**：

```
$ cd D:/workspace/vrcx-logfix && node --test test/world-kb-backfill.test.mjs   # 12 测试全过
$ ls logs/                                                                     # worktree 自身无 logs/
$ tail -1 D:/workspace/vrcx-mcp-actions/logs/monitor.log
… INFO  [app] [待办] 加入待逛: wrld_kbtest-backlog-0000-0000-000000000006 (待逛的图) priority=1
```
生产 DB 查无这些 world（隔离实例用临时库，**数据没被污染，只是日志脏了**）。

> 另：stdout 捕获文件里还有一段历史刷屏（本 PR 不涉及）—— MCP `ping/initialize/tools/list/call` 往返 **14186 行 = 该文件 console 部分 52%**（现行 `core/http-server.js:13` 已把 MCP 往返降 debug，当前输出里已消失）、`[logger] 写入日志文件失败: ENOENT` **2533 行**（09-03~09-09 自放大）、DNS 不通期 WS 重连噪音。记录在此供对照。

## 二、实现方式（3 个 commit）

**① `fix(logging)` 头像变更降为 debug**（`core/event-pipeline.js`）
- `case 'avatar'` 的 `log.info` → `log.debug`，注释写明依据与先例（`core/http-server.js:13`）；
- **只动 avatar**：bio/status/user_icon/pronouns 频率低且有内容（"xx → yy"），保持 INFO；
- DB 事件流不变（`get_friend_profile_changes` / 看板「Avatar/头像变更」页仍可查全量含新旧图 URL），需要时 `VRC_MONITOR_LOGGER_LEVEL=debug` 可恢复该行。

**② `fix(logger)` 测试进程不得写生产日志目录**（`core/logger.js` + `test/` + `package.json`）
- **B1 单点防御**：未显式设 `VRC_MONITOR_LOGGER_DIR` 且检测到 `NODE_TEST_CONTEXT`（node --test 子进程实测 `child-v8`）时，落盘改用 `os.tmpdir()/vrc-monitor-test-logs`，并**打一行非静默提示**；显式 `VRC_MONITOR_LOGGER_DIR` 永远最优先（优先级未变）。
- **B2 显式隔离**：新增 `test/setup-log-isolation.mjs`，经 `node --test --import` 把 LOGGER_DIR 钉到每次运行唯一的临时目录（已实测 `--import` 透传到子进程）。

**③ `fix(hermes-plugin)` stdout 捕获文件加轮转**（`hermes-plugin/process_manager.py`）
- 新增纯函数 `rotate_log_if_needed(path, max_size, keep)`：阈值 10MB（同 `core/logger.js` 默认 `maxSize`，`VRC_MONITOR_LOG_MAX_SIZE` 可覆盖）；归档命名对齐 `logger.js:doRotate()` = `monitor-<UTC YYYYMMDD-HHMMSS>-<pid>.log.gz`；保留 5 份按 mtime 删最旧；原文件重建为空；任何异常都不抛。
- `start()` 在 open 之前做一次检查（进程启动是低频事件，不引入运行时 watcher），**失败不阻断启动**。
- **逐分支一行日志**（禁静默降级）：轮转成功 / 跳过（未达阈值，含当前大小）/ 失败（不阻断启动，继续追加）；归档清理失败不改判轮转结果（与 `core/logger.js cleanupOldLogs()` 同策略）。

## 三、验证过程与结果（真实输出）

**全量测试**（`npm test`，worktree `D:/workspace/vrcx-logfix`）：
```
改前: # tests 98  / # pass 98  / # fail 0
改后: # tests 103 / # pass 103 / # fail 0     # +A 3、+B1 2
```

**交付 ① 回归测试**（`test/event-pipeline-avatar-log-level.test.mjs`，自包含临时 SQLite + stub）：
```
$ node --test test/event-pipeline-avatar-log-level.test.mjs
# tests 3 / # pass 3 / # fail 0
```
断言：`info` 收不到「头像变更」、`debug` 收得到、events 表仍有 type=avatar 记录且含新旧图 URL、bio/status 仍走 info（防误伤）、级别穿透（debug 落盘含该行 / 默认 info 落盘不含）。

**交付 ② 硬验收（同一生产日志文件，改前证明问题存在）**：
```
改前:  md5 0ac95fac… / 6836 行
       npm test
       md5 710da2fd… / 6849 行        ← +13 行，内含 wrld_kbtest 夹具（问题复现）
改后:  npm test 前  md5 62c54a4f… / 6861 行 / wrld_kbtest=132
       npm test 后  md5 62c54a4f… / 6861 行 / wrld_kbtest=132   ← 零变化
```
夹具日志改落到隔离目录（可见内容即原先污染生产的那 12 行）：
```
$ ls %TEMP% | grep vrc-monitor-test-logs
vrc-monitor-test-logs-23840-1789291293218/monitor.log   # 12 行，含 wrld_kbtest-*
```
> 说明：验收窗口内生产服务自身事件可能追加行（pid 21420 运行中）；故以 **md5 + 行数 + `wrld_kbtest` 计数** 三项一起判定，测试特征行增量为 0。作者侧与独立复验各跑一次 `npm test`，`wrld_kbtest` 计数均保持 132 不变。

**交付 ③ 单测**（stdlib unittest，自带 `hermes_constants` stub，不依赖 Hermes 运行时）：
```
$ python -m unittest discover -s hermes-plugin/tests -v
test_at_threshold_rotates_gzips_and_recreates_active ... ok
test_below_threshold_leaves_file_untouched ... ok
test_env_override_threshold ... ok
test_failure_returns_error_and_never_raises ... ok
test_prune_deletes_oldest_beyond_keep ... ok
test_rotate_branch_writes_notice_into_new_active_log ... ok
test_skip_branch_writes_notice_into_active_log ... ok
Ran 7 tests in 0.095s — OK
```

## 四、影响面

- 改动文件：`core/event-pipeline.js`、`core/logger.js`、`package.json`、`test/logger.test.mjs`（+2 用例、1 处兼容）、`test/setup-log-isolation.mjs`（新）、`test/event-pipeline-avatar-log-level.test.mjs`（新）、`hermes-plugin/process_manager.py`、`hermes-plugin/tests/test_log_rotation.py`（新）。
- **无 schema / 契约变更**：MCP 工具名/参数/schema、HTTP 路由、响应字段、DB 落库行为一律未动；事件照旧完整落库。
- 日志层唯一行为变化：默认 info 级别下日志文件不再出现「头像变更」逐条行（`VRC_MONITOR_LOGGER_LEVEL=debug` 可恢复）；测试进程日志改落系统临时目录（`VRC_MONITOR_LOGGER_DIR` 可显式指定）。
- 部署注意：交付 ③ 改的是仓库内 `hermes-plugin/`，**需重新同步插件副本后生效**（本地已安装副本为拷贝，非符号链接）。
- 文档同步另议（`docs/`、`README`、`AGENTS.md`、`skills/` 本 PR 未改，按要求单独过目后再提）。

---

## 五、审查意见响应（第 2 轮增量：`22b21bc` / `cf73388` / `5f551ee`，head `5f551ee`）

> 分支已 rebase 到最新 `origin/main`（含 #184/#185），旧 head `fbf0880` → 新 head `5f551ee`。

**⚠️1 轮转覆盖常驻服务**（`22b21bc`）：`start()` + `status()` 双钩子。**Windows 实测**子进程持有 stdout 句柄时父进程 rename 必失败（`PermissionError [WinError 32] 另一个程序正在使用此文件`），故实现为 **rename 优先 + copytruncate 兜底**：启动时无句柄走 rename（原子无损）；运行中 rename 抛 `OSError` 时回退「写 .gz 归档 → truncate(0)」，竞态按「最多 3 次 stat→读→stat，两次 size 一致才清空」最小化（与 Unix `logrotate copytruncate` 同性质，已在注释与 README 写明）。`status()` 的「跳过」分支**不写日志行**（防 `vrc_status` 高频调用变成新刷屏源），结果经新增返回字段 `log_capture` 可见（只增字段）；轮转成功/失败两分支两个钩子都各写一行。

**⚠️2 env 改名 + 登记**（`22b21bc` + `5f551ee`）：`VRC_MONITOR_LOG_MAX_SIZE` → **`VRC_MONITOR_CAPTURE_LOG_MAX_SIZE`**（PR 未合并，不留旧名别名）；`AGENTS.md` 变量清单登记并注明与 `VRC_MONITOR_LOGGER_MAX_SIZE` **不同名不同义**；新增 `hermes-plugin/README.md` 说明捕获文件位置、双钩子时机、阈值/保留份数、归档命名、两种轮转方式与竞态、`log_capture` 字段。

**💡1 归档清理补未压缩件**（`22b21bc`）：`_prune_archives` 同时匹配 `monitor-*.log.gz` 与 gzip 失败遗留的未压缩 `monitor-*.log`，两类**共享同一 keep 预算**（总数口径）；active `monitor.log` 不匹配任何前缀，不会被误删。

**💡2 剩余热路径降 debug**（`cf73388`）：经维护者侧确认，`换世界`(26.0%) / `上线`+`下线`(22.3%) 同样降 debug —— 至此 INFO 累计压掉 34.5%+26.0%+22.3%；DB 事件流 / SSE / 看板不受影响，`VRC_MONITOR_LOGGER_LEVEL=debug` 可恢复。

**💡3 测试隔离两条路径说明**（`5f551ee`）：`DEVELOPMENT.md` 写明 `npm test` 走 `--import ./test/setup-log-isolation.mjs` 显式隔离；裸 `node --test` 只受 `core/logger.js` 的 `NODE_TEST_CONTEXT` 单点兜底（落系统临时目录）；两条路径都不写生产日志目录。

**第 2 轮验收（真实输出）**

| 项 | 结果 |
|---|---|
| `npm test` | 改前基线（rebase 后）**107/107** → 改后 **110/110 / 0 fail**（+3 新用例） |
| python unittest | `Ran 14 tests ... OK`（新增 copytruncate 分支 / 竞态重试 / 未压缩归档共享预算 / env 新名旧名 / status 双调用防刷屏） |
| 交付②隔离硬验收 | 生产日志 `npm test` 前后 md5 `137bd414…` 相同、7289 行相同、`wrld_kbtest`=144 相同 |
| 独立探针（真实句柄占用，非 mock） | `method: copytruncate`，归档解压 12056 字节与原文逐字节一致、active 清空为 0、子进程续写正常；子进程退出后再轮转 `method: rename`；连续两次 `status()` 捕获文件 size/lines 零变化（40095→40095） |

> 环境说明：`check-doc-drift.py` 在未装插件依赖的 worktree 会多报 3 处 skill 死引用（`get_emoji_notes` 等）——跑 `npm run install-plugins` 后只剩 #184/#185 历史记录状态滞后这一项，与 main 基线完全相同（既有问题，本 PR 不改 `docs/history/`）。
